### PR TITLE
Include some reference XDG files

### DIFF
--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=1.0
+Name=Telegram Desktop
+Comment=Official desktop version of Telegram messaging app
+Exec=/usr/bin/telegram-desktop -- %u
+Icon=telegram-desktop
+Terminal=false
+StartupWMClass=Telegram
+Type=Application
+Categories=Network;
+MimeType=application/x-xdg-protocol-tg;x-scheme-handler/tg;

--- a/lib/xdg/tg.protocol
+++ b/lib/xdg/tg.protocol
@@ -1,0 +1,11 @@
+[Protocol]
+exec=/usr/bin/telegram-desktop -- %u
+protocol=tg
+input=none
+output=none
+helper=true
+listing=false
+reading=false
+writing=false
+makedir=false
+deleting=false


### PR DESCRIPTION
Include a .desktop file (for app menu in xdg-complaint desktops), and tg.protocol (for having xdg-complaint apps pick up the tg: protocol).

The intention of including these files is for package maintainers to re-use them, instead of each or them re-writing (or re-bundling for somewhere else) these files.