### PR TITLE
Remove depencency on Qt5PlatformSupport, it is unused

### DIFF
--- a/Telegram/gyp/qt.gypi
+++ b/Telegram/gyp/qt.gypi
@@ -34,7 +34,6 @@
           'qt_libs': [
             'qwebp',
             'Qt5PrintSupport',
-            'Qt5PlatformSupport',
             'Qt5Network',
             'Qt5Widgets',
             'Qt5Gui',
@@ -59,6 +58,7 @@
             'qt_libs': [
               '<@(qt_libs)',
               'Qt5Core',
+              'Qt5PlatformSupport',
               'qtmain',
               'qwindows',
               'qtfreetype',


### PR DESCRIPTION
And that library does not exist in Qt 5.8+ anymore (see #3564).

The other issue I got when building with Qt 5.9 is already fixed in #3379.