### PR TITLE
Remove rounded rectangle message bubble style

### DIFF
--- a/Telegram/Resources/basic.style
+++ b/Telegram/Resources/basic.style
@@ -665,7 +665,7 @@ scrollDef: flatScroll {
 	hiding: 1000;
 }
 
-msgRadius: 16px;
+msgRadius: 3px;
 dateRadius: 10px;
 buttonRadius: 3px;
 


### PR DESCRIPTION
added signature.

* advise 1

`macOS` version use Rounded rectangle style
`Windows` & `Linux` keep original style.

* advise 2

make it optional.
If you like rounded rectangle bubble style, Just enable it.

Which do you prefer?