### PR TITLE
Fix compilation of history widget.

### DIFF
--- a/Telegram/SourceFiles/historywidget.cpp
+++ b/Telegram/SourceFiles/historywidget.cpp
@@ -190,7 +190,8 @@ namespace {
 // is applied once for blocks list in a history and once for items list in the found block
 template <bool TopToBottom, typename T>
 int binarySearchBlocksOrItems(const T &list, int edge) {
-	auto start = 0, end = list.size();
+	// static_cast to work around GCC bug #78693
+	auto start = 0, end = static_cast<int>(list.size());
 	while (end - start > 1) {
 		auto middle = (start + end) / 2;
 		auto top = list[middle]->y;


### PR DESCRIPTION
error: inconsistent deduction for 'auto': 'int' and then 'auto'
  auto start = 0, end = list.size();
    ^~~~