### PR TITLE
force telegram respoect my workdir settings

### DIFF
--- a/Telegram/SourceFiles/logs.cpp
+++ b/Telegram/SourceFiles/logs.cpp
@@ -223,7 +223,9 @@ void logsInit() {
 #ifdef _DEBUG
 		cForceWorkingDir(cExeDir());
 #else
-		cForceWorkingDir(psAppDataPath());
+		if(cWorkingDir().isEmpty()){
+			cForceWorkingDir(psAppDataPath());
+		}
 #endif
 
 #if (defined Q_OS_LINUX && !defined _DEBUG) // fix first version


### PR DESCRIPTION
it seems telegram overwrites my `-workdir` argument in `logsInit`, ref #297 
here is a simple fix for that