### PR TITLE
Openal Link correction

### DIFF
--- a/MSVC.md
+++ b/MSVC.md
@@ -70,7 +70,7 @@ or download in ZIP and extract to **D:\TBuild\Libraries\**, rename **libexif-0.6
 
 Get sources by git – in [Git Bash](http://git-scm.com/downloads) go to **/d/tbuild/libraries** and run
 
-    git clone git://repo.or.cz/openal-soft.git
+    git clone http://repo.or.cz/openal-soft.git
 
 to have **D:\TBuild\Libraries\openal-soft\CMakeLists.txt**
 


### PR DESCRIPTION
The old link didn't work. (git://repo.or.cz/openal-soft.git)

For me the following, and corrected link worked:
http://repo.or.cz/openal-soft.git
