### PR TITLE
[WIP] Improvements of emoji panel

### DIFF
--- a/Telegram/SourceFiles/historywidget.cpp
+++ b/Telegram/SourceFiles/historywidget.cpp
@@ -3191,7 +3191,8 @@ HistoryWidget::HistoryWidget(QWidget *parent) : TWidget(parent)
 	_silent->hide();
 	_botCommandStart->hide();
 
-	_attachEmoji->installEventFilter(_emojiPan);
+	connect(_attachEmoji, SIGNAL(clicked()), _emojiPan, SLOT(toggleVisibility()));
+	_field->installEventFilter(_emojiPan);
 
 	connect(_botKeyboardShow, SIGNAL(clicked()), this, SLOT(onKbToggle()));
 	connect(_botKeyboardHide, SIGNAL(clicked()), this, SLOT(onKbToggle()));
@@ -7548,6 +7549,8 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 void HistoryWidget::onFieldTabbed() {
 	if (!_fieldAutocomplete->isHidden()) {
 		_fieldAutocomplete->chooseSelected(FieldAutocomplete::ChooseMethod::ByTab);
+	} else {
+		_emojiPan->toggleVisibility();
 	}
 }
 
@@ -7788,7 +7791,7 @@ bool HistoryWidget::sendExistingDocument(DocumentData *doc, const QString &capti
 		onCloudDraftSave(); // won't be needed if SendInlineBotResult will clear the cloud draft
 	}
 
-	hideSelectorControlsAnimated();
+	_fieldAutocomplete->hideAnimated();  // temporary here
 
 	_field->setFocus();
 	return true;

--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -3031,9 +3031,6 @@ int MainWidget::contentScrollAddToY() const {
 	return _contentScrollAddToY;
 }
 
