### PR TITLE
Replace hard-coded paths with pkg-config

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -58,8 +58,6 @@ prepare() {
 	fi
 
 	sed -i 's/CUSTOM_API_ID//g' "$srcdir/tdesktop/Telegram/Telegram.pro"
-	sed -i 's,LIBS += /usr/local/lib/libxkbcommon.a,,g' "$srcdir/tdesktop/Telegram/Telegram.pro"
-	sed -i 's,LIBS += /usr/local/lib/libz.a,LIBS += -lz,g' "$srcdir/tdesktop/Telegram/Telegram.pro"
 
 	local options=""
 
@@ -86,11 +84,6 @@ prepare() {
 	if [[ $BUILD_VERSION == *"disable_unity_integration"* ]]; then
 		options+="\nDEFINES += TDESKTOP_DISABLE_UNITY_INTEGRATION"
 	fi
-
-	options+='\nINCLUDEPATH += "/usr/lib/glib-2.0/include"'
-	options+='\nINCLUDEPATH += "/usr/lib/gtk-2.0/include"'
-	options+='\nINCLUDEPATH += "/usr/include/opus"'
-	options+='\nLIBS += -lcrypto -lssl'
 
 	info_msg "Build options: ${options}"
 

--- a/Telegram/Telegram.pro
+++ b/Telegram/Telegram.pro
@@ -476,35 +476,45 @@ CONFIG(debug, debug|release) {
 include(qt_static.pri)
 
 INCLUDEPATH += \
-	/usr/local/include\
-	/usr/local/include/opus\
 	./SourceFiles\
 	./GeneratedFiles\
 	./ThirdParty/minizip\
 	./../../Libraries/breakpad/src
 
-INCLUDEPATH += "/usr/include/libappindicator-0.1"
-#INCLUDEPATH += "/usr/include/gtk-3.0"
-INCLUDEPATH += "/usr/include/gtk-2.0"
-INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
-INCLUDEPATH += "/usr/lib/i386-linux-gnu/gtk-2.0/include"
-INCLUDEPATH += "/usr/include/glib-2.0"
-INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
-INCLUDEPATH += "/usr/lib/i386-linux-gnu/glib-2.0/include"
-INCLUDEPATH += "/usr/include/cairo"
-INCLUDEPATH += "/usr/include/pango-1.0"
-INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
-INCLUDEPATH += "/usr/include/atk-1.0"
+CONFIG += link_pkgconfig
+PKG_CONFIG = $$pkgConfigExecutable()
 
-INCLUDEPATH += "/usr/include/dee-1.0"
-INCLUDEPATH += "/usr/include/libdbusmenu-glib-0.4"
+# include dirs only
+QMAKE_CXXFLAGS += `$$PKG_CONFIG --cflags appindicator-0.1`
+QMAKE_CXXFLAGS += `$$PKG_CONFIG --cflags gtk+-2.0`
+QMAKE_CXXFLAGS += `$$PKG_CONFIG --cflags glib-2.0`
+QMAKE_CXXFLAGS += `$$PKG_CONFIG --cflags dee-1.0`
 
-LIBS += -ldl -llzma -lopenal -lavformat -lavcodec -lswresample -lswscale -lavutil -lopus -lva
+# include dirs and libraries
+PKGCONFIG += \
+	x11\
+	xi\
+	xext\
+	xkbcommon\
+	openal\
+	libavformat\
+	libavcodec\
+	libswresample\
+	libswscale\
+	libavutil\
+	opus\
+	libva\
+	libssl\
+	libcrypto\
+	zlib\
+	liblzma
+
+LIBS += -ldl
+
 LIBS += $${QT_TDESKTOP_PATH}/plugins/platforminputcontexts/libcomposeplatforminputcontextplugin.a \
         $${QT_TDESKTOP_PATH}/plugins/platforminputcontexts/libibusplatforminputcontextplugin.a \
         $${QT_TDESKTOP_PATH}/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.a
-LIBS += /usr/local/lib/libz.a
-LIBS += /usr/local/lib/libxkbcommon.a
+
 LIBS += ./../../../Libraries/breakpad/src/client/linux/libbreakpad_client.a
 
 RESOURCES += \

--- a/Telegram/build/build.sh
+++ b/Telegram/build/build.sh
@@ -4,6 +4,7 @@ pushd `dirname $0` > /dev/null
 FullScriptPath=`pwd`
 popd > /dev/null
 QMakePath="/usr/local/tdesktop/Qt-5.6.0/bin/qmake"
+QMakeArgs="INCLUDEPATH+=/usr/local/include INCLUDEPATH+=/usr/local/include/opus"
 
 if [ ! -d "$FullScriptPath/../../../TelegramPrivate" ]; then
   echo ""
@@ -136,7 +137,7 @@ if [ "$BuildTarget" == "linux" ] || [ "$BuildTarget" == "linux32" ]; then
 
   mkdir -p "$WorkPath/ReleaseIntermediate"
   cd "$WorkPath/ReleaseIntermediate"
-  "$QMakePath" "$HomePath/Telegram.pro" -r -spec linux-g++
+  "$QMakePath" $QMakeArgs "$HomePath/Telegram.pro" -r -spec linux-g++
 
   eval "$HomePath/build/makefile_static.sh"
   ./../codegen/Debug/codegen_style "-I./../../Telegram/Resources" "-I./../../Telegram/SourceFiles" "-o./GeneratedFiles/styles" all_files.style --rebuild

--- a/Telegram/build/makefile_static.sh
+++ b/Telegram/build/makefile_static.sh
@@ -48,6 +48,9 @@ Replace () {
     fi
 }
 
+Replace '\-lssl' "$ArchDirPath\/libssl\.a"
+Replace '\-lcrypto' "$ArchDirPath\/libcrypto\.a"
+Replace '\-lz' "$ArchDirPath\/libz\.a"
 Replace '\-llzma' "$ArchDirPath\/liblzma\.a"
 Replace '\-lXi' "$ArchDirPath\/libXi\.a $ArchDirPath\/libXext\.a"
 Replace '\-lSM' "$ArchDirPath\/libSM\.a"
@@ -55,6 +58,7 @@ Replace '\-lICE' "$ArchDirPath\/libICE\.a"
 Replace '\-lfontconfig' "$ArchDirPath\/libfontconfig\.a $ArchDirPath\/libexpat\.a"
 Replace '\-lfreetype' "$ArchDirPath\/libfreetype\.a"
 Replace '\-lXext' "$ArchDirPath\/libXext\.a"
+Replace '\-lxkbcommon' "$LocalDirPath\/libxkbcommon\.a"
 Replace '\-lopus' "$LocalDirPath\/libopus\.a"
 Replace '\-lopenal' "$LocalDirPath\/libopenal\.a"
 Replace '\-lavformat' "$LocalDirPath\/libavformat\.a"

--- a/doc/building-qmake.md
+++ b/doc/building-qmake.md
@@ -52,16 +52,10 @@ Preparation
     fi
 
     sed -i 's/CUSTOM_API_ID//g' "$srcdir/tdesktop/Telegram/Telegram.pro"
-    sed -i 's,LIBS += /usr/local/lib/libxkbcommon.a,,g' "$srcdir/tdesktop/Telegram/Telegram.pro"
-    sed -i 's,LIBS += /usr/local/lib/libz.a,LIBS += -lz,g' "$srcdir/tdesktop/Telegram/Telegram.pro"
 
     (
       echo "DEFINES += TDESKTOP_DISABLE_AUTOUPDATE"
       echo "DEFINES += TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME"
-      echo 'INCLUDEPATH += "/usr/lib/glib-2.0/include"'
-      echo 'INCLUDEPATH += "/usr/lib/gtk-2.0/include"'
-      echo 'INCLUDEPATH += "/usr/include/opus"'
-      echo 'LIBS += -lcrypto -lssl'
     ) >> "$srcdir/tdesktop/Telegram/Telegram.pro"
 
 Building


### PR DESCRIPTION
Hi,

This PR replaces hard-coded paths in `Telegram.pro` with [`pkg-config`](https://en.wikipedia.org/wiki/Pkg-config) invocation. All remaining `/usr/local/` references (which usually don't present on user system) are moved to `build/build.sh`, so that `Telegram.pro` is now generic and should work on any system without patching paths.
