### PR TITLE
[linux] Telegram puts a 'fontconfig' folder in the user's home on every start.

### DIFF
--- a/Telegram/SourceFiles/pspecific_linux.cpp
+++ b/Telegram/SourceFiles/pspecific_linux.cpp
@@ -1656,6 +1656,7 @@ void psRegisterCustomScheme() {
             s << "Name=Telegram Desktop\n";
             s << "Comment=Official desktop version of Telegram messaging app\n";
             s << "Exec=" << cExeDir().toLocal8Bit().constData() << cExeName().toLocal8Bit().constData() << " -- %u\n";
+            s << "Path=" << cExeDir().toLocal8Bit().constData();
             s << "Icon=" << icon.toLocal8Bit().constData() << "\n";
             s << "Terminal=false\n";
             s << "Type=Application\n";


### PR DESCRIPTION
Deleting the folder only makes it show up again the next time you launch Telegram from the desktop shortcut.

The folder shows up in the app's working directory, so included is a pull request that changes the working directory to where Telegram is installed. Unfortunately this will only work for new installs.