### PR TITLE
Fix a build error when TDESKTOP_DISABLE_AUTOUPDATE preprocessor defined.

### DIFF
--- a/Telegram/SourceFiles/autoupdater.cpp
+++ b/Telegram/SourceFiles/autoupdater.cpp
@@ -569,6 +569,8 @@ bool checkReadyUpdate() {
 	return true;
 }
 
+#endif
+
 QString countBetaVersionSignature(uint64 version) { // duplicated in packer.cpp
 	if (cBetaPrivateKey().isEmpty()) {
 		LOG(("Error: Trying to count beta version signature without beta private key!"));
@@ -613,4 +615,3 @@ QString countBetaVersionSignature(uint64 version) { // duplicated in packer.cpp
 	return QString::fromUtf8(signature.mid(19, 32));
 }
 
-#endif

--- a/Telegram/SourceFiles/autoupdater.h
+++ b/Telegram/SourceFiles/autoupdater.h
@@ -66,6 +66,11 @@ private:
 
 bool checkReadyUpdate();
 
-QString countBetaVersionSignature(uint64 version);
+#else
+class UpdateDownloader : public QObject {
+	Q_OBJECT
+};
 
 #endif
+
+QString countBetaVersionSignature(uint64 version);


### PR DESCRIPTION
If the 'TDESKTOP_DISABLE_AUTOUPDATE' defined, a build is failing because empty moc_autoupdater.cpp is being generated and the msvc compiler will complain about 'stdafx.h not found'. In addition, aboutbox.cpp also refers to countBetaVersionSignature() which will not be included when TDESKTOP_DISABLE_AUTOUPDATE defined.

Added a dummy UpdateDownloader inherits QObject when TDESKTOP_DISABLE_AUTOUPDATE not defined, and moved the location of countBetaVersionSignature(uint64 version) to outside of #ifndef/endif scope.

Fixed & Tested on dev branch w/ VS2015. 