### PR TITLE
Tuning of locating of winRT functions

### DIFF
--- a/Telegram/SourceFiles/pspecific_win.cpp
+++ b/Telegram/SourceFiles/pspecific_win.cpp
@@ -785,10 +785,8 @@ namespace {
 			if (!propVariantToString) return;
 			if (QSysInfo::windowsVersion() < QSysInfo::WV_WINDOWS8) return;
 			if (!loadFunction(procId, "RoGetActivationFactory", roGetActivationFactory)) return;
-
-			HINSTANCE otherProcId = LoadLibrary(L"api-ms-win-core-winrt-string-l1-1-0.dll");
-			if (!loadFunction(otherProcId, "WindowsCreateStringReference", windowsCreateStringReference)) return;
-			if (!loadFunction(otherProcId, "WindowsDeleteString", windowsDeleteString)) return;
+			if (!loadFunction(procId, "WindowsCreateStringReference", windowsCreateStringReference)) return;
+			if (!loadFunction(procId, "WindowsDeleteString", windowsDeleteString)) return;
 
 			useToast = true;
 		}


### PR DESCRIPTION
Both WindowsCreateStringReference & WindowsDeleteString are also in
COMBASE.DLL, using of "api-ms-win-core-winrt-string-l1-1-0.dll" looks
not nice plus the dll name can theoretically be changed