### PR TITLE
Add fast finish to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,17 @@ sudo: required
 language: cpp
 
 env:
-  - BUILD_VERSION=""
-  - BUILD_VERSION="disable_autoupdate"
-  - BUILD_VERSION="disable_register_custom_scheme"
-  - BUILD_VERSION="disable_crash_reports"
-  - BUILD_VERSION="disable_network_proxy"
-  - BUILD_VERSION="disable_desktop_file_generation"
-  - BUILD_VERSION="disable_unity_integration"
+  matrix:
+   - BUILD_VERSION=""
+   - BUILD_VERSION="disable_autoupdate"
+   - BUILD_VERSION="disable_register_custom_scheme"
+   - BUILD_VERSION="disable_crash_reports"
+   - BUILD_VERSION="disable_network_proxy"
+   - BUILD_VERSION="disable_desktop_file_generation"
+   - BUILD_VERSION="disable_unity_integration"
+
+matrix:
+  fast_finish: true
 
 arch:
   repos:


### PR DESCRIPTION
> Now, a build will finish as soon as a job has failed, or when the only jobs left allow failures.

See https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing