### PR TITLE
Clean up regular expressions

### DIFF
--- a/Telegram/SourceFiles/ui/text/text_entity.cpp
+++ b/Telegram/SourceFiles/ui/text/text_entity.cpp
@@ -28,12 +28,17 @@ const QRegularExpression _reDomain(QString::fromUtf8("(?<![\\w\\$\\-\\_%=\\.])(?
 const QRegularExpression _reExplicitDomain(QString::fromUtf8("(?<![\\w\\$\\-\\_%=\\.])(?:([a-zA-Z]+)://)((?:[A-Za-z" "\xd0\x90-\xd0\xaf\xd0\x81" "\xd0\xb0-\xd1\x8f\xd1\x91" "0-9\\-\\_]+\\.){0,5}([A-Za-z" "\xd1\x80\xd1\x84" "\\-\\d]{2,22})(\\:\\d+)?)"), QRegularExpression::UseUnicodePropertiesOption);
 const QRegularExpression _reMailName(qsl("[a-zA-Z\\-_\\.0-9]{1,256}$"));
 const QRegularExpression _reMailStart(qsl("^[a-zA-Z\\-_\\.0-9]{1,256}\\@"));
-const QRegularExpression _reHashtag(qsl("(^|[\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\%\\^\\*\\(\\)\\-\\+=\\x10])#[\\w]{2,64}([\\W]|$)"), QRegularExpression::UseUnicodePropertiesOption);
-const QRegularExpression _reMention(qsl("(^|[\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\%\\^\\*\\(\\)\\-\\+=\\x10])@[A-Za-z_0-9]{1,32}([\\W]|$)"), QRegularExpression::UseUnicodePropertiesOption);
-const QRegularExpression _reBotCommand(qsl("(^|[\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\%\\^\\*\\(\\)\\-\\+=\\x10])/[A-Za-z_0-9]{1,64}(@[A-Za-z_0-9]{5,32})?([\\W]|$)"));
-const QRegularExpression _rePre(qsl("(^|[\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\?\\%\\^\\*\\(\\)\\-\\+=\\x10])(````?)[\\s\\S]+?(````?)([\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\?\\%\\^\\*\\(\\)\\-\\+=\\x10]|$)"), QRegularExpression::UseUnicodePropertiesOption);
-const QRegularExpression _reCode(qsl("(^|[\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\?\\%\\^\\*\\(\\)\\-\\+=\\x10])(`)[^\\n]+?(`)([\\s\\.,:;<>|'\"\\[\\]\\{\\}`\\~\\!\\?\\%\\^\\*\\(\\)\\-\\+=\\x10]|$)"), QRegularExpression::UseUnicodePropertiesOption);
+
+#define dividers "\\s\\.,:;<>|'\"\\[\\]\\{\\}\\~\\!\\%\\^\\*\\(\\)\\-\\+=\\x10"
+
+const QRegularExpression _reHashtag(qsl("(^|[" dividers "`])#[\\w]{2,64}([\\W]|$)"), QRegularExpression::UseUnicodePropertiesOption);
+const QRegularExpression _reMention(qsl("(^|[" dividers "`])@[A-Za-z_0-9]{1,32}([\\W]|$)"), QRegularExpression::UseUnicodePropertiesOption);
+const QRegularExpression _reBotCommand(qsl("(^|[" dividers "`])/[A-Za-z_0-9]{1,64}(@[A-Za-z_0-9]{5,32})?([\\W]|$)"));
+const QRegularExpression _rePre(qsl("(^|[" dividers "\\?])(````?)[\\s\\S]+?(````?)([" dividers "\\?]|$)"), QRegularExpression::UseUnicodePropertiesOption);
+const QRegularExpression _reCode(qsl("(^|[" dividers "\\?])(`)[^\\n]+?(`)([" dividers "\\?]|$)"), QRegularExpression::UseUnicodePropertiesOption);
 QSet<int32> _validProtocols, _validTopDomains;
+
+#undef dividers
 
 } // namespace
 


### PR DESCRIPTION
New expressions are the same[1], but a big shared chunk was taken into
macro to simpliy understanding
<pre>
[1] -- the only difference is '`' is not an allowed "divider" for
Code&Pre anymore, because it makes no sence for it to be.
You can test it with this expression: \`\`\`fo\`\`\`o:
- Before: gets parsed as <code>``fo</code>``o
- Now: ```fo```o (stays unchanged)
</pre>

Also, I can't understand why is `?` allowed for code/pre but not for
hashtags/mentions/bot commands... But I decided to keep it. 