### PR TITLE
Fixed issue 1176

### DIFF
--- a/Telegram/_qt_5_5_0_patch/qtbase/src/widgets/widgets/qwidgettextcontrol.cpp
+++ b/Telegram/_qt_5_5_0_patch/qtbase/src/widgets/widgets/qwidgettextcontrol.cpp
@@ -74,6 +74,7 @@
 #include <QtWidgets/qlineedit.h>
 #include <QtGui/qaccessible.h>
 #include <QtCore/qmetaobject.h>
+#include <QLocale.h>
 
 #ifndef QT_NO_SHORTCUT
 #include "private/qapplication_p.h"
@@ -1341,11 +1342,15 @@ void QWidgetTextControlPrivate::keyPressEvent(QKeyEvent *e)
 
 process:
     {
-        // QTBUG-35734: ignore Ctrl/Ctrl+Shift; accept only AltGr (Alt+Ctrl) on German keyboards
-        if (e->modifiers() == Qt::ControlModifier
-            || e->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
-            e->ignore();
-            return;
+        if (QGuiApplication::inputMethod()->locale().language() == QLocale::German)
+        {
+            // QTBUG-35734: ignore Ctrl/Ctrl+Shift; accept only AltGr (Alt+Ctrl) on German keyboards
+            // 
+            if (e->modifiers() == Qt::ControlModifier
+                || e->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
+                e->ignore();
+                return;
+            }
         }
         QString text = e->text();
 		if (!text.isEmpty() && (text.at(0).isPrint() || text.at(0) == QLatin1Char('\t') || text.at(0).unicode() == 0x200C || text.at(0).unicode() == 0x200D)) {


### PR DESCRIPTION
A quick hotfix for issue #1176. 
This may also fix any other issues with the key combination which are raised because of stripped Ctrl+ and Ctrl+Shift+ in Qt code.