### PR TITLE
Build function countBetaVersionSignature() when autoupdater is disabled

### DIFF
--- a/Telegram/SourceFiles/autoupdater.cpp
+++ b/Telegram/SourceFiles/autoupdater.cpp
@@ -569,6 +569,8 @@ bool checkReadyUpdate() {
 	return true;
 }
 
+#endif
+
 QString countBetaVersionSignature(uint64 version) { // duplicated in packer.cpp
 	if (cBetaPrivateKey().isEmpty()) {
 		LOG(("Error: Trying to count beta version signature without beta private key!"));
@@ -612,5 +614,3 @@ QString countBetaVersionSignature(uint64 version) { // duplicated in packer.cpp
 	signature = signature.replace('-', '8').replace('_', 'B');
 	return QString::fromUtf8(signature.mid(19, 32));
 }
-
-#endif

--- a/Telegram/SourceFiles/autoupdater.h
+++ b/Telegram/SourceFiles/autoupdater.h
@@ -66,6 +66,6 @@ private:
 
 bool checkReadyUpdate();
 
-QString countBetaVersionSignature(uint64 version);
-
 #endif
+
+QString countBetaVersionSignature(uint64 version);


### PR DESCRIPTION
It is needed by boxes/aboutbox.cpp.