### PR TITLE
More accurate phrasing when copying text

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -962,7 +962,7 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 "lng_context_pin_msg" = "Pin Message";
 "lng_context_unpin_msg" = "Unpin Message";
 "lng_context_cancel_upload" = "Cancel Upload";
-"lng_context_copy_selected" = "Copy Selected Text";
+"lng_context_copy_selected" = "Copy Selected as Text";
 "lng_context_forward_selected" = "Forward Selected";
 "lng_context_delete_selected" = "Delete Selected";
 "lng_context_clear_selection" = "Clear Selection";


### PR DESCRIPTION
If I select a message and right click it says "Copy Selected Text",
while in fact it puts more information than just the text as content.

If I select the message "Test" and choose "Copy Selected Text", it
copies the following:
"Andreas Lindhé, [02.05.17 18:12]
Test"

By this choice of words, it is more clear to the user that it's not only
the text that gets copied.

I would have preferred "Copy Selected Messages", but that would
necessitate extending the functionality to check if more than one
message was selected (in order to look nice and be grammatically
correct). Another option would have been "Copy Selected Content", but
that might be perceived as copying multimedia content as well.

Signed-off-by: Andreas Lindhé <andreas@lindhe.io> (github: lindhe)