### PR TITLE
Fixed focus problem when reentering the app by clicking History Message.

### DIFF
--- a/Telegram/SourceFiles/historywidget.cpp
+++ b/Telegram/SourceFiles/historywidget.cpp
@@ -551,7 +551,7 @@ void HistoryList::dragActionFinish(const QPoint &screenPos, Qt::MouseButton butt
 	} else if (_dragAction == Selecting) {
 		if (_dragSelFrom && _dragSelTo) {
 			applyDragSelection();
-		} else if (!_selected.isEmpty() && !_dragWasInactive) {
+		} else if (!_selected.isEmpty()) {
 			uint32 sel = _selected.cbegin().value();
 			if (sel != FullItemSel && (sel & 0xFFFF) == ((sel >> 16) & 0xFFFF)) {
 				_selected.clear();


### PR DESCRIPTION
Addresses issue: telegramdesktop/tdesktop#377

On Windows _dragWasInactive is set to true while clicking into the Telegram window. This prevents App::main()->activate() from being called, and instead of refocusing the Message Field, leaves the History Message incorrectly with focus even when nothing has been selected.

Tested on Windows 8.1 and Windows XP and it now appears to work correctly. (tested with selecting portions of items, as well as entire items to ensure focus isn't incorrectly given to the Message Field)

However, Ubuntu worked correctly with the previous code, and so unsure what this change will do on that platform. Do not have an Ubuntu or Mac OS dev environment in place to test there.