### PR TITLE
Allow to disable 'register custom scheme' functions using a macro

### DIFF
--- a/Telegram/SourceFiles/pspecific_linux.cpp
+++ b/Telegram/SourceFiles/pspecific_linux.cpp
@@ -1165,6 +1165,7 @@ namespace {
 }
 
 void psRegisterCustomScheme() {
+    #ifndef TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME
     QString home(_psHomeDir());
     if (home.isEmpty()) return;
 
@@ -1249,6 +1250,7 @@ void psRegisterCustomScheme() {
             LOG(("App Error: Could not open '%1' for write").arg(file));
         }
     }
+    #endif
 }
 
 void psNewVersion() {

--- a/Telegram/SourceFiles/pspecific_mac_p.mm
+++ b/Telegram/SourceFiles/pspecific_mac_p.mm
@@ -932,8 +932,10 @@ void objc_finish() {
 }
 
 void objc_registerCustomScheme() {
+	#ifndef TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME
 	OSStatus result = LSSetDefaultHandlerForURLScheme(CFSTR("tg"), (CFStringRef)[[NSBundle mainBundle] bundleIdentifier]);
 	DEBUG_LOG(("App Info: set default handler for 'tg' scheme result: %1").arg(result));
+	#endif
 }
 
 BOOL _execUpdater(BOOL update = YES) {

--- a/Telegram/SourceFiles/pspecific_wnd.cpp
+++ b/Telegram/SourceFiles/pspecific_wnd.cpp
@@ -2211,6 +2211,7 @@ namespace {
 }
 
 void RegisterCustomScheme() {
+	#ifndef TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME
 	DEBUG_LOG(("App Info: Checking custom scheme 'tg'.."));
 
 	HKEY rkey;
@@ -2227,6 +2228,7 @@ void RegisterCustomScheme() {
 	if (!_psOpenRegKey(L"Software\\Classes\\tg\\shell\\open", &rkey)) return;
 	if (!_psOpenRegKey(L"Software\\Classes\\tg\\shell\\open\\command", &rkey)) return;
 	if (!_psSetKeyValue(rkey, 0, '"' + exe + qsl("\" -workdir \"") + cWorkingDir() + qsl("\" -- \"%1\""))) return;
+	#endif
 }
 
 void psNewVersion() {


### PR DESCRIPTION
Adding "DEFINES += TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME" to Telegram.pro would disable these functions. This can be useful when the application is distributed using an installer or a package manager that can apply these settings system-globaly.
