### PR TITLE
main-window-linux: parse XDG_CURRENT_DESKTOP as colon separated list

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -368,9 +368,9 @@ bool MainWindow::psHasNativeNotifications() {
 }
 
 void MainWindow::LibsLoaded() {
-	QString cdesktop = QString(getenv("XDG_CURRENT_DESKTOP")).toLower();
-	noQtTrayIcon = (cdesktop == qstr("pantheon")) || (cdesktop == qstr("gnome"));
-	tryAppIndicator = (cdesktop == qstr("xfce"));
+	QStringList cdesktop = QString(getenv("XDG_CURRENT_DESKTOP")).toLower().split(':');
+	noQtTrayIcon = (cdesktop.contains(qstr("pantheon"))) || (cdesktop.contains(qstr("gnome")));
+	tryAppIndicator = cdesktop.contains(qstr("xfce"));
 
 	if (noQtTrayIcon) cSetSupportTray(false);
 


### PR DESCRIPTION
As per [freedesktop specifications](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html), $XDG_CURRENT_DESKTOP is a "colon-separated list of strings". Thus we need to parse it in that way.

Various desktops are now exporting this variable exposing multiple flavors.