### PR TITLE
strip out .desktop file generation (and xdg uri association)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - BUILD_VERSION="disable_register_custom_scheme"
   - BUILD_VERSION="disable_crash_reports"
   - BUILD_VERSION="disable_network_proxy"
+  - BUILD_VERSION="disable_desktop_file_generation"
 
 arch:
   packages:

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -79,6 +79,10 @@ prepare() {
 		options+="\nDEFINES += TDESKTOP_DISABLE_NETWORK_PROXY"
 	fi
 
+	if [[ $BUILD_VERSION == *"disable_desktop_file_generation"* ]]; then
+		options+="\nDEFINES += TDESKTOP_DISABLE_DESKTOP_FILE_GENERATION"
+	fi
+
 	options+='\nINCLUDEPATH += "/usr/lib/glib-2.0/include"'
 	options+='\nINCLUDEPATH += "/usr/lib/gtk-2.0/include"'
 	options+='\nINCLUDEPATH += "/usr/include/opus"'

--- a/Telegram/SourceFiles/pspecific_linux.cpp
+++ b/Telegram/SourceFiles/pspecific_linux.cpp
@@ -434,6 +434,7 @@ void psRegisterCustomScheme() {
     QString home(_psHomeDir());
     if (home.isEmpty() || cBetaVersion()) return; // don't update desktop file for beta version
 
+    #ifndef TDESKTOP_DISABLE_DESKTOP_FILE_GENERATION
     DEBUG_LOG(("App Info: placing .desktop file"));
     if (QDir(home + qsl(".local/")).exists()) {
         QString apps = home + qsl(".local/share/applications/");
@@ -480,6 +481,7 @@ void psRegisterCustomScheme() {
             LOG(("App Error: Could not open '%1' for write").arg(file));
         }
     }
+    #endif // TDESKTOP_DISABLE_DESKTOP_FILE_GENERATION
 
     DEBUG_LOG(("App Info: registerting for Gnome"));
     if (_psRunCommand("gconftool-2 -t string -s /desktop/gnome/url-handlers/tg/command " + escapeShell(escapeShell(QFile::encodeName(cExeDir() + cExeName())) + " -- %s"))) {


### PR DESCRIPTION
The two elements I've stripped out (runtime-generated `.desktop` launcher and xdg mime URI association) are in my view at best redundant functions and at worst meddling gremlins in the machinery.

Packagers who previously relied on the generated-at-launch `.desktop` file should instead use the one provided in `lib/xdg/`, modifying if necessary.

Fixes #306 