### PR TITLE
Automatic comment for missing signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 language: cpp
 
 env:
+  global:
+   # GitHub auth token (GH_AUTH_TOKEN)
+   - secure: "QBbD9VXAx3Mn0vFmHZtm6/sq+twMyR7ilQh7TQm8gBy2TrjhHKDKQ4wRQ5sa2MUFUbzrUOvPlPGq1WuY1mAUt8UE6jZDJNyyDWb6iIlcEmNRsd39XAhYHvJ+uI9JsD+U3OctZ+7Bo4fno0RLv1D5lzh5bpohmjgWxx9TiSZItbsRU+m0XM0Tahx335aXF8NFoVjheGXCOcLAXDt6OmaKPmlrXreuta5nOoRKeOg5vHlt/KNU1pYb8MFvWJc14DKxq3jNqrYlo9vHFv5tVhR1aqvVFWTD/4Z88OSxx3POzyVWdMso0lFov9uxs8qHoqLsGhDMElggyz/jnqZIHpwQMaYIGQ0LLYDv21jGgOuCOWKYlfjDY+tuESXmVPzerTlYBWLZDPrpE8BnXVYo8B/sF4WN6oCuBRjawlqYhqTH+tDDORc9Uc9pamhcuh6OsLMx3PHoyg8joN3t8yUnwhySXyfQ36hqlZ+Y4bBDRZBH/SB/EPmedyLGwdhzQFsUnOBotYeOym7LUdnGraGcj1iTPLdo5TMlBYlAiB12J5mHTNuzUKXh+PBV4REg4Mm2xYX+Pue5Qo1JcOWJteIX4BdPv526DXB3yaNWS1pZgGvYqtBwQlCeOfwOYupS0PksvmV7aX7c4qJSyW3dmEd03cxmebD0b2SbqyPxGFuUajJ7B60="
   matrix:
    - BUILD_VERSION=""
    - BUILD_VERSION="disable_autoupdate"

--- a/.travis/check.sh
+++ b/.travis/check.sh
@@ -13,11 +13,43 @@ checkCommitMessage() {
 		if [[  $TRAVIS_COMMIT_MSG != *"Signed-off-by: "* ]];then
 			error_msg "The commit message does not contain the signature!"
 			error_msg "More information: https://github.com/telegramdesktop/tdesktop/blob/master/.github/CONTRIBUTING.md#sign-your-work"
+			addMissingSignatureInfos
 			exit 1
 		else
 			success_msg "Commit message contains signature"
 		fi
 	fi
+}
+
+addMissingSignatureInfos() {
+	if [[ $BUILD_VERSION == "" ]]; then
+		local TEXT="Hi,\n\
+thanks for the pull request!\n\
+\n\
+Please read our [contributing policy](https://github.com/telegramdesktop/tdesktop/blob/master/.github/CONTRIBUTING.md). You'll need to make a pull request with the \\\"Signed-off-by:\\\" signature being the last line of your commit message, like it is described in [sign your work](https://github.com/telegramdesktop/tdesktop/blob/master/.github/CONTRIBUTING.md#sign-your-work) section. That will grant your work into the public domain.\n\
+\n\
+(See [travis build](https://travis-ci.org/telegramdesktop/tdesktop/jobs/${TRAVIS_JOB_ID}))"
+		addCommentToGitHub "${TEXT}"
+		addLabelToGitHub "missing signature"
+		info_msg "Added missing signature info on github"
+	fi
+}
+
+addCommentToGitHub() {
+	local BODY=$1
+	sendGitHubRequest "POST" "{\"body\": \"${BODY}\"}" "repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"
+}
+
+addLabelToGitHub() {
+	local LABEL=$1
+	sendGitHubRequest "PATCH" "{\"labels\": [\"${LABEL}\"]}" "repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}"
+}
+
+sendGitHubRequest() {
+	local METHOD=$1
+	local BODY=$2
+	local URI=$3
+	curl -H "Authorization: token ${GH_AUTH_TOKEN}" --request "${METHOD}" --data "${BODY}" --silent "https://api.github.com/${URI}" > /dev/null
 }
 
 source ./.travis/common.sh


### PR DESCRIPTION
With this PR, travis will add a comment to all PR's which have a commit which is missing the signature.

**Depends on #2210 and #2213 (merge first!)**