### PR TITLE
Add c++11 config flag to Telegram.pro

### DIFF
--- a/Telegram/Telegram.pro
+++ b/Telegram/Telegram.pro
@@ -1,6 +1,6 @@
 QT += core gui network widgets
 
-CONFIG += plugin static
+CONFIG += plugin static c++11
 
 CONFIG(debug, debug|release) {
     DEFINES += _DEBUG


### PR DESCRIPTION
It is needed to use UTF-16 string literals (u"string"), which are generated by MetaLang.