-void MainWidget::keyPressEvent(QKeyEvent *e) {
-}
-
 bool MainWidget::eventFilter(QObject *o, QEvent *e) {
 	if (o == _sideResizeArea) {
 		auto mouseLeft = [this, e] {
@@ -4181,7 +4178,6 @@ void MainWidget::incrementSticker(DocumentData *sticker) {
 	if (writeRecentStickers) {
 		Local::writeRecentStickers();
 	}
-	_history->updateRecentStickers();
 }
 
 void MainWidget::activate() {

--- a/Telegram/SourceFiles/mainwidget.h
+++ b/Telegram/SourceFiles/mainwidget.h
@@ -476,7 +476,6 @@ public slots:
 protected:
 	void paintEvent(QPaintEvent *e) override;
 	void resizeEvent(QResizeEvent *e) override;
-	void keyPressEvent(QKeyEvent *e) override;
 	bool eventFilter(QObject *o, QEvent *e) override;
 
 private:

--- a/Telegram/SourceFiles/stickers/emoji_pan.cpp
+++ b/Telegram/SourceFiles/stickers/emoji_pan.cpp
@@ -1164,8 +1164,14 @@ void StickerPanInner::mouseReleaseEvent(QMouseEvent *e) {
 		return;
 	}
 
+	if (_selected == pressed || _selectedFeaturedSet == pressedFeaturedSet || _selectedFeaturedSetAdd == pressedFeaturedSetAdd) {
+		sendSelectedSticker();
+	}
+}
+
+void StickerPanInner::sendSelectedSticker() {
 	auto &sets = shownSets();
-	if (_selected >= 0 && _selected < MatrixRowShift * sets.size() && _selected == pressed) {
+	if (_selected >= 0 && _selected < MatrixRowShift * sets.size()) {
 		int tab = (_selected / MatrixRowShift), sel = _selected % MatrixRowShift;
 		if (sets[tab].id == Stickers::RecentSetId && sel >= sets[tab].pack.size() && sel < sets[tab].pack.size() * 2 && _custom.at(sel - sets[tab].pack.size())) {
 			removeRecentSticker(tab, sel - sets[tab].pack.size());
@@ -1174,9 +1180,9 @@ void StickerPanInner::mouseReleaseEvent(QMouseEvent *e) {
 		if (sel < sets[tab].pack.size()) {
 			emit selected(sets[tab].pack[sel]);
 		}
-	} else if (_selectedFeaturedSet >= 0 && _selectedFeaturedSet < sets.size() && _selectedFeaturedSet == pressedFeaturedSet) {
+	} else if (_selectedFeaturedSet >= 0 && _selectedFeaturedSet < sets.size()) {
 		emit displaySet(sets[_selectedFeaturedSet].id);
-	} else if (_selectedFeaturedSetAdd >= 0 && _selectedFeaturedSetAdd < sets.size() && _selectedFeaturedSetAdd == pressedFeaturedSetAdd) {
+	} else if (_selectedFeaturedSetAdd >= 0 && _selectedFeaturedSetAdd < sets.size()) {
 		emit installSet(sets[_selectedFeaturedSetAdd].id);
 	}
 }
@@ -2144,6 +2150,76 @@ void StickerPanInner::setSelected(int newSelected, int newSelectedFeaturedSet, i
 	}
 }
 
+void StickerPanInner::moveSelection(Qt::Key key) {
+	if (_section != Section::Stickers) return; // so far works only for stickers section
+
+	if (_selected < 0) {
+		_selected = 0;
+		emit scrollToY(0);
+		emit scrollUpdated();
+		update();
+		return;
+	}
+
+	// x_X
+	int tab = _selected / MatrixRowShift, sel = _selected % MatrixRowShift;
+	switch (key) {
+	case Qt::Key_Up:
+		if (sel >= StickerPanPerRow) {
+			_selected -= StickerPanPerRow;
+		} else {
+			while (--tab >= 0) {
+				if (_mySets[tab].pack.size() >= sel) {
+					int remainder = _mySets[tab].pack.size() % StickerPanPerRow;
+					int shift = remainder > sel ? 0 : StickerPanPerRow;
+					_selected = tab * MatrixRowShift + _mySets[tab].pack.size() + sel - remainder - shift;
+					break;
+				}
+			}
+		}
+		break;
+	case Qt::Key_Down:
+		if (sel < _mySets[tab].pack.size() - StickerPanPerRow) {
+			_selected += StickerPanPerRow;
+		} else {
+			while (++tab < _mySets.count()) {
+				if (_mySets[tab].pack.size() > sel % StickerPanPerRow) {
+					_selected = tab * MatrixRowShift + sel % StickerPanPerRow;
+					break;
+				}
+			}
+		}
+		break;
+	case Qt::Key_Left:
+		if (sel > 0) {
+			_selected -= 1;
+		} else if (tab > 0) {
+			_selected = (tab - 1) * MatrixRowShift + _mySets[tab - 1].pack.size() - 1;
+		}
+		break;
+	case Qt::Key_Right:
+		if (sel < _mySets[tab].pack.size() - 1) {
+			_selected += 1;
+		} else if (tab < _mySets.count() - 1) {
+			_selected = (tab + 1) * MatrixRowShift;
+		}
+		break;
+	}
+	tab = _selected / MatrixRowShift, sel = _selected % MatrixRowShift;
+
+	int32 y = st::emojiPanHeader * tab;
+	for (int i = 0; i < tab; i++) {
+		int rows = _mySets[i].pack.size() / StickerPanPerRow;
+		rows += _mySets[i].pack.size() % StickerPanPerRow != 0;
+		y += rows * st::stickerPanSize.height();
+	}
+	y += sel / StickerPanPerRow * st::stickerPanSize.height();
+
+	emit scrollToY(y, y + st::stickerPanSize.height() + 42);  // why 42? idk, TODO: find relevant constant
+	emit scrollUpdated();
+	update();
+}
+
 void StickerPanInner::onSettings() {
 	Ui::show(Box<StickersBox>(StickersBox::Section::Installed));
 }
@@ -2379,6 +2455,7 @@ void EmojiSwitchButton::updateText(const QString &inlineBotUsername) {
 
 	int32 w = st::emojiSwitchSkip + _textWidth + (st::emojiSwitchSkip - st::emojiSwitchImgSkip) - st::buttonRadius;
 	resize(w, st::emojiPanHeader);
+	moveToRight(st::buttonRadius, 0, st::emojiPanWidth);
 }
 
 void EmojiSwitchButton::paintEvent(QPaintEvent *e) {
@@ -2702,7 +2779,7 @@ EmojiPan::EmojiPan(QWidget *parent) : TWidget(parent)
 	connect(e_inner, SIGNAL(scrollToY(int)), e_scroll, SLOT(scrollToY(int)));
 	connect(e_inner, SIGNAL(disableScroll(bool)), e_scroll, SLOT(disableScroll(bool)));
 
-	connect(s_inner, SIGNAL(scrollToY(int)), s_scroll, SLOT(scrollToY(int)));
+	connect(s_inner, SIGNAL(scrollToY(int, int)), s_scroll, SLOT(scrollToY(int, int)));
 	connect(s_inner, SIGNAL(scrollUpdated()), this, SLOT(onScrollStickers()));
 
 	connect(e_scroll, SIGNAL(scrolled()), this, SLOT(onScrollEmoji()));
@@ -2712,6 +2789,9 @@ EmojiPan::EmojiPan(QWidget *parent) : TWidget(parent)
 	connect(s_inner, SIGNAL(selected(DocumentData*)), this, SIGNAL(stickerSelected(DocumentData*)));
 	connect(s_inner, SIGNAL(selected(PhotoData*)), this, SIGNAL(photoSelected(PhotoData*)));
 	connect(s_inner, SIGNAL(selected(InlineBots::Result*,UserData*)), this, SIGNAL(inlineResultSelected(InlineBots::Result*,UserData*)));
+
+	connect(this, SIGNAL(emojiSelected(EmojiPtr)), this, SLOT(scheduleHiding()));
+	connect(this, SIGNAL(stickerSelected(DocumentData*)), this, SLOT(scheduleHiding()));
 
 	connect(s_inner, SIGNAL(emptyInlineRows()), this, SLOT(onEmptyInlineRows()));
 
@@ -2997,7 +3077,7 @@ void EmojiPan::enterEvent(QEvent *e) {
 }
 
 bool EmojiPan::preventAutoHide() const {
-	return _removingSetId || _displayingSetId;
+	return _removingSetId || _displayingSetId || !_hidingScheduled;
 }
 
 void EmojiPan::leaveEvent(QEvent *e) {
@@ -3134,7 +3214,7 @@ void EmojiPan::refreshStickers() {
 
 void EmojiPan::refreshSavedGifs() {
 	e_switch->updateText();
-	e_switch->moveToRight(st::buttonRadius, 0, st::emojiPanWidth);
+	s_switch->show();
 	s_inner->refreshSavedGifs();
 	if (_emojiShown) {
 		s_inner->preloadImages();
@@ -3327,6 +3407,17 @@ void EmojiPan::hideAnimated() {
 	startOpacityAnimation(true);
 }
 
+void EmojiPan::toggleVisibility() {
+	if (isHidden() || _hiding) {
+		_hideTimer.stop();
+		showAnimated(_origin);
+	} else {
+		hideAnimated();
+		e_inner->hideFinish();
+		s_inner->hideFinish(true);
+	}
+}
+
 EmojiPan::~EmojiPan() = default;
 
 void EmojiPan::hideFinished() {
@@ -3373,9 +3464,11 @@ void EmojiPan::showStarted() {
 			_shownFromInlineQuery = true;
 		} else {
 			s_inner->refreshRecent();
-			_emojiShown = true;
+			s_inner->showFinish();
 			_shownFromInlineQuery = false;
+			_hidingScheduled = false;
 			_cache = QPixmap(); // clear after refreshInlineRows()
+			validateSelectedIcon(ValidateIconAnimations::None);
 		}
 		recountContentMaxHeight();
 		s_inner->preloadImages();
@@ -3393,25 +3486,28 @@ void EmojiPan::showStarted() {
 }
 
 bool EmojiPan::eventFilter(QObject *obj, QEvent *e) {
-	if (e->type() == QEvent::Enter) {
-		//if (dynamic_cast<StickerPan*>(obj)) {
-		//	enterEvent(e);
-		//} else {
-			otherEnter();
-		//}
-	} else if (e->type() == QEvent::Leave) {
-		//if (dynamic_cast<StickerPan*>(obj)) {
-		//	leaveEvent(e);
-		//} else {
-			otherLeave();
-		//}
-	} else if (e->type() == QEvent::MouseButtonPress && static_cast<QMouseEvent*>(e)->button() == Qt::LeftButton/* && !dynamic_cast<StickerPan*>(obj)*/) {
-		if (isHidden() || _hiding) {
-			_hideTimer.stop();
-			showAnimated(_origin);
-		} else {
-			hideAnimated();
+	if (isHidden() || e->type() != QEvent::KeyPress) {
+		return false;
+	}
+	int key = static_cast<QKeyEvent*>(e)->key();
+
+	if (key == Qt::Key_Return || key == Qt::Key_Enter) {
+		if (_emojiShown) {
+//			e_inner->sendSelected();
+		} else if (!inlineResultsShown()) {
+			s_inner->sendSelectedSticker();
 		}
+		toggleVisibility();
+		return true;
+	}
+
+	if (key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left || key == Qt::Key_Right) {
+		if (_emojiShown) {
+//			e_inner->moveSelection(static_cast<Qt::Key>(key));
+		} else {
+			s_inner->moveSelection(static_cast<Qt::Key>(key));
+		}
+		return true;
 	}
 	return false;
 }
@@ -3637,6 +3733,11 @@ void EmojiPan::onSwitch() {
 
 	_a_slide.start([this] { update(); }, 0., 1., st::emojiPanSlideDuration, anim::linear);
 	update();
+
+	emit updateStickers();
+	e_inner->refreshRecent();
+	s_inner->refreshRecent();
+	_hidingScheduled = false;
 }
 
 void EmojiPan::performSwitch() {
@@ -3751,7 +3852,7 @@ void EmojiPan::onDelayedHide() {
 void EmojiPan::clearInlineBot() {
 	inlineBotChanged();
 	e_switch->updateText();
-	e_switch->moveToRight(st::buttonRadius, 0, st::emojiPanWidth);
+	s_switch->show();
 }
 
 bool EmojiPan::overlaps(const QRect &globalRect) const {
@@ -3920,9 +4021,7 @@ int32 EmojiPan::showInlineRows(bool newResults) {
 	int32 added = 0;
 	bool clear = !refreshInlineRows(&added);
 	if (newResults) s_scroll->scrollToY(0);
-
-	e_switch->updateText(s_inner->inlineResultsShown() ? _inlineBot->username : QString());
-	e_switch->moveToRight(0, 0, st::emojiPanWidth);
+	s_switch->hide();
 
 	bool hidden = isHidden();
 	if (!hidden && !clear) {

--- a/Telegram/SourceFiles/stickers/emoji_pan.h
+++ b/Telegram/SourceFiles/stickers/emoji_pan.h
@@ -218,6 +218,8 @@ public:
 
 	bool showSectionIcons() const;
 	void clearSelection();
+	void moveSelection(Qt::Key);
+	void sendSelectedSticker();
 
 	void refreshStickers();
 	void refreshRecentStickers(bool resize = true);
@@ -282,7 +284,7 @@ signals:
 
 	void switchToEmoji();
 
-	void scrollToY(int y);
+	void scrollToY(int topValue, int bottomValue = -1);
 	void scrollUpdated();
 	void disableScroll(bool dis);
 	void needRefreshPanels();
@@ -520,10 +522,12 @@ protected:
 
 public slots:
 	void refreshStickers();
+	void toggleVisibility();
 
 private slots:
 	void hideByTimerOrLeave();
 	void refreshSavedGifs();
+	void scheduleHiding() { _hidingScheduled = true; }
 
 	void onWndActiveChanged();
 
@@ -662,6 +666,7 @@ private:
 
 	bool _emojiShown = true;
 	bool _shownFromInlineQuery = false;
+	bool _hidingScheduled = false;
 
 	object_ptr<Ui::ScrollArea> e_scroll;
 	QPointer<internal::EmojiPanInner> e_inner;


### PR DESCRIPTION
The emoji panel very annoys me if it pops out when I'm trying to go to a last message in a chat or to cancel answering. So I removed the possibility of opening this panel by hovering mouse on attach button (the icon with smile on the left of the text input field). You can open the list of emoji or stickers by clicking on this icon or pressing tabulation on keyboard, and now you can choose a sticker using keyboard.

Also I simplified sending several stickers from the same pack at a time. The panel isn't hiding when you sent a sticker using mouse. But it automatically hides if you use keyboard for sending.

But the work is still not finished. I'd like to implement storing current selected section of the panel between launches the application and displaying on attach icon which section would be opened, just like on Android.

And maybe I'll make a some refactoring of `EmojiPan`, `FieldAutocomplete` classes.

**Work in progress…**