### PR TITLE
Done #687: options to disable link preview [re-created PR]

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -288,6 +288,8 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 "lng_settings_section_chat_settings" = "Chat Settings";
 "lng_settings_replace_emojis" = "Replace emoji";
 "lng_settings_view_emojis" = "View list";
+"lng_settings_no_web_page_preview" = "No web pages preview";
+"lng_settings_no_document_preview" = "No documents preview";
 "lng_settings_emoji_list" = "Supported emoji";
 "lng_settings_send_enter" = "Send by Enter";
 "lng_settings_send_ctrlenter" = "Send by Ctrl+Enter";

--- a/Telegram/SourceFiles/history/history_message.cpp
+++ b/Telegram/SourceFiles/history/history_message.cpp
@@ -703,12 +703,18 @@ void HistoryMessage::initMedia(const MTPMessageMedia *media) {
 		}
 	} break;
 	case mtpc_messageMediaDocument: {
+		if (cNoDocumentPreview()) {
+			break;
+		}
 		auto &document = media->c_messageMediaDocument().vdocument;
 		if (document.type() == mtpc_document) {
 			return initMediaFromDocument(App::feedDocument(document), qs(media->c_messageMediaDocument().vcaption));
 		}
 	} break;
 	case mtpc_messageMediaWebPage: {
+		if (cNoWebPagePreview()) {
+			break;
+		}
 		auto &d = media->c_messageMediaWebPage().vwebpage;
 		switch (d.type()) {
 		case mtpc_webPageEmpty: break;

--- a/Telegram/SourceFiles/settings.cpp
+++ b/Telegram/SourceFiles/settings.cpp
@@ -61,6 +61,8 @@ int32 gLastUpdateCheck = 0;
 bool gNoStartUpdate = false;
 bool gStartToSettings = false;
 bool gReplaceEmojis = true;
+bool gNoWebPagePreview = false;
+bool gNoDocumentPreview = false;
 
 bool gCtrlEnter = false;
 

--- a/Telegram/SourceFiles/settings.h
+++ b/Telegram/SourceFiles/settings.h
@@ -107,6 +107,8 @@ DeclareSetting(int32, LastUpdateCheck);
 DeclareSetting(bool, NoStartUpdate);
 DeclareSetting(bool, StartToSettings);
 DeclareSetting(bool, ReplaceEmojis);
+DeclareSetting(bool, NoWebPagePreview);
+DeclareSetting(bool, NoDocumentPreview);
 DeclareReadSetting(bool, ManyInstance);
 
 DeclareSetting(QByteArray, LocalSalt);

--- a/Telegram/SourceFiles/settings/settings_chat_settings_widget.cpp
+++ b/Telegram/SourceFiles/settings/settings_chat_settings_widget.cpp
@@ -158,12 +158,16 @@ void ChatSettingsWidget::createControls() {
 	style::margins marginSub(0, 0, 0, st::settingsSubSkip);
 	style::margins slidedPadding(0, marginSub.bottom() / 2, 0, marginSub.bottom() - (marginSub.bottom() / 2));
 
+	// replaceEmoji + viewList link block
 	addChildRow(_replaceEmoji, marginSub, lang(lng_settings_replace_emojis), SLOT(onReplaceEmoji()), cReplaceEmojis());
 	style::margins marginList(st::defaultBoxCheckbox.textPosition.x(), 0, 0, st::settingsSkip);
 	addChildRow(_viewList, marginList, slidedPadding, lang(lng_settings_view_emojis), SLOT(onViewList()), st::defaultLinkButton);
 	if (!cReplaceEmojis()) {
 		_viewList->hideFast();
 	}
+	// noWebPagePreview and noDocumentPreview option
+	addChildRow(_noWebPagePreview, marginSub, lang(lng_settings_no_web_page_preview), SLOT(onNoWebPagePreview()), cNoWebPagePreview());
+	addChildRow(_noDocumentPreview, marginSub, lang(lng_settings_no_document_preview), SLOT(onNoDocumentPreview()), cNoDocumentPreview());
 
 #ifndef OS_WIN_STORE
 	auto pathMargin = marginSub;
@@ -200,6 +204,16 @@ void ChatSettingsWidget::onReplaceEmoji() {
 
 void ChatSettingsWidget::onViewList() {
 	Ui::show(Box<EmojiBox>());
+}
+
+void ChatSettingsWidget::onNoWebPagePreview() {
+    cSetNoWebPagePreview(_noWebPagePreview->checked());
+    Local::writeUserSettings();
+}
+
+void ChatSettingsWidget::onNoDocumentPreview() {
+    cSetNoDocumentPreview(_noDocumentPreview->checked());
+    Local::writeUserSettings();
 }
 
 void ChatSettingsWidget::onDontAskDownloadPath() {

--- a/Telegram/SourceFiles/settings/settings_chat_settings_widget.h
+++ b/Telegram/SourceFiles/settings/settings_chat_settings_widget.h
@@ -97,6 +97,8 @@ public:
 private slots:
 	void onReplaceEmoji();
 	void onViewList();
+	void onNoWebPagePreview();
+	void onNoDocumentPreview();
 	void onDontAskDownloadPath();
 	void onAutomaticMediaDownloadSettings();
 	void onManageStickerSets();
@@ -111,6 +113,8 @@ private:
 
 	object_ptr<Ui::Checkbox> _replaceEmoji = { nullptr };
 	object_ptr<Ui::WidgetSlideWrap<Ui::LinkButton>> _viewList = { nullptr };
+	object_ptr<Ui::Checkbox> _noWebPagePreview = { nullptr };
+	object_ptr<Ui::Checkbox> _noDocumentPreview = { nullptr };
 	object_ptr<Ui::Checkbox> _dontAskDownloadPath = { nullptr };
 
 #ifndef OS_WIN_STORE

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -575,6 +575,8 @@ enum {
 	dbiMtpAuthorization = 0x4b,
 	dbiLastSeenWarningSeenOld = 0x4c,
 	dbiAuthSessionData = 0x4d,
+	dbiNoWebPagePreview = 0x4e,
+	dbiNoDocumentPreview = 0x4f,
 
 	dbiEncryptedWithSalt = 333,
 	dbiEncrypted = 444,
@@ -1306,6 +1308,22 @@ bool _readSetting(quint32 blockId, QDataStream &stream, int version, ReadSetting
 		cSetReplaceEmojis(v == 1);
 	} break;
 
+    case dbiNoWebPagePreview: {
+        qint32 v;
+        stream >> v;
+        if (!_checkStreamStatus(stream)) return false;
+
+        cSetNoWebPagePreview(v == 1);
+    } break;
+
+    case dbiNoDocumentPreview: {
+        qint32 v;
+        stream >> v;
+        if (!_checkStreamStatus(stream)) return false;
+
+        cSetNoDocumentPreview(v == 1);
+    } break;
+
 	case dbiDefaultAttach: {
 		qint32 v;
 		stream >> v;
@@ -1720,7 +1738,9 @@ void _writeUserSettings() {
 		return Window::Controller::kDefaultDialogsWidthRatio;
 	};
 
-	uint32 size = 21 * (sizeof(quint32) + sizeof(qint32));
+	// NOTE: number below is a number of single qint32 options that are serialized right after 'data' object definition.
+	// don't forget to update it after adding of new option.
+	uint32 size = 26 * (sizeof(quint32) + sizeof(qint32));
 	size += sizeof(quint32) + Serialize::stringSize(Global::AskDownloadPath() ? QString() : Global::DownloadPath()) + Serialize::bytearraySize(Global::AskDownloadPath() ? QByteArray() : Global::DownloadPathBookmark());
 
 	size += sizeof(quint32) + sizeof(qint32);
@@ -1746,6 +1766,8 @@ void _writeUserSettings() {
 	data.stream << quint32(dbiAdaptiveForWide) << qint32(Global::AdaptiveForWide() ? 1 : 0);
 	data.stream << quint32(dbiAutoLock) << qint32(Global::AutoLock());
 	data.stream << quint32(dbiReplaceEmojis) << qint32(cReplaceEmojis() ? 1 : 0);
+	data.stream << quint32(dbiNoWebPagePreview) << qint32(cNoWebPagePreview() ? 1 : 0);
+	data.stream << quint32(dbiNoDocumentPreview) << qint32(cNoDocumentPreview() ? 1 : 0);
 	data.stream << quint32(dbiSoundNotify) << qint32(Global::SoundNotify());
 	data.stream << quint32(dbiIncludeMuted) << qint32(Global::IncludeMuted());
 	data.stream << quint32(dbiDesktopNotify) << qint32(Global::DesktopNotify());


### PR DESCRIPTION
I've implemented a feature request #687 that was published over 2 years ago and is wanted by many users: couple of options to control web pages preview. Now web pages and documents preview could be disabled in Chat options.

![no-preview-checkboxes](https://user-images.githubusercontent.com/1774752/27256757-ff5ebfbe-53c8-11e7-91ab-7ed0c4a12d95.png)

Rationale: ability to have compact history, when lots of links are used (web dev or design collaboration, etc.)