### PR TITLE
adding new feature of using external video player

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -281,6 +281,7 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 "lng_settings_auto_start" = "Launch Telegram when system starts";
 "lng_settings_start_min" = "Launch minimized";
 "lng_settings_add_sendto" = "Place Telegram in «Send to» menu";
+"lng_settings_use_external_videoplayer" = "Use external video player";
 "lng_settings_section_scale" = "Interface Scale";
 "lng_settings_scale_auto" = "Auto ({cur})";
 

--- a/Telegram/SourceFiles/localstorage.cpp
+++ b/Telegram/SourceFiles/localstorage.cpp
@@ -528,6 +528,7 @@ enum {
 	// 0x1b reserved
 	dbiNotifyView = 0x1c,
 	dbiSendToMenu = 0x1d,
+	dbiUseExternalVideoPlayer = 0x49,
 	dbiCompressPastedImage = 0x1e,
 	dbiLang = 0x1f,
 	dbiLangFile = 0x20,
@@ -926,6 +927,14 @@ bool _readSetting(quint32 blockId, QDataStream &stream, int version) {
 		if (!_checkStreamStatus(stream)) return false;
 
 		cSetSendToMenu(v == 1);
+	} break;
+
+	case dbiUseExternalVideoPlayer: {
+		qint32 v;
+		stream >> v;
+		if (!_checkStreamStatus(stream)) return false;
+
+		cSetUseExternalVideoPlayer(v == 1);
 	} break;
 
 	case dbiSoundNotify: {
@@ -2251,6 +2260,7 @@ void writeSettings() {
 	data.stream << quint32(dbiAutoStart) << qint32(cAutoStart());
 	data.stream << quint32(dbiStartMinimized) << qint32(cStartMinimized());
 	data.stream << quint32(dbiSendToMenu) << qint32(cSendToMenu());
+	data.stream << quint32(dbiUseExternalVideoPlayer) << qint32(cUseExternalVideoPlayer());
 	data.stream << quint32(dbiWorkMode) << qint32(cWorkMode());
 	data.stream << quint32(dbiSeenTrayTooltip) << qint32(cSeenTrayTooltip());
 	data.stream << quint32(dbiAutoUpdate) << qint32(cAutoUpdate());

--- a/Telegram/SourceFiles/settings.cpp
+++ b/Telegram/SourceFiles/settings.cpp
@@ -51,6 +51,7 @@ bool gStartMinimized = false;
 bool gStartInTray = false;
 bool gAutoStart = false;
 bool gSendToMenu = false;
+bool gUseExternalVideoPlayer = false;
 bool gAutoUpdate = true;
 TWindowPos gWindowPos;
 LaunchMode gLaunchMode = LaunchModeNormal;

--- a/Telegram/SourceFiles/settings.h
+++ b/Telegram/SourceFiles/settings.h
@@ -69,6 +69,7 @@ DeclareSetting(bool, AutoStart);
 DeclareSetting(bool, StartMinimized);
 DeclareSetting(bool, StartInTray);
 DeclareSetting(bool, SendToMenu);
+DeclareSetting(bool, UseExternalVideoPlayer);
 enum LaunchMode {
 	LaunchModeNormal = 0,
 	LaunchModeAutoStart,

--- a/Telegram/SourceFiles/settings/settings_general_widget.cpp
+++ b/Telegram/SourceFiles/settings/settings_general_widget.cpp
@@ -204,6 +204,7 @@ void GeneralWidget::refreshControls() {
 		addChildRow(_addInSendTo, marginSmall, lang(lng_settings_add_sendto), SLOT(onAddInSendTo()), cSendToMenu());
 #endif // OS_WIN_STORE
 #endif // Q_OS_WIN
+		addChildRow(_useExternalVideoPlayer, marginSmall, lang(lng_settings_use_external_videoplayer), SLOT(onUseExternalVideoPlayer()), cUseExternalVideoPlayer());
 	}
 }
 
@@ -336,5 +337,10 @@ void GeneralWidget::onAddInSendTo() {
 	Local::writeSettings();
 }
 #endif // Q_OS_WIN && !OS_WIN_STORE
+
+void GeneralWidget::onUseExternalVideoPlayer() {
+	cSetUseExternalVideoPlayer(_useExternalVideoPlayer->checked());
+	Local::writeSettings();
+}
 
 } // namespace Settings

--- a/Telegram/SourceFiles/settings/settings_general_widget.h
+++ b/Telegram/SourceFiles/settings/settings_general_widget.h
@@ -100,6 +100,8 @@ private slots:
 	void onAddInSendTo();
 #endif // Q_OS_WIN && !OS_WIN_STORE
 
+	void onUseExternalVideoPlayer();
+
 	void onRestart();
 
 private:
@@ -118,6 +120,7 @@ private:
 	object_ptr<Ui::Checkbox> _autoStart = { nullptr };
 	object_ptr<Ui::WidgetSlideWrap<Ui::Checkbox>> _startMinimized = { nullptr };
 	object_ptr<Ui::Checkbox> _addInSendTo = { nullptr };
+	object_ptr<Ui::Checkbox> _useExternalVideoPlayer = { nullptr };
 
 	FileDialog::QueryId _chooseLangFileQueryId = 0;
 	QString _testLanguage;

--- a/Telegram/SourceFiles/window/main_window.cpp
+++ b/Telegram/SourceFiles/window/main_window.cpp
@@ -99,10 +99,15 @@ void MainWindow::showPhoto(PhotoData *photo, PeerData *peer) {
 }
 
 void MainWindow::showDocument(DocumentData *doc, HistoryItem *item) {
-	if (_mediaView->isHidden()) Ui::hideLayer(true);
-	_mediaView->showDocument(doc, item);
-	_mediaView->activateWindow();
-	_mediaView->setFocus();
+	if(cUseExternalVideoPlayer() && doc->isVideo())
+		QDesktopServices::openUrl(QUrl("file:///"+ doc->location(false).fname));
+	else
+	{
+		if (_mediaView->isHidden()) Ui::hideLayer(true);
+		_mediaView->showDocument(doc, item);
+		_mediaView->activateWindow();
+		_mediaView->setFocus();
+	}
 }
 
 bool MainWindow::ui_isMediaViewShown() {


### PR DESCRIPTION
I have added a new option in general section, "Use external video player"

![image](https://cloud.githubusercontent.com/assets/9818491/22859656/d358afb8-f137-11e6-8a98-7479cd641cbf.png)

If this checkbox has been selected by user then all videos will be played by default os media player.

I am a .NET Engineer and I am not sure about mac and Linux.  