### PR TITLE
Commented string, which creates an error while compiling on non MacOS OS

### DIFF
--- a/QTCREATOR.md
+++ b/QTCREATOR.md
@@ -82,6 +82,7 @@ In Terminal go to **/home/user/TBuild/Libraries** and run
 
     sudo apt-get install xutils-dev bison python-xcbgen
     git clone https://github.com/xkbcommon/libxkbcommon.git
+    cd libxkbcommon
     ./autogen.sh --disable-x11
     make
     sudo make install

--- a/Telegram/SourceFiles/_other/genemoji.cpp
+++ b/Telegram/SourceFiles/_other/genemoji.cpp
@@ -36,7 +36,7 @@ Q_IMPORT_PLUGIN(QTiffPlugin)
 Q_IMPORT_PLUGIN(QWbmpPlugin)
 Q_IMPORT_PLUGIN(QWebpPlugin)
 #else
-#error Only Mac OS X is supported
+//#error Only Mac OS X is supported
 #endif
 
 typedef quint32 uint32;


### PR DESCRIPTION
I wasnt able to build MetaEmoji on my Linux system until I've commented this error macro, which seems to be wrong.
But I'm newbie, this is my first commit into not my project, and I dont't know all about how things get done here, just want to help.
If my commit is bad, comment below, I want to know your oppinion.