### PR TITLE
Remove lines in genemoji.cpp that prevents building on non-macs

### DIFF
--- a/Telegram/SourceFiles/_other/genemoji.cpp
+++ b/Telegram/SourceFiles/_other/genemoji.cpp
@@ -35,8 +35,6 @@ Q_IMPORT_PLUGIN(QTgaPlugin)
 Q_IMPORT_PLUGIN(QTiffPlugin)
 Q_IMPORT_PLUGIN(QWbmpPlugin)
 Q_IMPORT_PLUGIN(QWebpPlugin)
-#else
-#error Only Mac OS X is supported
 #endif
 
 typedef quint32 uint32;


### PR DESCRIPTION
The two line removed seem unnecessary. I have successfully built and run the software in Debian with this configuration.