### PR TITLE
Update libva git URL and QT init-repository invocation

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -205,7 +205,7 @@ buildVa() {
   rm -rf *
 
   cd "$EXTERNAL"
-  git clone git://anongit.freedesktop.org/git/libva
+  git clone https://github.com/01org/libva
 
   cd "$EXTERNAL/libva"
   ./autogen.sh --prefix=$VA_PATH --enable-static
@@ -523,8 +523,7 @@ buildCustomQt() {
   git clone git://code.qt.io/qt/qt5.git qt${QT_VERSION}
 
   cd "$EXTERNAL/qt${QT_VERSION}"
-  git checkout "$(echo ${QT_VERSION} | sed -e s/\..$//)"
-  perl init-repository --module-subset=qtbase,qtimageformats
+  perl init-repository --branch --module-subset=qtbase,qtimageformats
   git checkout v${QT_VERSION}
   cd qtbase && git checkout v${QT_VERSION} && cd ..
   cd qtimageformats && git checkout v${QT_VERSION} && cd ..


### PR DESCRIPTION
Signed-off-by: Fritz Elfert <fritz-github@fritz-elfert.de> (github: felfert)

When attempting to build on my own travis account, those two changes were necessary, because I did not yet had dependencies cached and therefore full builds were necessary.
 - The libva repo has moved.
 - The invocation of the init-repository script in the Qt repo has changed.