### PR TITLE
Add appstream metadata file

### DIFF
--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -8,6 +8,10 @@
     <description>
        <p>Fast and secure desktop app, perfectly synced with your mobile phone.</p>
     </description>
+    <categories>
+        <category>Network</category>
+        <category>InstantMessaging</category>
+    </categories>
     <url type="homepage">https://desktop.telegram.org/</url>
     <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>
     <screenshots>

--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -2,13 +2,13 @@
 <component type="desktop">
     <id>org.telegram.TelegramDesktop.desktop</id>
     <metadata_license>CC0-1.0</metadata_license>
-    <project_license>GPL-2.0+</project_license>
-    <name>Telegram desktop</name>
+    <project_license>GPL-3.0</project_license>
+    <name>Telegram Desktop</name>
     <summary>Telegram Desktop messenger</summary>
     <description>
        <p>Fast and secure desktop app, perfectly synced with your mobile phone.</p>
     </description>
-    <url type="homepage">https://github.com/telegramdesktop/tdesktop</url>
+    <url type="homepage">https://desktop.telegram.org/</url>
     <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>
     <screenshots>
       <screenshot type="default">

--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop">
+    <id>org.telegram.TelegramDesktop.desktop</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-2.0+</project_license>
+    <name>Telegram desktop</name>
+    <summary>Telegram Desktop messenger</summary>
+    <description>
+       <p>Fast and secure desktop app, perfectly synced with your mobile phone.</p>
+    </description>
+    <url type="homepage">https://github.com/telegramdesktop/tdesktop</url>
+    <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>
+    <screenshots>
+      <screenshot type="default">
+        <image>https://jgrulich.fedorapeople.org/telegram/telegram-screenshot.png</image>
+      </screenshot>
+    </screenshots>
+    <provides>
+        <binary>telegram-desktop</binary>
+    </provides>
+</component>

--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="desktop">
-    <id>org.telegram.TelegramDesktop.desktop</id>
+    <id>org.telegram.tdesktop.desktop</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <name>Telegram Desktop</name>

--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="desktop">
-    <id>org.telegram.tdesktop.desktop</id>
+    <id>org.telegram.desktop</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <name>Telegram Desktop</name>
@@ -12,7 +12,7 @@
     <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>
     <screenshots>
       <screenshot type="default">
-        <image>https://jgrulich.fedorapeople.org/telegram/telegram-screenshot.png</image>
+        <image>https://raw.githubusercontent.com/telegramdesktop/tdesktop/dev/docs/assets/preview.png</image>
       </screenshot>
     </screenshots>
     <provides>


### PR DESCRIPTION
Add appstream metadata file [1] providing basic information about telegram desktop app. I would also prefer if there is some official screenshot rather than the one I'm currently hosting, but that can be changed later. The most important thing is to agree on appstream app ID, which can be then used to identify telegram desktop app, e.g. when writing reviews in ODRS [2].

[1] - https://www.freedesktop.org/wiki/Distributions/AppStream/
[2] - https://odrs.gnome.org/