### PR TITLE
Changed the German translation of typing to be more common

### DIFF
--- a/Telegram/SourceFiles/langs/lang_de.strings
+++ b/Telegram/SourceFiles/langs/lang_de.strings
@@ -368,10 +368,10 @@ Copyright (c) 2014 John Preston, https://desktop.telegram.org
 "lng_message_with_from" = "[c]{from}:[/c] {message}";
 "lng_from_you" = "Ich";
 
-"lng_typing" = "tippt";
-"lng_user_typing" = "{user} tippt";
-"lng_users_typing" = "{user} und {second_user} tippen";
-"lng_many_typing" = "{count:_not_used_|# tippt|# tippen}";
+"lng_typing" = "schreibt";
+"lng_user_typing" = "{user} schreibt";
+"lng_users_typing" = "{user} und {second_user} schreiben";
+"lng_many_typing" = "{count:_not_used_|# schreibt|# schreiben}";
 "lng_unread_bar" = "{count:_not_used_|# Ungelesene Nachricht|# Ungelesene Nachrichten}";
 
 "lng_maps_point" = "Standort";


### PR DESCRIPTION
Because people aren't always on a keyboard. Also it should be the same translation as on the mobile version.