### PR TITLE
Remove nonexistant MIME type from desktop file

### DIFF
--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -9,4 +9,4 @@ Terminal=false
 StartupWMClass=Telegram
 Type=Application
 Categories=Network;
-MimeType=application/x-xdg-protocol-tg;x-scheme-handler/tg;
+MimeType=x-scheme-handler/tg;


### PR DESCRIPTION
x-xdg-protocol has never been a way to bind to a schema in XDG.