### PR TITLE
Changed to open audio stream on demand, rather than keeping it permanently open

### DIFF
--- a/Telegram/SourceFiles/audio.cpp
+++ b/Telegram/SourceFiles/audio.cpp
@@ -109,15 +109,15 @@ VoiceMessages::~VoiceMessages() {
 
 	for (int32 i = 0; i < AudioVoiceMsgSimultaneously; ++i) {
 		alSourceStop(_data[i].source);
-		if (alIsBuffer(_data[i].buffers[0])) {
-			alDeleteBuffers(3, _data[i].buffers);
+        if (alIsSource(_data[i].source)) {
+            alDeleteSources(1, &_data[i].source);
+            _data[i].source = 0;
+        }
+        if (alIsBuffer(_data[i].buffers[0])) {
+            alDeleteBuffers(3, _data[i].buffers);
 			for (int32 j = 0; j < 3; ++j) {
 				_data[i].buffers[j] = _data[i].samplesCount[j] = 0;
 			}
-		}
-		if (alIsSource(_data[i].source)) {
-			alDeleteSources(1, &_data[i].source);
-			_data[i].source = 0;
 		}
 	}
 	_faderThread.quit();
@@ -152,21 +152,18 @@ bool VoiceMessages::purgeALStructures(){
 	int32 index = 0;
 	for (; index < AudioVoiceMsgSimultaneously; ++index) {
 		if (_data[index].state == VoiceMessageStopped) {
-			if (_data[index].source) {
-				alSourceStop(_data[index].source);
-				_data[index].source = 0;
-			}
-			if (alIsBuffer(_data[index].buffers[0])) {
-				alDeleteBuffers(3, _data[index].buffers);
-				for (int32 j = 0; j < 3; ++j) {
-					_data[index].buffers[j] = _data[index].samplesCount[j] = 0;
-				}
-			}
-			if (alIsSource(_data[index].source)) {
-				alDeleteSources(1, &_data[index].source);
-				_data[index].source = 0;
-			}
-		}
+        if (alIsSource(_data[index].source)) {
+            alSourceStop(_data[index].source);
+            alDeleteSources(1, &_data[index].source);
+            _data[index].source = 0;
+        }
+        if (alIsBuffer(_data[index].buffers[0])) {
+            alDeleteBuffers(3, _data[index].buffers);
+            for (int32 j = 0; j < 3; ++j) {
+                _data[index].buffers[j] = _data[index].samplesCount[j] = 0;
+            }
+        }
+        }
 		else {
 			return false;
 		}
@@ -813,14 +810,14 @@ void AudioControl::destoryCoreAL(){
 
 void AudioControl::destroyNotificationAL(){
 	alSourceStop(notifySource);
-	if (alIsBuffer(notifyBuffer)) {
-		alDeleteBuffers(1, &notifyBuffer);
+    if (alIsSource(notifySource)) {
+        alDeleteSources(1, &notifySource);
+        notifySource = 0;
+    }
+    if (alIsBuffer(notifyBuffer)) {
+        alDeleteBuffers(1, &notifyBuffer);
 		notifyBuffer = 0;
-	}
-	if (alIsSource(notifySource)) {
-		alDeleteSources(1, &notifySource);
-		notifySource = 0;
-	}
+    }
 }
 
 void AudioControl::destroyAll(){

--- a/Telegram/SourceFiles/audio.cpp
+++ b/Telegram/SourceFiles/audio.cpp
@@ -649,28 +649,17 @@ AudioControl::~AudioControl(){
 void AudioControl::audioRequired(){
 	QMutexLocker lock(&_mutex);
 	_audioSuspendCountdown = 2;
-	if (!setupCoreAL()) return audioFinished();
+	if (!setupCoreAL()) return destroyAll();
 
-	if (!loadNotificationWaveData()) return audioFinished();
-	if (!setupNotificationAL()) return audioFinished();
+	if (!loadNotificationWaveData()) return destroyAll();
+	if (!setupNotificationAL()) return destroyAll();
 	if (!voicemsgs)	voicemsgs = new VoiceMessages();
 	_audioEnabled = true;
 }
 
 void AudioControl::audioFinished(){
 	QMutexLocker lock(&_mutex);
-	_audioEnabled = false;
-	if (voicemsgs){
-		if (!voicemsgs->purgeALStructures())
-			return;
-	};
-
-	destroyNotificationAL();
-	destoryCoreAL();
-	if (voicemsgs) {
-		delete voicemsgs;
-		voicemsgs = NULL;
-	}
+	destroyAll();
 }
 
 void AudioControl::onTimer(){
@@ -831,5 +820,20 @@ void AudioControl::destroyNotificationAL(){
 	if (alIsSource(notifySource)) {
 		alDeleteSources(1, &notifySource);
 		notifySource = 0;
+	}
+}
+
+void AudioControl::destroyAll(){
+	_audioEnabled = false;
+	if (voicemsgs){
+		if (!voicemsgs->purgeALStructures())
+			return;
+	};
+
+	destroyNotificationAL();
+	destoryCoreAL();
+	if (voicemsgs) {
+		delete voicemsgs;
+		voicemsgs = NULL;
 	}
 }

--- a/Telegram/SourceFiles/audio.cpp
+++ b/Telegram/SourceFiles/audio.cpp
@@ -30,6 +30,12 @@ namespace {
 	ALuint notifyBuffer = 0;
 	QMutex voicemsgsMutex;
 	VoiceMessages *voicemsgs = 0;
+	AudioControl *autoSuspend = 0;
+	uint32 notifySoundByteOffset = 0;
+	uint32 notifySoundSampleRate = 0;
+	uint32 notifySoundSize = 0;
+	ALenum notifySoundFormat = 0;
+	QByteArray notifySoundData;
 }
 
 bool _checkALCError() {
@@ -51,103 +57,11 @@ bool _checkALError() {
 }
 
 void audioInit() {
-	if (audioDevice) return;
-
-	audioDevice = alcOpenDevice(NULL);
-	if (!audioDevice) {
-		LOG(("Audio Error: default sound device not present."));
-		return;
-	}
-	
-	ALCint attributes[] = { ALC_STEREO_SOURCES, 8, 0 };
-	audioContext = alcCreateContext(audioDevice, attributes);
-	alcMakeContextCurrent(audioContext);
-	if (!_checkALCError()) return audioFinish();
-
-	ALfloat v[] = { 0.f, 0.f, -1.f, 0.f, 1.f, 0.f };
-	alListener3f(AL_POSITION, 0.f, 0.f, 0.f);
-	alListener3f(AL_VELOCITY, 0.f, 0.f, 0.f);
-	alListenerfv(AL_ORIENTATION, v);
-
-	alDistanceModel(AL_NONE);
-
-	alGenSources(1, &notifySource);
-	alSourcef(notifySource, AL_PITCH, 1.f);
-	alSourcef(notifySource, AL_GAIN, 1.f);
-	alSource3f(notifySource, AL_POSITION, 0, 0, 0);
-	alSource3f(notifySource, AL_VELOCITY, 0, 0, 0);
-	alSourcei(notifySource, AL_LOOPING, 0);
-
-	alGenBuffers(1, &notifyBuffer);
-	if (!_checkALError()) return audioFinish();
-
-	QFile notify(st::newMsgSound);
-	if (!notify.open(QIODevice::ReadOnly)) return audioFinish();
-
-	QByteArray blob = notify.readAll();
-	const char *data = blob.constData();
-	if (blob.size() < 44) return audioFinish();
-
-	if (*((const uint32*)(data + 0)) != 0x46464952) return audioFinish(); // ChunkID - "RIFF"
-	if (*((const uint32*)(data + 4)) != uint32(blob.size() - 8)) return audioFinish(); // ChunkSize
-	if (*((const uint32*)(data + 8)) != 0x45564157) return audioFinish(); // Format - "WAVE"
-	if (*((const uint32*)(data + 12)) != 0x20746d66) return audioFinish(); // Subchunk1ID - "fmt "
-	uint32 subchunk1Size = *((const uint32*)(data + 16)), extra = subchunk1Size - 16;
-	if (subchunk1Size < 16 || (extra && extra < 2)) return audioFinish();
-	if (*((const uint16*)(data + 20)) != 1) return audioFinish(); // AudioFormat - PCM (1)
-
-	uint16 numChannels = *((const uint16*)(data + 22));
-	if (numChannels != 1 && numChannels != 2) return audioFinish();
-
-	uint32 sampleRate = *((const uint32*)(data + 24));
-	uint32 byteRate = *((const uint32*)(data + 28));
-
-	uint16 blockAlign = *((const uint16*)(data + 32));
-	uint16 bitsPerSample = *((const uint16*)(data + 34));
-	if (bitsPerSample % 8) return audioFinish();
-	uint16 bytesPerSample = bitsPerSample / 8;
-	if (bytesPerSample != 1 && bytesPerSample != 2) return audioFinish();
-
-	if (blockAlign != numChannels * bytesPerSample) return audioFinish();
-	if (byteRate != sampleRate * blockAlign) return audioFinish();
-
-	if (extra) {
-		uint16 extraSize = *((const uint16*)(data + 36));
-        if (uint32(extraSize + 2) != extra) return audioFinish();
-		if (uint32(blob.size()) < 44 + extra) return audioFinish();
+	if (!autoSuspend) {
+		autoSuspend = new AudioControl();
 	}
 
-	if (*((const uint32*)(data + extra + 36)) != 0x61746164) return audioFinish(); // Subchunk2ID - "data"
-	uint32 subchunk2Size = *((const uint32*)(data + extra + 40));
-	if (subchunk2Size % (numChannels * bytesPerSample)) return audioFinish();
-	uint32 numSamples = subchunk2Size / (numChannels * bytesPerSample);
-
-	if (uint32(blob.size()) < 44 + extra + subchunk2Size) return audioFinish();
-	data += 44 + extra;
-
-	ALenum format = 0;
-	switch (bytesPerSample) {
-	case 1:
-		switch (numChannels) {
-		case 1: format = AL_FORMAT_MONO8; break;
-		case 2: format = AL_FORMAT_STEREO8; break;
-		}
-	break;
-
-	case 2:
-		switch (numChannels) {
-		case 1: format = AL_FORMAT_MONO16; break;
-		case 2: format = AL_FORMAT_STEREO16; break;
-		}
-	break;
-	}
-	if (!format) return audioFinish();
-
-	alBufferData(notifyBuffer, format, data, subchunk2Size, sampleRate);
-	alSourcei(notifySource, AL_BUFFER, notifyBuffer);
-	if (!_checkALError()) return audioFinish();
-
-	voicemsgs = new VoiceMessages();
+	autoSuspend->audioRequired();
 }
 
 bool audioWorks() {
@@ -155,35 +69,16 @@ bool audioWorks() {
 }
 
 void audioPlayNotify() {
+	autoSuspend->audioRequired();
 	if (!audioWorks()) return;
 
 	alSourcePlay(notifySource);
 }
 
 void audioFinish() {
-	if (voicemsgs) {
-		delete voicemsgs;
-	}
-
-	alSourceStop(notifySource);
-	if (alIsBuffer(notifyBuffer)) {
-		alDeleteBuffers(1, &notifyBuffer);
-		notifyBuffer = 0;
-	}
-	if (alIsSource(notifySource)) {
-		alDeleteSources(1, &notifySource);
-		notifySource = 0;
-	}
-
-	if (audioContext) {
-		alcMakeContextCurrent(NULL);
-		alcDestroyContext(audioContext);
-		audioContext = 0;
-	}
-
-	if (audioDevice) {
-		alcCloseDevice(audioDevice);
-		audioDevice = 0;
+	if (autoSuspend) {
+		autoSuspend->audioFinished();
+		autoSuspend = NULL;
 	}
 }
 
@@ -252,8 +147,37 @@ bool VoiceMessages::updateCurrentStarted(int32 pos) {
 	return true;
 }
 
+bool VoiceMessages::purgeALStructures(){
+	QMutexLocker lock(&voicemsgsMutex);
+	int32 index = 0;
+	for (; index < AudioVoiceMsgSimultaneously; ++index) {
+		if (_data[index].state == VoiceMessageStopped) {
+			if (_data[index].source) {
+				alSourceStop(_data[index].source);
+				_data[index].source = 0;
+			}
+			if (alIsBuffer(_data[index].buffers[0])) {
+				alDeleteBuffers(3, _data[index].buffers);
+				for (int32 j = 0; j < 3; ++j) {
+					_data[index].buffers[j] = _data[index].samplesCount[j] = 0;
+				}
+			}
+			if (alIsSource(_data[index].source)) {
+				alDeleteSources(1, &_data[index].source);
+				_data[index].source = 0;
+			}
+		}
+		else {
+			return false;
+		}
+	}
+	return true;
+
+}
+
 void VoiceMessages::play(AudioData *audio) {
 	QMutexLocker lock(&voicemsgsMutex);
+	autoSuspend->audioRequired();
 
 	bool startNow = true;
 	if (_data[_current].audio != audio) {
@@ -345,6 +269,7 @@ void VoiceMessagesFader::onInit() {
 void VoiceMessagesFader::onTimer() {
 	bool hasFading = false, hasPlaying = false;
 	QMutexLocker lock(&voicemsgsMutex);
+	autoSuspend->audioRequired();
 	VoiceMessages *voice = audioVoice();
 	if (!voice) return;
 
@@ -646,7 +571,10 @@ void VoiceMessagesLoader::onLoad(AudioData *audio) {
 			alSource3f(m.source, AL_VELOCITY, 0, 0, 0);
 			alSourcei(m.source, AL_LOOPING, 0);
 		}
-		if (!m.buffers[m.nextBuffer]) alGenBuffers(3, m.buffers);
+		if (!m.buffers[m.nextBuffer])
+		{
+			alGenBuffers(3, m.buffers);
+		}
 		if (!_checkALError()) {
 			m.state = VoiceMessageStopped;
 			return loadError(j);
@@ -704,5 +632,204 @@ void VoiceMessagesLoader::onCancel(AudioData *audio) {
 		if (m.audio == audio) {
 			m.loading = false;
 		}
+	}
+}
+
+AudioControl::AudioControl() : _audioEnabled(false), _audioSuspendCountdown(0) {
+	_audioSuspendTimer.setSingleShot(false);
+	_audioSuspendTimer.setInterval(3000);
+	connect(&_audioSuspendTimer, SIGNAL(timeout()), this, SLOT(onTimer()));
+	_audioSuspendTimer.start();
+}
+
+AudioControl::~AudioControl(){
+	audioFinished();
+}
+
+void AudioControl::audioRequired(){
+	QMutexLocker lock(&_mutex);
+	_audioSuspendCountdown = 2;
+	if (!setupCoreAL()) return audioFinished();
+
+	if (!loadNotificationWaveData()) return audioFinished();
+	if (!setupNotificationAL()) return audioFinished();
+	if (!voicemsgs)	voicemsgs = new VoiceMessages();
+	_audioEnabled = true;
+}
+
+void AudioControl::audioFinished(){
+	QMutexLocker lock(&_mutex);
+	_audioEnabled = false;
+	if (voicemsgs){
+		if (!voicemsgs->purgeALStructures())
+			return;
+	};
+
+	destroyNotificationAL();
+	destoryCoreAL();
+	if (voicemsgs) {
+		delete voicemsgs;
+		voicemsgs = NULL;
+	}
+}
+
+void AudioControl::onTimer(){
+	QMutexLocker lock(&_mutex);
+	if (_audioSuspendCountdown > 0) _audioSuspendCountdown--;
+
+	if (_audioSuspendCountdown == 0){
+		if (_audioEnabled){
+			_audioEnabled = false;
+			if (voicemsgs){
+				if (!voicemsgs->purgeALStructures())
+					return;
+			};
+
+			destroyNotificationAL();
+			destoryCoreAL();
+		}
+	}
+}
+
+bool AudioControl::loadNotificationWaveData(){
+	if (notifySoundFormat) return true;
+
+	QFile notify(st::newMsgSound);
+	if (!notify.open(QIODevice::ReadOnly)) return false;
+
+	notifySoundData = notify.readAll();
+	const char *data = notifySoundData.constData();
+	if (notifySoundData.size() < 44) return false;
+
+	if (*((const uint32*)(data + 0)) != 0x46464952) return false; // ChunkID - "RIFF"
+	if (*((const uint32*)(data + 4)) != uint32(notifySoundData.size() - 8)) return false; // ChunkSize
+	if (*((const uint32*)(data + 8)) != 0x45564157) return false; // Format - "WAVE"
+	if (*((const uint32*)(data + 12)) != 0x20746d66) return false; // Subchunk1ID - "fmt "
+	uint32 subchunk1Size = *((const uint32*)(data + 16)), extra = subchunk1Size - 16;
+	if (subchunk1Size < 16 || (extra && extra < 2)) return false;
+	if (*((const uint16*)(data + 20)) != 1) return false; // AudioFormat - PCM (1)
+
+	uint16 numChannels = *((const uint16*)(data + 22));
+	if (numChannels != 1 && numChannels != 2) return false;
+
+	uint32 sampleRate = *((const uint32*)(data + 24));
+	uint32 byteRate = *((const uint32*)(data + 28));
+
+	uint16 blockAlign = *((const uint16*)(data + 32));
+	uint16 bitsPerSample = *((const uint16*)(data + 34));
+	if (bitsPerSample % 8) return false;
+	uint16 bytesPerSample = bitsPerSample / 8;
+	if (bytesPerSample != 1 && bytesPerSample != 2) return false;
+
+	if (blockAlign != numChannels * bytesPerSample) return false;
+	if (byteRate != sampleRate * blockAlign) return false;
+
+	if (extra) {
+		uint16 extraSize = *((const uint16*)(data + 36));
+		if (uint32(extraSize + 2) != extra) return false;
+		if (uint32(notifySoundData.size()) < 44 + extra) return false;
+	}
+
+	if (*((const uint32*)(data + extra + 36)) != 0x61746164) return false; // Subchunk2ID - "data"
+	uint32 subchunk2Size = *((const uint32*)(data + extra + 40));
+	if (subchunk2Size % (numChannels * bytesPerSample)) return false;
+	uint32 numSamples = subchunk2Size / (numChannels * bytesPerSample);
+
+	if (uint32(notifySoundData.size()) < 44 + extra + subchunk2Size) return false;
+	data += 44 + extra;
+
+	ALenum format = 0;
+	switch (bytesPerSample) {
+	case 1:
+		switch (numChannels) {
+		case 1: format = AL_FORMAT_MONO8; break;
+		case 2: format = AL_FORMAT_STEREO8; break;
+		}
+		break;
+
+	case 2:
+		switch (numChannels) {
+		case 1: format = AL_FORMAT_MONO16; break;
+		case 2: format = AL_FORMAT_STEREO16; break;
+		}
+		break;
+	}
+	if (!format) return false;
+
+	notifySoundByteOffset = 44 + extra;
+	notifySoundSampleRate = sampleRate;
+	notifySoundSize = subchunk2Size;
+	notifySoundFormat = format;
+	return true;
+}
+
+bool AudioControl::setupCoreAL(){
+	if (audioDevice) return true;
+
+	audioDevice = alcOpenDevice(NULL);
+	if (!audioDevice) {
+		LOG(("Audio Error: default sound device not present."));
+		return false;
+	}
+
+	ALCint attributes[] = { ALC_STEREO_SOURCES, 8, 0 };
+	audioContext = alcCreateContext(audioDevice, attributes);
+	alcMakeContextCurrent(audioContext);
+	if (!_checkALCError()) return false;
+
+	ALfloat v[] = { 0.f, 0.f, -1.f, 0.f, 1.f, 0.f };
+	alListener3f(AL_POSITION, 0.f, 0.f, 0.f);
+	alListener3f(AL_VELOCITY, 0.f, 0.f, 0.f);
+	alListenerfv(AL_ORIENTATION, v);
+
+	alDistanceModel(AL_NONE);
+	return true;
+}
+
+bool AudioControl::setupNotificationAL(){
+	if (notifyBuffer) return true;
+
+	alGenSources(1, &notifySource);
+	alSourcef(notifySource, AL_PITCH, 1.f);
+	alSourcef(notifySource, AL_GAIN, 1.f);
+	alSource3f(notifySource, AL_POSITION, 0, 0, 0);
+	alSource3f(notifySource, AL_VELOCITY, 0, 0, 0);
+	alSourcei(notifySource, AL_LOOPING, 0);
+
+	alGenBuffers(1, &notifyBuffer);
+	if (!_checkALError()) return false;
+
+	const char *data = notifySoundData.constData();
+	data += notifySoundByteOffset;
+
+	alBufferData(notifyBuffer, notifySoundFormat, data, notifySoundSize, notifySoundSampleRate);
+	alSourcei(notifySource, AL_BUFFER, notifyBuffer);
+	if (!_checkALError()) return false;
+
+	return true;
+}
+
+void AudioControl::destoryCoreAL(){
+	if (audioContext) {
+		alcMakeContextCurrent(NULL);
+		alcDestroyContext(audioContext);
+		audioContext = 0;
+	}
+
+	if (audioDevice) {
+		alcCloseDevice(audioDevice);
+		audioDevice = 0;
+	}
+}
+
+void AudioControl::destroyNotificationAL(){
+	alSourceStop(notifySource);
+	if (alIsBuffer(notifyBuffer)) {
+		alDeleteBuffers(1, &notifyBuffer);
+		notifyBuffer = 0;
+	}
+	if (alIsSource(notifySource)) {
+		alDeleteSources(1, &notifySource);
+		notifySource = 0;
 	}
 }

--- a/Telegram/SourceFiles/audio.cpp
+++ b/Telegram/SourceFiles/audio.cpp
@@ -109,12 +109,12 @@ VoiceMessages::~VoiceMessages() {
 
 	for (int32 i = 0; i < AudioVoiceMsgSimultaneously; ++i) {
 		alSourceStop(_data[i].source);
-        if (alIsSource(_data[i].source)) {
-            alDeleteSources(1, &_data[i].source);
-            _data[i].source = 0;
-        }
-        if (alIsBuffer(_data[i].buffers[0])) {
-            alDeleteBuffers(3, _data[i].buffers);
+		if (alIsSource(_data[i].source)) {
+			alDeleteSources(1, &_data[i].source);
+			_data[i].source = 0;
+		}
+		if (alIsBuffer(_data[i].buffers[0])) {
+			alDeleteBuffers(3, _data[i].buffers);
 			for (int32 j = 0; j < 3; ++j) {
 				_data[i].buffers[j] = _data[i].samplesCount[j] = 0;
 			}
@@ -152,18 +152,18 @@ bool VoiceMessages::purgeALStructures(){
 	int32 index = 0;
 	for (; index < AudioVoiceMsgSimultaneously; ++index) {
 		if (_data[index].state == VoiceMessageStopped) {
-        if (alIsSource(_data[index].source)) {
-            alSourceStop(_data[index].source);
-            alDeleteSources(1, &_data[index].source);
-            _data[index].source = 0;
-        }
-        if (alIsBuffer(_data[index].buffers[0])) {
-            alDeleteBuffers(3, _data[index].buffers);
-            for (int32 j = 0; j < 3; ++j) {
-                _data[index].buffers[j] = _data[index].samplesCount[j] = 0;
-            }
-        }
-        }
+		if (alIsSource(_data[index].source)) {
+			alSourceStop(_data[index].source);
+			alDeleteSources(1, &_data[index].source);
+			_data[index].source = 0;
+		}
+		if (alIsBuffer(_data[index].buffers[0])) {
+			alDeleteBuffers(3, _data[index].buffers);
+			for (int32 j = 0; j < 3; ++j) {
+				_data[index].buffers[j] = _data[index].samplesCount[j] = 0;
+			}
+		}
+		}
 		else {
 			return false;
 		}
@@ -467,7 +467,7 @@ void VoiceMessagesLoader::onLoad(AudioData *audio) {
 	}
 
 	bool finished = false;
-    DEBUG_LOG(("Audio Info: reading buffer for file '%1', data size '%2', current pcm_offset %3").arg(l->fname).arg(l->data.size()).arg(l->pcm_offset));
+	DEBUG_LOG(("Audio Info: reading buffer for file '%1', data size '%2', current pcm_offset %3").arg(l->fname).arg(l->data.size()).arg(l->pcm_offset));
 
 	QByteArray result;
 	int64 samplesAdded = 0;
@@ -810,14 +810,14 @@ void AudioControl::destoryCoreAL(){
 
 void AudioControl::destroyNotificationAL(){
 	alSourceStop(notifySource);
-    if (alIsSource(notifySource)) {
-        alDeleteSources(1, &notifySource);
-        notifySource = 0;
-    }
-    if (alIsBuffer(notifyBuffer)) {
-        alDeleteBuffers(1, &notifyBuffer);
+	if (alIsSource(notifySource)) {
+		alDeleteSources(1, &notifySource);
+		notifySource = 0;
+	}
+	if (alIsBuffer(notifyBuffer)) {
+		alDeleteBuffers(1, &notifyBuffer);
 		notifyBuffer = 0;
-    }
+	}
 }
 
 void AudioControl::destroyAll(){

--- a/Telegram/SourceFiles/audio.cpp
+++ b/Telegram/SourceFiles/audio.cpp
@@ -30,7 +30,7 @@ namespace {
 	ALuint notifyBuffer = 0;
 	QMutex voicemsgsMutex;
 	VoiceMessages *voicemsgs = 0;
-	AudioControl *autoSuspend = 0;
+	AudioControl *audioControl = 0;
 	uint32 notifySoundByteOffset = 0;
 	uint32 notifySoundSampleRate = 0;
 	uint32 notifySoundSize = 0;
@@ -57,11 +57,11 @@ bool _checkALError() {
 }
 
 void audioInit() {
-	if (!autoSuspend) {
-		autoSuspend = new AudioControl();
+	if (!audioControl) {
+		audioControl = new AudioControl();
 	}
 
-	autoSuspend->audioRequired();
+	audioControl->audioRequired();
 }
 
 bool audioWorks() {
@@ -69,16 +69,16 @@ bool audioWorks() {
 }
 
 void audioPlayNotify() {
-	autoSuspend->audioRequired();
+	audioControl->audioRequired();
 	if (!audioWorks()) return;
 
 	alSourcePlay(notifySource);
 }
 
 void audioFinish() {
-	if (autoSuspend) {
-		autoSuspend->audioFinished();
-		autoSuspend = NULL;
+	if (audioControl) {
+		audioControl->audioFinished();
+		audioControl = NULL;
 	}
 }
 
@@ -174,7 +174,7 @@ bool VoiceMessages::purgeALStructures(){
 
 void VoiceMessages::play(AudioData *audio) {
 	QMutexLocker lock(&voicemsgsMutex);
-	autoSuspend->audioRequired();
+	audioControl->audioRequired();
 
 	bool startNow = true;
 	if (_data[_current].audio != audio) {
@@ -266,7 +266,7 @@ void VoiceMessagesFader::onInit() {
 void VoiceMessagesFader::onTimer() {
 	bool hasFading = false, hasPlaying = false;
 	QMutexLocker lock(&voicemsgsMutex);
-	autoSuspend->audioRequired();
+	audioControl->audioRequired();
 	VoiceMessages *voice = audioVoice();
 	if (!voice) return;
 

--- a/Telegram/SourceFiles/audio.h
+++ b/Telegram/SourceFiles/audio.h
@@ -188,6 +188,8 @@ private:
 	void destoryCoreAL();
 	void destroyNotificationAL();
 
+	void destroyAll();
+
     bool _audioEnabled;
     int _audioSuspendCountdown;
     QTimer _audioSuspendTimer;

--- a/Telegram/SourceFiles/audio.h
+++ b/Telegram/SourceFiles/audio.h
@@ -188,9 +188,9 @@ private:
 	void destoryCoreAL();
 	void destroyNotificationAL();
 
-	QTimer _audioSuspendTimer;
-	int _audioSuspendCountdown;
+    bool _audioEnabled;
+    int _audioSuspendCountdown;
+    QTimer _audioSuspendTimer;
 	QMutex _mutex;
-	bool _audioEnabled;
 
 };

--- a/Telegram/SourceFiles/audio.h
+++ b/Telegram/SourceFiles/audio.h
@@ -190,9 +190,9 @@ private:
 
 	void destroyAll();
 
-    bool _audioEnabled;
-    int _audioSuspendCountdown;
-    QTimer _audioSuspendTimer;
+	bool _audioEnabled;
+	int _audioSuspendCountdown;
+	QTimer _audioSuspendTimer;
 	QMutex _mutex;
 
 };

--- a/Telegram/SourceFiles/audio.h
+++ b/Telegram/SourceFiles/audio.h
@@ -47,6 +47,8 @@ public:
 	void play(AudioData *audio);
 	void pauseresume();
 
+	bool purgeALStructures();
+
 	void currentState(AudioData **audio, VoiceMessageState *state = 0, int64 *position = 0, int64 *duration = 0);
 
 	~VoiceMessages();
@@ -158,5 +160,37 @@ private:
 	Loaders _loaders;
 
 	void loadError(Loaders::iterator i);
+
+};
+
+class AudioControl : public QObject {
+	Q_OBJECT
+
+public:
+
+	AudioControl();
+	~AudioControl();
+
+	void audioRequired();
+	void audioFinished();
+
+public slots:
+
+	void onTimer();
+
+private:
+
+	bool loadNotificationWaveData();
+
+	bool setupCoreAL();
+	bool setupNotificationAL();
+
+	void destoryCoreAL();
+	void destroyNotificationAL();
+
+	QTimer _audioSuspendTimer;
+	int _audioSuspendCountdown;
+	QMutex _mutex;
+	bool _audioEnabled;
 
 };


### PR DESCRIPTION
**Why:**

Keeping an audio stream open on Windows 8.1 prevents Windows from entering sleep.
Depending on the audio driver it can significantly increase CPU usage, in the form of AUDIODG.EXE on Windows or pulseaudio on Linux.
Depending on the audio driver it can force Windows to use high Timer Resolution, further draining battery.
(I sometimes have Telegram running in a Windows VM on my Mac, and having Telegram open and idle would use an extra 16% of a core. With this change it uses a negligible amount.)

**Addresses the following issues:**

telegramdesktop/tdesktop#229
telegramdesktop/tdesktop#258
telegramdesktop/tdesktop#351
telegramdesktop/tdesktop#176
telegramdesktop/tdesktop#191
telegramdesktop/tdesktop#179

**What changed:**

Split the audio initialisation (audioInit()) into separate methods:

1. Basic OpenAL setup was moved into AudioControl::setupCoreAL()
2. Loading the notification sound's WAV data was moved into AudioControl::loadNotificationWaveData()
3. Setting up the OpenAL buffers to play the notification sound was moved into AudioControl::setupNotificationAL()

This was split so that the notification sound's WAV data could be loaded once, even if the OpenAL specific commands needed to be rerun each time the audio stream was shut down and recreated.

Added a method AudioControl::audioRequired() that is called when the Notification Sound or a Voice Message is played, that resets up the audio stream if it has been shut down. It also resets the audio stream shutdown timer.

Added a timer method which gets executed after a few seconds of inactivity, and if no audio is playing (paused Voice Messages are still counted as playing), it will free buffers, sources, the audio context, and then close the device.

**Known implementation issue:**

If a Voice Message is paused in playback the audio stream will not shut down so as to maintain the context and position of playback. When you finish listening to the Voice Message, then the audio stream will shut down as normal.

Tested on Windows 8.1, Windows XP and Ubuntu 14.04