### PR TITLE
Fix inconsistency of max width for message content

### DIFF
--- a/Telegram/Resources/basic.style
+++ b/Telegram/Resources/basic.style
@@ -239,7 +239,7 @@ dragPadding: margins(20px, 10px, 20px, 10px);
 dragHeight: 72px;
 
 minPhotoSize: 100px;
-maxMediaSize: 420px;
+maxMediaSize: 430px;
 maxStickerSize: 256px;
 maxGifSize: 320px;
 maxSignatureSize: 144px;


### PR DESCRIPTION
Full-width text-only messages are slightly wider than images.