### PR TITLE
Fix remove option in normal groups

### DIFF
--- a/Telegram/SourceFiles/profile/profile_block_group_members.cpp
+++ b/Telegram/SourceFiles/profile/profile_block_group_members.cpp
@@ -406,8 +406,10 @@ void GroupMembersWidget::setItemFlags(Item *item, ChatData *chat) {
 		item->hasRemoveLink = false;
 	} else if (chat->amCreator() || (chat->amAdmin() && !item->hasAdminStar)) {
 		item->hasRemoveLink = true;
+	} else if (chat->invitedByMe.contains(user) && !item->hasAdminStar) {
+		item->hasRemoveLink = true;
 	} else {
-		item->hasRemoveLink = chat->invitedByMe.contains(user);
+		item->hasRemoveLink = false;
 	}
 }
 


### PR DESCRIPTION
If user invites X to group and then X becomes an admin, user won't be able to remove X anymore, so remove option shouldn't be shown.

Currently remove is always shown if X was invited by user.
![image](https://user-images.githubusercontent.com/11808223/27759470-603dcd7c-5e3a-11e7-9f6b-cbb9267b7acf.png)
