### PR TITLE
main-window-linux: try to use AppIndicator in Unity

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -370,7 +370,7 @@ bool MainWindow::psHasNativeNotifications() {
 void MainWindow::LibsLoaded() {
 	QStringList cdesktop = QString(getenv("XDG_CURRENT_DESKTOP")).toLower().split(':');
 	noQtTrayIcon = (cdesktop.contains(qstr("pantheon"))) || (cdesktop.contains(qstr("gnome")));
-	tryAppIndicator = cdesktop.contains(qstr("xfce"));
+	tryAppIndicator = (cdesktop.contains(qstr("xfce")) || cdesktop.contains(qstr("unity")));
 
 	if (noQtTrayIcon) cSetSupportTray(false);
 


### PR DESCRIPTION
AppIndicator is the native format for indicators in Ubuntu unity shell, since telegram supports them, it's better to rely on the system library for that. As it also allows better integration with [snap packages](http://snapcraft.io).

This PR has https://github.com/telegramdesktop/tdesktop/pull/2659 as prerequisite.