### PR TITLE
Fix path to qt patch

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -49,7 +49,7 @@ prepare() {
 
 	ln -s "$srcdir/qt5_6_0" "$srcdir/Libraries/qt5_6_0"
 	cd "$srcdir/Libraries/qt5_6_0/qtbase"
-	git apply "$srcdir/tdesktop/Telegram/_qtbase_5_6_0_patch.diff"
+	git apply "$srcdir/tdesktop/Telegram/Patches/qtbase_5_6_0.diff"
 
 	if [ ! -h "$srcdir/Libraries/breakpad" ]; then
 		ln -s "$srcdir/breakpad" "$srcdir/Libraries/breakpad"


### PR DESCRIPTION
breakpad is still broken

```
Build breakpad
.travis/build.sh: line 111: cd: /build/Libraries/breakpad: No such file or directory
+ cd qtbase
+ /build/qt5_6_0/qtbase/configure -top-level 
Which edition of Qt do you want to use ?
Type 'c' if you want to use the Commercial Edition.
Type 'o' if you want to use the Open Source Edition.
```