### PR TITLE
Wide screen view improvements

### DIFF
--- a/Telegram/SourceFiles/history.cpp
+++ b/Telegram/SourceFiles/history.cpp
@@ -3297,7 +3297,7 @@ void HistoryPhoto::initDimensions() {
 	if (!tw || !th) {
 		tw = th = 1;
 	}
-	if (tw > st::maxMediaSize) {
+	if (!Adaptive::Wide() && tw > st::maxMediaSize) {
 		th = (st::maxMediaSize * th) / tw;
 		tw = st::maxMediaSize;
 	}
@@ -3330,7 +3330,7 @@ int HistoryPhoto::resizeGetHeight(int width) {
 	bool bubble = _parent->hasBubble();
 
 	int tw = convertScale(_data->full->width()), th = convertScale(_data->full->height());
-	if (tw > st::maxMediaSize) {
+	if (!Adaptive::Wide() && tw > st::maxMediaSize) {
 		th = (st::maxMediaSize * th) / tw;
 		tw = st::maxMediaSize;
 	}

--- a/Telegram/SourceFiles/history/history_service_layout.cpp
+++ b/Telegram/SourceFiles/history/history_service_layout.cpp
@@ -143,11 +143,7 @@ void paintBubblePart(Painter &p, int x, int y, int width, int height, SideStyle 
 
 void paintPreparedDate(Painter &p, const QString &dateText, int dateTextWidth, int y, int w) {
 	int left = st::msgServiceMargin.left();
-	int maxwidth = w;
-	if (Adaptive::Wide()) {
-		maxwidth = qMin(maxwidth, int32(st::msgMaxWidth + 2 * st::msgPhotoSkip + 2 * st::msgMargin.left()));
-	}
-	w = maxwidth - st::msgServiceMargin.left() - st::msgServiceMargin.left();
+	w = w - st::msgServiceMargin.left() - st::msgServiceMargin.left();
 
 	left += (w - dateTextWidth - st::msgServicePadding.left() - st::msgServicePadding.right()) / 2;
 	int height = st::msgServicePadding.top() + st::msgServiceFont->height + st::msgServicePadding.bottom();

--- a/Telegram/SourceFiles/historywidget.cpp
+++ b/Telegram/SourceFiles/historywidget.cpp
@@ -5518,6 +5518,11 @@ void HistoryWidget::doneShow() {
 }
 
 void HistoryWidget::updateAdaptiveLayout() {
+	if (_history) {
+		_history->setPendingResize();
+	}
+
+	updateListSize(false, false, {ScrollChangeAdd, App::main() ? App::main()->contentScrollAddToY() : 0});
 	update();
 }
 

--- a/Telegram/SourceFiles/profile/profile_info_widget.cpp
+++ b/Telegram/SourceFiles/profile/profile_info_widget.cpp
@@ -72,7 +72,10 @@ int InfoWidget::resizeGetHeight(int newWidth) {
 		int availableWidth = newWidth - left - st::profileBlockMarginRight;
 		int maxWidth = st::msgMaxWidth;
 		accumulate_min(textWidth, availableWidth);
-		accumulate_min(textWidth, st::msgMaxWidth);
+		if (!Adaptive::Wide()) {
+			accumulate_min(textWidth, st::msgMaxWidth);
+		}
+
 		_about->resizeToWidth(textWidth + marginLeft + marginRight);
 		_about->moveToLeft(left - marginLeft, newHeight - st::profileBlockTextPart.margin.top());
 		newHeight += _about->height();


### PR DESCRIPTION
Hi guys,
this merge request refers to #2060 (and similar issues).
Below you can find comparison screenshots.
(old pr #2337)

Messages before:
![Messages before](https://cloud.githubusercontent.com/assets/3112183/17497048/987028b6-5dc8-11e6-96f0-f740ba852bf9.png)

Messages after:
![Messages after](https://cloud.githubusercontent.com/assets/3112183/17497051/9b9758fc-5dc8-11e6-87e0-b14fc0162be4.png)

Group/Bot/Channel info before:
![Group/Bot/Channel info before](https://cloud.githubusercontent.com/assets/3112183/17497052/9e2ebbb4-5dc8-11e6-8ad9-5a962f2a9fcd.png)

Group/Bot/Channel info after:
![Group/Bot/Channel info after](https://cloud.githubusercontent.com/assets/3112183/17497053/9fa1f510-5dc8-11e6-825d-32081391b8c5.png)


Max size of photo's dimension is 420px, so we can use it space for photos.

Photo with caption before:
![before](https://cloud.githubusercontent.com/assets/3112183/17507458/5c40bf5e-5e18-11e6-9a21-392ba0ed358a.png)

Photo with caption after:
![after](https://cloud.githubusercontent.com/assets/3112183/17507459/5cd46560-5e18-11e6-9043-c2653a6582cd.png)