### PR TITLE
Build instructions for Visual Studio (Qt 5.5.1)

### DIFF
--- a/Telegram/SourceFiles/config.h
+++ b/Telegram/SourceFiles/config.h
@@ -23,7 +23,7 @@ Copyright (c) 2014-2015 John Preston, https://desktop.telegram.org
 static const int32 AppVersion = 9014;
 static const wchar_t *AppVersionStr = L"0.9.14";
 static const bool DevVersion = true;
-#define BETA_VERSION (9014003ULL) // just comment this line to build public version
+//#define BETA_VERSION (9014003ULL) // just comment this line to build public version
 
 static const wchar_t *AppNameOld = L"Telegram Win (Unofficial)";
 static const wchar_t *AppName = L"Telegram Desktop";

--- a/Telegram/Telegram.pro
+++ b/Telegram/Telegram.pro
@@ -89,6 +89,7 @@ SOURCES += \
     ./SourceFiles/autoupdater.cpp \
     ./SourceFiles/dialogswidget.cpp \
     ./SourceFiles/dropdown.cpp \
+    ./SourceFiles/facades.cpp \
     ./SourceFiles/fileuploader.cpp \
     ./SourceFiles/history.cpp \
     ./SourceFiles/historywidget.cpp \
@@ -112,6 +113,7 @@ SOURCES += \
     ./SourceFiles/types.cpp \
     ./SourceFiles/window.cpp \
     ./SourceFiles/mtproto/mtp.cpp \
+    ./SourceFiles/mtproto/mtpAuthKey.cpp \
     ./SourceFiles/mtproto/mtpConnection.cpp \
     ./SourceFiles/mtproto/mtpCoreTypes.cpp \
     ./SourceFiles/mtproto/mtpDC.cpp \
@@ -175,6 +177,7 @@ HEADERS += \
     ./SourceFiles/countries.h \
     ./SourceFiles/dialogswidget.h \
     ./SourceFiles/dropdown.h \
+    ./SourceFiles/facades.h \
     ./SourceFiles/fileuploader.h \
     ./SourceFiles/history.h \
     ./SourceFiles/historywidget.h \

--- a/Telegram/Version
+++ b/Telegram/Version
@@ -3,4 +3,4 @@ AppVersionStrMajor 0.9
 AppVersionStrSmall 0.9.14
 AppVersionStr      0.9.14
 DevChannel         1
-BetaVersion        9014003
+BetaVersion        0 9014003


### PR DESCRIPTION
When executing this command:

perl init-repository --module-subset=qtbase,qtimageformats

In my case, just only one of those modules was taken into account, so that a had to execute it separately with every module. Maybe, it a note shall be included in the instructions or directly splitting the command.