### PR TITLE
Fixes "pushd: not found"

### DIFF
--- a/Telegram/gyp/refresh.sh
+++ b/Telegram/gyp/refresh.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 FullExecPath=$PWD
 pushd `dirname $0` > /dev/null


### PR DESCRIPTION
If this script is executed as `./refresh.sh` instead of bash `./refresh.sh` you may recieve the error:  

>./refresh.sh: 3: ./refresh.sh: pushd: not found  
  
This fixes the issue by making sure that bash is always used (as pushd is a bash extension).