### PR TITLE
Added missing FileDescrtiption in winrc file for main .exe

### DIFF
--- a/Telegram/Resources/winrc/Telegram.rc
+++ b/Telegram/Resources/winrc/Telegram.rc
@@ -51,6 +51,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName", "Telegram Messenger LLP"
+            VALUE "FileDescription", "Telegram Desktop"
             VALUE "FileVersion", "1.0.6.0"
             VALUE "LegalCopyright", "Copyright (C) 2014-2017"
             VALUE "ProductName", "Telegram Desktop"


### PR DESCRIPTION
Following the fix for URI associations it turns out that the only field Windows uses to display a friendly app name and not the exe filename is the FileDescription resource string, actually missing from released binaries. Given that no RC generation script is present in this repo I simply hardcoded the "Telegram Desktop" as such description. Updater is done already the same way.