### PR TITLE
Update .desktop file on Linux

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -467,16 +467,16 @@ void psRegisterCustomScheme() {
 			QTextStream s(&f);
 			s.setCodec("UTF-8");
 			s << "[Desktop Entry]\n";
-			s << "Encoding=UTF-8\n";
 			s << "Version=1.0\n";
 			s << "Name=Telegram Desktop\n";
 			s << "Comment=Official desktop version of Telegram messaging app\n";
+			s << "TryExec=" << EscapeShell(QFile::encodeName(cExeDir() + cExeName())) << "\n";
 			s << "Exec=" << EscapeShell(QFile::encodeName(cExeDir() + cExeName())) << " -- %u\n";
 			s << "Icon=telegram\n";
 			s << "Terminal=false\n";
-			s << "StartupWMClass=Telegram\n";
+			s << "StartupWMClass=TelegramDesktop\n";
 			s << "Type=Application\n";
-			s << "Categories=Network;\n";
+			s << "Categories=Network;InstantMessaging;Qt;\n";
 			s << "MimeType=x-scheme-handler/tg;\n";
 			f.close();
 
@@ -541,7 +541,7 @@ bool _execUpdater(bool update = true, const QString &crashreport = QString()) {
 	static const int MaxLen = 65536, MaxArgsCount = 128;
 
 	char path[MaxLen] = {0};
-	QByteArray data(QFile::encodeName(cExeDir() + "Updater"));
+	QByteArray data(QFile::encodeName(cExeDir() + (update ? "Updater" : gExeName)));
 	memcpy(path, data.constData(), data.size());
 
 	char *args[MaxArgsCount] = {0}, p_noupdate[] = "-noupdate", p_autostart[] = "-autostart", p_debug[] = "-debug", p_tosettings[] = "-tosettings", p_key[] = "-key", p_path[] = "-workpath", p_startintray[] = "-startintray", p_testmode[] = "-testmode", p_crashreport[] = "-crashreport";

--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -1,12 +1,11 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Name=Telegram Desktop
 Comment=Official desktop version of Telegram messaging app
-Exec=/usr/bin/telegram-desktop -- %u
-Icon=telegram-desktop
+Exec=telegram-desktop -- %u
+Icon=telegram
 Terminal=false
-StartupWMClass=Telegram
+StartupWMClass=TelegramDesktop
 Type=Application
-Categories=Network;
+Categories=Network;InstantMessaging;Qt;
 MimeType=x-scheme-handler/tg;


### PR DESCRIPTION
What I have done:

 * Removed deprecated _Encoding_ key
 * Specified correct WM class for _StartupWMClass key_
 * Fixed icon name in `lib/xdg/telegramdesktop.desktop`

The _Encoding_ key is deprecated as [the specification says][1].

A WM class, which was specified, represents the name of binary and depends on its file name. Qt sets this class equal to the _ApplicationName_, which you specified in [Telegram/SourceFiles/main.cpp][2]. To show all WM classes use **xprop** utility.

What happens if you specify incorrect _StartupWMClass_: then when you click on Telegram menu item, you'll see two Telegram icon on the taskbar. And one of them will disappear after a while.

![Screenshot of the taskbar](https://cloud.githubusercontent.com/assets/9163157/23829631/18b02baa-0708-11e7-9ce0-584bc370c84b.png)

---

I also fixed restarting when language is changed and there is no Updater near Telegram executable file. By the way, you need not have a special Updater on Linux. Telegram Desktop can update itself within a single process. When a new version is downloaded, just rename it to `gExeName` and do restart. You can rename any file (if you certainly have permissions) even if it's opened.

Besides, you can find all valid values for the _Category_ key in [annex to menu specification][3].

 [1]: https://standards.freedesktop.org/desktop-entry-spec/1.1/apc.html
 [2]: https://github.com/telegramdesktop/tdesktop/blob/83720d87898e62e4e8ef98d2e410b931a9328562/Telegram/SourceFiles/main.cpp#L29
 [3]: https://specifications.freedesktop.org/menu-spec/latest/apa.html