### PR TITLE
Suppress notifications when in D3D full screen and presentation mode

### DIFF
--- a/Telegram/SourceFiles/pspecific_wnd.cpp
+++ b/Telegram/SourceFiles/pspecific_wnd.cpp
@@ -55,6 +55,7 @@ namespace {
 	bool useDWM = false;
 	bool useTheme = false;
 	bool useOpenAs = false;
+	bool useNotifySuspend = false;
 	bool themeInited = false;
 	bool finished = true;
 	int menuShown = 0, menuHidden = 0;
@@ -620,6 +621,9 @@ namespace {
 	typedef HRESULT (FAR STDAPICALLTYPE *f_shOpenWithDialog)(HWND hwndParent, const OPENASINFO *poainfo);
 	f_shOpenWithDialog shOpenWithDialog;
 
+	typedef HRESULT(FAR STDAPICALLTYPE *f_shQueryUserNotificationState)(_Out_ QUERY_USER_NOTIFICATION_STATE *pquns);
+	f_shQueryUserNotificationState shQueryUserNotificationState;
+
 	template <typename TFunction>
 	bool loadFunction(HINSTANCE dll, LPCSTR name, TFunction &func) {
 		if (!dll) return false;
@@ -637,6 +641,7 @@ namespace {
 
 			setupUx();
 			setupOpenAs();
+			setupNotificationSuspension();
 		}
 		void setupDWM() {
 			HINSTANCE procId = LoadLibrary(L"DWMAPI.DLL");
@@ -657,6 +662,12 @@ namespace {
 
 			if (!loadFunction(procId, "SHOpenWithDialog", shOpenWithDialog) && !loadFunction(procId, "OpenAs_RunDLLW", openAs_RunDLL)) return;
 			useOpenAs = true;
+		}
+		void setupNotificationSuspension() {
+			HINSTANCE procId = LoadLibrary(L"SHELL32.DLL");
+
+			if (!loadFunction(procId, "SHQueryUserNotificationState", shQueryUserNotificationState)) return;
+			useNotifySuspend = true;
 		}
 	};
 	_PsInitializer _psInitializer;
@@ -2166,6 +2177,20 @@ void psStart() {
 }
 
 void psFinish() {
+}
+
+PsNotificationSuspension psCheckNotificationSuspension(){
+	if (shQueryUserNotificationState){
+		QUERY_USER_NOTIFICATION_STATE notifyState;
+		shQueryUserNotificationState(&notifyState);
+		if ((notifyState == QUNS_PRESENTATION_MODE)) {
+			return NotifySuspendAll;
+		}
+		if ((notifyState == QUNS_RUNNING_D3D_FULL_SCREEN)) {
+			return NotifySuspendPopup;
+		}		
+	}
+	return NotifySuspendNone;
 }
 
 namespace {

--- a/Telegram/SourceFiles/pspecific_wnd.h
+++ b/Telegram/SourceFiles/pspecific_wnd.h
@@ -201,6 +201,13 @@ void psShowInFolder(const QString &name);
 void psStart();
 void psFinish();
 
+enum PsNotificationSuspension {
+	NotifySuspendNone = 0,
+	NotifySuspendPopup = 1,
+	NotifySuspendAll = 2
+};
+PsNotificationSuspension psCheckNotificationSuspension();
+
 void psRegisterCustomScheme();
 
 void psUpdateOverlayed(TWidget *widget);

--- a/Telegram/SourceFiles/window.cpp
+++ b/Telegram/SourceFiles/window.cpp
@@ -1095,6 +1095,15 @@ void Window::notifySchedule(History *history, MsgId msgId) {
 	if (App::quiting() || !history->currentNotification()) return;
 
 	bool haveSetting = (history->peer->notify != UnknownNotifySettings);
+	bool notifiesSuspended = false;
+
+#ifdef Q_OS_WIN
+	PsNotificationSuspension currentNotificationState = psCheckNotificationSuspension();
+	if ((currentNotificationState == NotifySuspendAll) || (currentNotificationState == NotifySuspendPopup)) {
+		notifiesSuspended = true;
+	}
+#endif
+
 	if (haveSetting) {
 		if (history->peer->notify != EmptyNotifySettings && history->peer->notify->mute > unixtime()) {
 			history->clearNotifications();
@@ -1106,7 +1115,7 @@ void Window::notifySchedule(History *history, MsgId msgId) {
 
 	uint64 ms = getms(true) + NotifyWaitTimeout;
 	notifyWhenAlerts[history].insert(ms, NullType());
-	if (cDesktopNotify()) {
+	if ((cDesktopNotify()) && (!notifiesSuspended)) {
 		NotifyWhenMaps::iterator i = notifyWhenMaps.find(history);
 		if (i == notifyWhenMaps.end()) {
 			i = notifyWhenMaps.insert(history, NotifyWhenMap());
@@ -1216,6 +1225,13 @@ void Window::notifyShowNext(NotifyWindow *remove) {
 			++i;
 		}
 	}
+
+#ifdef Q_OS_WIN
+	if (psCheckNotificationSuspension() == NotifySuspendAll) {
+		alert = false;
+	}
+#endif
+
 	if (alert) {
 		psFlash();
 		App::playSound();


### PR DESCRIPTION
Addresses issues:
telegramdesktop/tdesktop#228
telegramdesktop/tdesktop#127

Updated to include support for the Vista and later feature that allows one to query the OS to determine if notifications should be suppressed. http://msdn.microsoft.com/en-us/library/bb762242%28VS.85%29.aspx

Checks SHQueryUserNotificationState to see if the system is running a full screen exclusive D3D application, and hides popup notifications. If the Windows Mobility Center feature of  "I am currently giving a presentation" is enabled, sounds will be suppressed as well.

This does not impact regular full screen apps, or games running in Windowed (Borderless).

Tested on Windows 8.1 and Windows XP (where XP doesn't support the feature, but is not harmed by the presence of it).