### PR TITLE
Windows URI association fix

### DIFF
--- a/Telegram/SourceFiles/pspecific_win.cpp
+++ b/Telegram/SourceFiles/pspecific_win.cpp
@@ -827,13 +827,13 @@ void RegisterCustomScheme() {
 	
 	if (!_psOpenRegKey(L"Software\\TelegramDesktop", &rkey)) return;
 	if (!_psOpenRegKey(L"Software\\TelegramDesktop\\Capabilities", &rkey)) return;
-	if (!_psSetKeyValue(rkey, L"ApplicationName", qls("Telegram Desktop"))) return;
+	if (!_psSetKeyValue(rkey, L"ApplicationName", qls("TelegramDesktop"))) return;
 	if (!_psSetKeyValue(rkey, L"ApplicationDescription", qls("Telegram Desktop"))) return;
 	if (!_psOpenRegKey(L"Software\\TelegramDesktop\\Capabilities\\UrlAssociations", &rkey)) return;
 	if (!_psSetKeyValue(rkey, L"tg", qls("tg"))) return;
 	
 	if (!_psOpenRegKey(L"Software\\RegisteredApplications", &rkey)) return;
-	if (!_psSetKeyValue(key, L"Telegram Desktop", qls("SOFTWARE\\TelegramDesktop\\Capabilities"))) return;
+	if (!_psSetKeyValue(key, L"TelegramDesktop", qls("SOFTWARE\\TelegramDesktop\\Capabilities"))) return;
 #endif // !TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME
 }
 

--- a/Telegram/SourceFiles/pspecific_win.cpp
+++ b/Telegram/SourceFiles/pspecific_win.cpp
@@ -824,6 +824,16 @@ void RegisterCustomScheme() {
 	if (!_psOpenRegKey(L"Software\\Classes\\tg\\shell\\open", &rkey)) return;
 	if (!_psOpenRegKey(L"Software\\Classes\\tg\\shell\\open\\command", &rkey)) return;
 	if (!_psSetKeyValue(rkey, 0, '"' + exe + qsl("\" -workdir \"") + cWorkingDir() + qsl("\" -- \"%1\""))) return;
+	
+	if (!_psOpenRegKey(L"Software\\TelegramDesktop", &rkey)) return;
+	if (!_psOpenRegKey(L"Software\\TelegramDesktop\\Capabilities", &rkey)) return;
+	if (!_psSetKeyValue(rkey, L"ApplicationName", qls("Telegram Desktop"))) return;
+	if (!_psSetKeyValue(rkey, L"ApplicationDescription", qls("Telegram Desktop"))) return;
+	if (!_psOpenRegKey(L"Software\\TelegramDesktop\\Capabilities\\UrlAssociations", &rkey)) return;
+	if (!_psSetKeyValue(rkey, L"tg", qls("tg"))) return;
+	
+	if (!_psOpenRegKey(L"Software\\RegisteredApplications", &rkey)) return;
+	if (!_psSetKeyValue(key, L"Telegram Desktop", qls("SOFTWARE\\TelegramDesktop\\Capabilities"))) return;
 #endif // !TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME
 }
 


### PR DESCRIPTION
The added code will register Telegram Desktop as a Windows Default Program to handle tg:// uri scheme.