### PR TITLE
Allow to disable the updater using a marco

### DIFF
--- a/Telegram/SourceFiles/application.cpp
+++ b/Telegram/SourceFiles/application.cpp
@@ -95,7 +95,10 @@ namespace {
 
 Application::Application(int &argc, char **argv) : PsApplication(argc, argv),
     serverName(psServerPrefix() + cGUIDStr()), closing(false),
-	updateRequestId(0), updateReply(0), updateThread(0), updateDownloader(0), _translator(0) {
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
+	updateRequestId(0), updateReply(0), updateThread(0), updateDownloader(0),
+	#endif
+	_translator(0) {
 
 	DEBUG_LOG(("Application Info: creation.."));
 
@@ -178,9 +181,11 @@ Application::Application(int &argc, char **argv) : PsApplication(argc, argv),
 	connect(&socket, SIGNAL(readyRead()), this, SLOT(socketReading()));
 	connect(&server, SIGNAL(newConnection()), this, SLOT(newInstanceConnected()));
 	connect(this, SIGNAL(aboutToQuit()), this, SLOT(closeApplication()));
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	connect(&updateCheckTimer, SIGNAL(timeout()), this, SLOT(startUpdateCheck()));
 	connect(this, SIGNAL(updateFailed()), this, SLOT(onUpdateFailed()));
 	connect(this, SIGNAL(updateReady()), this, SLOT(onUpdateReady()));
+	#endif
 	connect(this, SIGNAL(applicationStateChanged(Qt::ApplicationState)), this, SLOT(onAppStateChanged(Qt::ApplicationState)));
 	//connect(&writeUserConfigTimer, SIGNAL(timeout()), this, SLOT(onWriteUserConfig()));
 	//writeUserConfigTimer.setSingleShot(true);
@@ -195,6 +200,7 @@ Application::Application(int &argc, char **argv) : PsApplication(argc, argv),
 	}
 }
 
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 void Application::updateGotCurrent() {
 	if (!updateReply || updateThread) return;
 
@@ -258,6 +264,7 @@ void Application::onUpdateFailed() {
 	cSetLastUpdateCheck(unixtime());
 	Local::writeSettings();
 }
+#endif
 
 void Application::regPhotoUpdate(const PeerId &peer, MsgId msgId) {
 	photoUpdates.insert(msgId, peer);
@@ -431,11 +438,16 @@ void Application::onSwitchTestMode() {
 }
 
 Application::UpdatingState Application::updatingState() {
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	if (!updateThread) return Application::UpdatingNone;
 	if (!updateDownloader) return Application::UpdatingReady;
 	return Application::UpdatingDownload;
+	#else
+	return Application::UpdatingNone;
+	#endif
 }
 
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 int32 Application::updatingSize() {
 	if (!updateDownloader) return 0;
 	return updateDownloader->size();
@@ -445,6 +457,7 @@ int32 Application::updatingReady() {
 	if (!updateDownloader) return 0;
 	return updateDownloader->ready();
 }
+#endif
 
 FileUploader *Application::uploader() {
 	if (!::uploader) ::uploader = new FileUploader();
@@ -488,6 +501,7 @@ void Application::uploadProfilePhoto(const QImage &tosend, const PeerId &peerId)
 	App::uploader()->uploadMedia(newId, ready);
 }
 
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 void Application::stopUpdate() {
 	if (updateReply) {
 		updateReply->abort();
@@ -541,6 +555,7 @@ void Application::startUpdateCheck(bool forceWait) {
 		updateCheckTimer.start((updateInSecs + 5) * 1000);
 	}
 }
+#endif
 
 namespace {
 	QChar _toHex(ushort v) {
@@ -643,11 +658,13 @@ void Application::socketError(QLocalSocket::LocalSocketError e) {
 		return App::quit();
 	}
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	if (!cNoStartUpdate() && checkReadyUpdate()) {
 		cSetRestartingUpdate(true);
 		DEBUG_LOG(("Application Info: installing update instead of starting app.."));
 		return App::quit();
 	}
+	#endif
 
 	startApp();
 }
@@ -833,13 +850,15 @@ Application::~Application() {
 	App::deinitMedia();
 	deinitImageLinkManager();
 	mainApp = 0;
-	delete updateReply;
 	delete ::uploader;
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
+	delete updateReply;
 	updateReply = 0;
 	if (updateDownloader) updateDownloader->deleteLater();
 	updateDownloader = 0;
 	if (updateThread) updateThread->quit();
 	updateThread = 0;
+	#endif
 
 	delete window;
 

--- a/Telegram/SourceFiles/application.h
+++ b/Telegram/SourceFiles/application.h
@@ -49,8 +49,10 @@ public:
 		UpdatingReady,
 	};
 	UpdatingState updatingState();
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	int32 updatingSize();
 	int32 updatingReady();
+	#endif
 
 	FileUploader *uploader();
 	void uploadProfilePhoto(const QImage &tosend, const PeerId &peerId);
@@ -78,11 +80,13 @@ public:
 
 signals:
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	void updateChecking();
 	void updateLatest();
 	void updateDownloading(qint64 ready, qint64 total);
 	void updateReady();
 	void updateFailed();
+	#endif
 
 	void peerPhotoDone(PeerId peer);
 	void peerPhotoFail(PeerId peer);
@@ -91,7 +95,9 @@ signals:
 
 public slots:
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	void startUpdateCheck(bool forceWait = false);
+	#endif
 	void socketConnected();
 	void socketError(QLocalSocket::LocalSocketError e);
 	void socketDisconnected();
@@ -103,11 +109,13 @@ public slots:
 	void readClients();
 	void removeClients();
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	void updateGotCurrent();
 	void updateFailedCurrent(QNetworkReply::NetworkError e);
 
 	void onUpdateReady();
 	void onUpdateFailed();
+	#endif
 
 	void photoUpdated(MsgId msgId, const MTPInputFile &file);
 
@@ -142,12 +150,14 @@ private:
 
 	Window *window;
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	mtpRequestId updateRequestId;
 	QNetworkAccessManager updateManager;
 	QNetworkReply *updateReply;
 	SingleTimer updateCheckTimer;
 	QThread *updateThread;
 	UpdateDownloader *updateDownloader;
+	#endif
 
 	QTimer writeUserConfigTimer;
 

--- a/Telegram/SourceFiles/autoupdater.cpp
+++ b/Telegram/SourceFiles/autoupdater.cpp
@@ -15,6 +15,9 @@ GNU General Public License for more details.
 Full license: https://github.com/telegramdesktop/tdesktop/blob/master/LICENSE
 Copyright (c) 2014 John Preston, https://desktop.telegram.org
 */
+
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
+
 #include "stdafx.h"
 #include "application.h"
 #include "pspecific.h"
@@ -534,3 +537,5 @@ bool checkReadyUpdate() {
 #endif
 	return true;
 }
+
+#endif

--- a/Telegram/SourceFiles/autoupdater.h
+++ b/Telegram/SourceFiles/autoupdater.h
@@ -17,6 +17,8 @@ Copyright (c) 2014 John Preston, https://desktop.telegram.org
 */
 #pragma once
 
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
+
 #include <QtNetwork/QLocalSocket>
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QNetworkReply>
@@ -60,3 +62,5 @@ private:
 };
 
 bool checkReadyUpdate();
+
+#endif

--- a/Telegram/SourceFiles/intro/intro.cpp
+++ b/Telegram/SourceFiles/intro/intro.cpp
@@ -43,7 +43,9 @@ namespace {
 			countryForReg = nearest.vcountry.c_string().v.c_str();
 			emit signalEmitOn->countryChanged();
 		}
+		#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 		if (App::app()) App::app()->startUpdateCheck();
+		#endif
 	}
 }
 

--- a/Telegram/SourceFiles/main.cpp
+++ b/Telegram/SourceFiles/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char *argv[]) {
 
 	DEBUG_LOG(("Application Info: Telegram done, result: %1").arg(result));
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	if (cRestartingUpdate()) {
 		if (DevVersion) {
 			LOG(("Writing 'devversion' file before launching the Updater!"));
@@ -93,7 +94,9 @@ int main(int argc, char *argv[]) {
 
 		DEBUG_LOG(("Application Info: executing updater to install update.."));
 		psExecUpdater();
-	} else if (cRestarting()) {
+	} else
+	#endif
+	if (cRestarting()) {
 		DEBUG_LOG(("Application Info: executing Telegram, because of restart.."));
 		psExecTelegram();
 	}

--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -2768,7 +2768,9 @@ void MainWidget::start(const MTPUser &user) {
 
 	cSetOtherOnline(0);
 	App::feedUsers(MTP_vector<MTPUser>(1, user));
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	App::app()->startUpdateCheck();
+	#endif
 	MTP::send(MTPupdates_GetState(), rpcDone(&MainWidget::gotState));
 	update();
 	if (!cStartUrl().isEmpty()) {

--- a/Telegram/SourceFiles/settingswidget.cpp
+++ b/Telegram/SourceFiles/settingswidget.cpp
@@ -127,9 +127,11 @@ SettingsInner::SettingsInner(SettingsWidget *parent) : QWidget(parent),
 
 	// general
 	_changeLanguage(this, lang(lng_settings_change_lang)),
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	_autoUpdate(this, lang(lng_settings_auto_update), cAutoUpdate()),
 	_checkNow(this, lang(lng_settings_check_now)),
 	_restartNow(this, lang(lng_settings_update_now)),
+	#endif
 
     _supportTray(cSupportTray()),
 	_workmodeTray(this, lang(lng_settings_workmode_tray), (cWorkMode() == dbiwmTrayOnly || cWorkMode() == dbiwmWindowAndTray)),
@@ -226,9 +228,11 @@ SettingsInner::SettingsInner(SettingsWidget *parent) : QWidget(parent),
 
 	// general
 	connect(&_changeLanguage, SIGNAL(clicked()), this, SLOT(onChangeLanguage()));
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	connect(&_autoUpdate, SIGNAL(changed()), this, SLOT(onAutoUpdate()));
 	connect(&_checkNow, SIGNAL(clicked()), this, SLOT(onCheckNow()));
 	connect(&_restartNow, SIGNAL(clicked()), this, SLOT(onRestartNow()));
+	#endif
 
 	connect(&_workmodeTray, SIGNAL(changed()), this, SLOT(onWorkmodeTray()));
 	connect(&_workmodeWindow, SIGNAL(changed()), this, SLOT(onWorkmodeWindow()));
@@ -246,11 +250,13 @@ SettingsInner::SettingsInner(SettingsWidget *parent) : QWidget(parent),
 	_newVersionText = lang(lng_settings_update_ready) + ' ';
 	_newVersionWidth = st::linkFont->m.width(_newVersionText);
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	connect(App::app(), SIGNAL(updateChecking()), this, SLOT(onUpdateChecking()));
 	connect(App::app(), SIGNAL(updateLatest()), this, SLOT(onUpdateLatest()));
 	connect(App::app(), SIGNAL(updateDownloading(qint64,qint64)), this, SLOT(onUpdateDownloading(qint64,qint64)));
 	connect(App::app(), SIGNAL(updateReady()), this, SLOT(onUpdateReady()));
 	connect(App::app(), SIGNAL(updateFailed()), this, SLOT(onUpdateFailed()));
+	#endif
 
 	// chat options
 	connect(&_replaceEmojis, SIGNAL(changed()), this, SLOT(onReplaceEmojis()));
@@ -303,6 +309,7 @@ SettingsInner::SettingsInner(SettingsWidget *parent) : QWidget(parent),
 
 	updateOnlineDisplay();
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	switch (App::app()->updatingState()) {
 	case Application::UpdatingDownload:
 		setUpdatingState(UpdatingDownload, true);
@@ -311,6 +318,9 @@ SettingsInner::SettingsInner(SettingsWidget *parent) : QWidget(parent),
 	case Application::UpdatingReady: setUpdatingState(UpdatingReady, true); break;
 	default: setUpdatingState(UpdatingNone, true); break;
 	}
+	#else
+	_updatingState = UpdatingNone;
+	#endif
 
 	updateConnectionType();
 
@@ -430,6 +440,7 @@ void SettingsInner::paintEvent(QPaintEvent *e) {
 	p.drawText(_left + st::setHeaderLeft, top + st::setHeaderTop + st::setHeaderFont->ascent, lang(lng_settings_section_general));
 	top += st::setHeaderSkip;
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	top += _autoUpdate.height(); 
 	QString textToDraw;
 	if (cAutoUpdate()) {
@@ -448,6 +459,7 @@ void SettingsInner::paintEvent(QPaintEvent *e) {
 	p.setPen(st::setVersionColor->p);
 	p.drawText(_left + st::setVersionLeft, top + st::setVersionTop + st::linkFont->ascent, textToDraw);
 	top += st::setVersionHeight;
+	#endif
 
     if (cPlatform() == dbipWindows) {
         top += _workmodeTray.height() + st::setLittleSkip;
@@ -656,10 +668,12 @@ void SettingsInner::resizeEvent(QResizeEvent *e) {
 	// general
 	top += st::setHeaderSkip;
 	_changeLanguage.move(_left + st::setWidth - _changeLanguage.width(), top - st::setHeaderSkip + st::setHeaderTop + st::setHeaderFont->ascent - st::linkFont->ascent);
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	_autoUpdate.move(_left, top);
 	_checkNow.move(_left + st::setWidth - _checkNow.width(), top + st::cbDefFlat.textTop); top += _autoUpdate.height();
 	_restartNow.move(_left + st::setWidth - _restartNow.width(), top + st::setVersionTop);
 	top += st::setVersionHeight;
+	#endif
 
     if (cPlatform() == dbipWindows) {
         _workmodeTray.move(_left, top); top += _workmodeTray.height() + st::setLittleSkip;
@@ -972,8 +986,10 @@ void SettingsInner::showAll() {
 
 	// general
 	_changeLanguage.show();
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	_autoUpdate.show();
 	setUpdatingState(_updatingState, true);
+	#endif
     if (cPlatform() == dbipWindows) {
         _workmodeTray.show();
         _workmodeWindow.show();
@@ -1219,6 +1235,7 @@ void SettingsInner::onUpdateLocalStorage() {
 	update();
 }
 
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 void SettingsInner::onAutoUpdate() {
 	cSetAutoUpdate(!cAutoUpdate());
 	Local::writeSettings();
@@ -1244,8 +1261,10 @@ void SettingsInner::onCheckNow() {
 	cSetLastUpdateCheck(0);
 	App::app()->startUpdateCheck();
 }
+#endif
 
 void SettingsInner::onRestartNow() {
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	checkReadyUpdate();
 	if (_updatingState == UpdatingReady) {
 		cSetRestartingUpdate(true);
@@ -1253,6 +1272,10 @@ void SettingsInner::onRestartNow() {
 		cSetRestarting(true);
 		cSetRestartingToSettings(true);
 	}
+	#else
+	cSetRestarting(true);
+	cSetRestartingToSettings(true);
+	#endif
 	App::quit();
 }
 
@@ -1636,6 +1659,7 @@ void SettingsInner::onTempDirClearFailed(int task) {
 	update();
 }
 
+#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 void SettingsInner::setUpdatingState(UpdatingState state, bool force) {
 	if (_updatingState != state || force) {
 		_updatingState = state;
@@ -1689,6 +1713,7 @@ void SettingsInner::onUpdateReady() {
 void SettingsInner::onUpdateFailed() {
 	setUpdatingState(UpdatingFail);
 }
+#endif
 
 void SettingsInner::onPhotoUpdateStart() {
 	showAll();

--- a/Telegram/SourceFiles/settingswidget.h
+++ b/Telegram/SourceFiles/settingswidget.h
@@ -97,8 +97,10 @@ public slots:
 	void onUpdatePhoto();
 	void onUpdatePhotoCancel();
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	void onAutoUpdate();
 	void onCheckNow();
+	#endif
 	void onRestartNow();
 
 	void onPasscode();
@@ -149,11 +151,13 @@ public slots:
 
 	void onLocalStorageClear();
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	void onUpdateChecking();
 	void onUpdateLatest();
 	void onUpdateDownloading(qint64 ready, qint64 total);
 	void onUpdateReady();
 	void onUpdateFailed();
+	#endif
 
 	void onShowSessions();
 
@@ -206,8 +210,10 @@ private:
 
 	// general
 	LinkButton _changeLanguage;
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	FlatCheckbox _autoUpdate;
 	LinkButton _checkNow, _restartNow;
+	#endif
     bool _supportTray; // cSupportTray() value on settings create
 	FlatCheckbox _workmodeTray, _workmodeWindow;
 	FlatCheckbox _autoStart, _startMinimized, _sendToMenu;
@@ -280,8 +286,10 @@ private:
 	void offPasswordDone(const MTPBool &result);
 	bool offPasswordFail(const RPCError &error);
 
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	void setUpdatingState(UpdatingState state, bool force = false);
 	void setDownloadProgress(qint64 ready, qint64 total);
+	#endif
 
 
 };

--- a/Telegram/SourceFiles/sysbuttons.cpp
+++ b/Telegram/SourceFiles/sysbuttons.cpp
@@ -143,7 +143,9 @@ UpdateBtn::UpdateBtn(QWidget *parent, Window *window, const QString &text) : Sys
 }
 
 void UpdateBtn::onClick() {
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	checkReadyUpdate();
+	#endif
 	if (App::app()->updatingState() == Application::UpdatingReady) {
 		cSetRestartingUpdate(true);
 	} else {

--- a/Telegram/SourceFiles/title.cpp
+++ b/Telegram/SourceFiles/title.cpp
@@ -80,7 +80,9 @@ TitleWidget::TitleWidget(Window *window)
 	connect(&_contacts, SIGNAL(clicked()), this, SLOT(onContacts()));
 	connect(&_about, SIGNAL(clicked()), this, SLOT(onAbout()));
 	connect(wnd->windowHandle(), SIGNAL(windowStateChanged(Qt::WindowState)), this, SLOT(stateChanged(Qt::WindowState)));
+	#ifndef TDESKTOP_DISABLE_AUTOUPDATE
 	connect(App::app(), SIGNAL(updateReady()), this, SLOT(showUpdateBtn()));
+	#endif
 	
     if (cPlatform() != dbipWindows) {
         _minimize.hide();


### PR DESCRIPTION
Adding "DEFINES += TDESKTOP_DISABLE_AUTOUPDATE" to Telegram.pro would disable the updater. This eases creating packages for Linux distributions, where updates are handled by the corresponding package manager.