### PR TITLE
Resolving "failed retrieving file" error

### DIFF
--- a/MSVC.md
+++ b/MSVC.md
@@ -128,6 +128,7 @@ Open **VS2013 x86 Native Tools Command Prompt.bat** (should be in **\\Program Fi
     PATH="/c/Program Files (x86)/Microsoft Visual Studio 12.0/VC/BIN:$PATH"
 
     cd /d/TBuild/Libraries/ffmpeg-2.6.3
+    pacman -Sy
     pacman -S msys/make
     pacman -S mingw64/mingw-w64-x86_64-opus
     pacman -S pkg-config


### PR DESCRIPTION
The command "pacman -S mingw64/mingw-w64-x86_64-opus" gives an error and based on the comment on this ticket: http://sourceforge.net/p/msys2/tickets/186/ , we should sync the package database first.
It worked for me.