### PR TITLE
Linux: Make Telegram config folder XDG compatible

### DIFF
--- a/Telegram/SourceFiles/_other/updater_linux.cpp
+++ b/Telegram/SourceFiles/_other/updater_linux.cpp
@@ -366,7 +366,7 @@ int main(int argc, char *argv[]) {
                     writeLog("No workdir, trying to figure it out");
                     struct passwd *pw = getpwuid(getuid());
                     if (pw && pw->pw_dir && strlen(pw->pw_dir)) {
-                        string tryDir = pw->pw_dir + string("/.TelegramDesktop/");
+                        string tryDir = pw->pw_dir + string("/.config/telegram-desktop/");
                         struct stat statbuf;
                         writeLog("Trying to use '%s' as workDir, getting stat() for tupdates/ready", tryDir.c_str());
                         if (!stat((tryDir + "tupdates/ready").c_str(), &statbuf)) {

--- a/Telegram/SourceFiles/pspecific_linux.cpp
+++ b/Telegram/SourceFiles/pspecific_linux.cpp
@@ -325,7 +325,7 @@ namespace {
 
 QString psAppDataPath() {
     QString home(_psHomeDir());
-    return home.isEmpty() ? QString() : (home + qsl(".TelegramDesktop/"));
+    return home.isEmpty() ? QString() : (home + qsl(".config/telegram-desktop/"));
 }
 
 QString psDownloadPath() {


### PR DESCRIPTION
This is a very small change, but it helps improve Linux compatibility very much.

The XDG specification recommends using `.config/<program name>` and `.cache/<program name>` as its folder structure. This means that the `~/.TelegramDesktop` folder is violating that specification, leading to errors with pretty much all system-integrated tools that do management, cleanup or further integration of those files.

I changed the configuration folder to `~/.config/telegram-desktop`, assuming that telegram-desktop is still the name of the program judging from Windows App Id "TelegramDesktop".

However, XDG would suggest that `telegram` binary opens the config for `telegram`, not for `telegram-desktop` - meaning that it is up for discussion if it makes sense to rename the binary to just Telegram or leave it as-is.

These two changes affect only these files:

- _other/update_linux.cpp
- pspecific_linux.cpp

Tested on ArchLinux, known to work perfectly on Debian Testing, too. Tested with up-to-date GNOME3, MATE (v1.10 with GTK 2.8) and XFCE4.

edit:// Just for the sake of completeness: The [XDG user dirs article on freedesktop](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)