### PR TITLE
Switches show in folder to use user's preferred file manager

### DIFF
--- a/Telegram/SourceFiles/pspecific_linux.cpp
+++ b/Telegram/SourceFiles/pspecific_linux.cpp
@@ -1548,7 +1548,7 @@ void psOpenFile(const QString &name, bool openWith) {
 
 void psShowInFolder(const QString &name) {
     App::wnd()->layerHidden();
-    system(("nautilus \"" + QFileInfo(name).absoluteDir().absolutePath() + "\"").toLocal8Bit().constData());
+    system(("xdg-open \"" + QFileInfo(name).absoluteDir().absolutePath() + "\"").toLocal8Bit().constData());
 }
 
 void psStart() {


### PR DESCRIPTION
xdg-open is the preferred way to do this.
http://linux.die.net/man/1/xdg-open

Addresses #438 