### PR TITLE
Menu for picking mute time for specific chat

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -545,6 +545,10 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 "lng_change_phone_code_description" = "We've sent an SMS with a confirmation code to your phone {phone}.";
 "lng_change_phone_success" = "Your phone number has been changed.";
 
+"lng_mute_duration_hours#one" = "For {count} hour";
+"lng_mute_duration_hours#other" = "For {count} hours";
+"lng_mute_box_tip" = "Choose duration of turning off notifications from the following chat";
+
 "lng_preview_loading" = "Getting Link Info...";
 
 "lng_profile_chat_unaccessible" = "Group is inaccessible";

--- a/Telegram/SourceFiles/boxes/boxes.style
+++ b/Telegram/SourceFiles/boxes/boxes.style
@@ -683,3 +683,16 @@ rightsHeaderLabel: FlatLabel(boxLabel) {
 	textFg: windowActiveTextFg;
 }
 rightsUntilMargin: margins(0px, 8px, 0px, 0px);
+
+mutePhotoButton: PeerAvatarButton {
+	size: 40px;
+	photoSize: 40px;
+}
+muteChatTitle: FlatLabel(boxLabel) {
+	width: 235px;
+	maxHeight: 20px;  // block word wrap
+	margin: margins(50px, 0px, 0px, 0px);  // left offset for place peer avatar
+	style: TextStyle(boxTextStyle) {
+		font: font(boxFontSize semibold);
+	}
+}

--- a/Telegram/SourceFiles/boxes/mute_settings_box.cpp
+++ b/Telegram/SourceFiles/boxes/mute_settings_box.cpp
@@ -1,0 +1,64 @@
+/* This file is part of Telegram Desktop, the official desktop version of
+ * Telegram messaging app, see https://desktop.telegram.org
+ *
+ * This code is in Public Domain, see license terms in .github/CONTRIBUTING.md
+ * Copyright (C) 2017, Nicholas Guriev <guriev-ns@ya.ru>
+ */
+
+#include "boxes/mute_settings_box.h"
+
+#include "lang/lang_keys.h"
+#include "mainwidget.h"
+#include "styles/style_boxes.h"
+#include "ui/special_buttons.h"
+#include "ui/widgets/checkbox.h"
+#include "ui/widgets/labels.h"
+
+void MuteSettingsBox::prepare() {
+	setTitle(langFactory(lng_disable_notifications_from_tray));
+	int y = 0;
+
+	object_ptr<Ui::FlatLabel> info(this, st::boxLabel);
+	info->setText(lang(lng_mute_box_tip));
+	info->moveToLeft(st::boxPadding.left(), y);
+	y += info->height() + st::boxLittleSkip;
+
+	object_ptr<Ui::PeerAvatarButton> icon(this, _peer, st::mutePhotoButton);
+	icon->setPointerCursor(false);
+	icon->moveToLeft(st::boxPadding.left(), y);
+
+	object_ptr<Ui::FlatLabel> title(this, st::muteChatTitle);
+	title->setText(App::peerName(_peer, true));
+	title->moveToLeft(st::boxPadding.left(),
+		y + icon->height() / 2 - title->height() / 2);
+	// the icon is always higher than this chat title
+	y += icon->height() + st::boxMediumSkip;
+
+	const int FOREVER = 8760;  // in fact, this is mute only for 1 year
+	auto group = std::make_shared<Ui::RadiobuttonGroup>(FOREVER);
+	y += st::boxOptionListPadding.top();
+	for (int value : { 1, 4, 18, 72, FOREVER }) {  // periods in hours
+		QString text;
+		if (value < 24) {
+			text = lng_mute_duration_hours(lt_count, value);
+		} else if (value < FOREVER) {
+			text = lng_rights_chat_banned_day(lt_count, value / 24);
+		} else {
+			text = lang(lng_rights_chat_banned_forever);
+		}
+		object_ptr<Ui::Radiobutton> option(this, group, value, text);
+		option->moveToLeft(st::boxPadding.left(), y);
+		y += option->heightNoMargins() + st::boxOptionListSkip;
+	}
+	y += st::boxOptionListPadding.bottom() - st::boxOptionListSkip;
+
+	addButton(langFactory(lng_box_ok), [this, group] {
+		App::main()->updateNotifySetting(_peer, NotifySettingSetMuted,
+			SilentNotifiesDontChange, group->value() * 3600);
+		closeBox();
+	});
+	addButton(langFactory(lng_cancel), [this] { closeBox(); });
+
+	setDimensions(st::boxWidth, y);
+}
+// vi: ts=4 tw=80

--- a/Telegram/SourceFiles/boxes/mute_settings_box.h
+++ b/Telegram/SourceFiles/boxes/mute_settings_box.h
@@ -1,0 +1,28 @@
+/* This file is part of Telegram Desktop, the official desktop version of
+ * Telegram messaging app, see https://desktop.telegram.org
+ *
+ * This code is in Public Domain, see license terms in .github/CONTRIBUTING.md
+ * Copyright (C) 2017, Nicholas Guriev <guriev-ns@ya.ru>
+ */
+#pragma once
+
+#include "boxes/abstract_box.h"
+
+/* This class implements a dialog-box with radio-buttons for pick duration of
+ * turning off notifications from a chat. The widget is opened by a context menu
+ * in the left list of dialogues. */
+class MuteSettingsBox : public BoxContent {
+	Q_OBJECT
+
+  public:
+	MuteSettingsBox(QWidget *parent, gsl::not_null<PeerData*> peer)
+	  : _peer(peer) {
+	}
+
+  protected:
+	void prepare() override;
+
+  private:
+	gsl::not_null<PeerData*> _peer;
+};
+// vi: ts=4 tw=80

--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -49,6 +49,7 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 #include "inline_bots/inline_bot_layout_item.h"
 #include "boxes/confirm_box.h"
 #include "boxes/sticker_set_box.h"
+#include "boxes/mute_settings_box.h"
 #include "boxes/contacts_box.h"
 #include "boxes/download_path_box.h"
 #include "storage/localstorage.h"
@@ -2244,9 +2245,16 @@ void MainWidget::fillPeerMenu(PeerData *peer, base::lambda<QAction*(const QStrin
 		Ui::showPeerProfile(peer);
 	});
 	auto muteSubscription = MakeShared<base::Subscription>();
-	auto muteAction = callback(lang(peer->isMuted() ? lng_enable_notifications_from_tray : lng_disable_notifications_from_tray), [peer, muteSubscription] {
-		App::main()->updateNotifySetting(peer, peer->isMuted() ? NotifySettingSetNotify : NotifySettingSetMuted);
-	});
+	QAction *muteAction;
+	if (!peer->isMuted()) {
+		muteAction = callback(lang(lng_disable_notifications_from_tray), [peer] {
+			Ui::show(Box<MuteSettingsBox>(peer));
+		});
+	} else {
+		muteAction = callback(lang(lng_enable_notifications_from_tray), [peer] {
+			App::main()->updateNotifySetting(peer, NotifySettingSetNotify);
+		});
+	}
 	auto muteChangedHandler = Notify::PeerUpdatedHandler(Notify::PeerUpdate::Flag::NotificationsEnabled, [muteAction, peer](const Notify::PeerUpdate &update) {
 		if (update.peer != peer) return;
 		muteAction->setText(lang(peer->isMuted() ? lng_enable_notifications_from_tray : lng_disable_notifications_from_tray));
@@ -4307,11 +4315,10 @@ void MainWidget::applyNotifySetting(const MTPNotifyPeer &peer, const MTPPeerNoti
 	}
 }
 
-void MainWidget::updateNotifySetting(PeerData *peer, NotifySettingStatus notify, SilentNotifiesStatus silent) {
+void MainWidget::updateNotifySetting(PeerData *peer, NotifySettingStatus notify, SilentNotifiesStatus silent, int muteFor) {
 	if (notify == NotifySettingDontChange && silent == SilentNotifiesDontChange) return;
 
 	updateNotifySettingPeers.insert(peer);
-	int32 muteFor = 86400 * 365;
 	if (peer->notify == EmptyNotifySettings) {
 		if (notify == NotifySettingSetMuted || silent == SilentNotifiesSetSilent) {
 			peer->notify = new NotifySettings();

--- a/Telegram/SourceFiles/mainwidget.h
+++ b/Telegram/SourceFiles/mainwidget.h
@@ -175,7 +175,7 @@ public:
 	bool started();
 	void applyNotifySetting(const MTPNotifyPeer &peer, const MTPPeerNotifySettings &settings, History *history = 0);
 
-	void updateNotifySetting(PeerData *peer, NotifySettingStatus notify, SilentNotifiesStatus silent = SilentNotifiesDontChange);
+	void updateNotifySetting(PeerData *peer, NotifySettingStatus notify, SilentNotifiesStatus silent = SilentNotifiesDontChange, int muteFor = 86400 * 365);
 
 	void incrementSticker(DocumentData *sticker);
 

--- a/Telegram/gyp/telegram_sources.txt
+++ b/Telegram/gyp/telegram_sources.txt
@@ -56,6 +56,8 @@
 <(src_loc)/boxes/language_box.h
 <(src_loc)/boxes/local_storage_box.cpp
 <(src_loc)/boxes/local_storage_box.h
+<(src_loc)/boxes/mute_settings_box.cpp
+<(src_loc)/boxes/mute_settings_box.h
 <(src_loc)/boxes/notifications_box.cpp
 <(src_loc)/boxes/notifications_box.h
 <(src_loc)/boxes/peer_list_box.cpp


### PR DESCRIPTION
Now, an user can choose silent time for a specific chat using Telegram Desktop, like on mobile platforms. The pop-up window may be caused by context menu of dialog list, and it is as follows.

![2017-07-19 18-21-42](https://user-images.githubusercontent.com/9163157/28375877-5fb05750-6cb1-11e7-9a1c-26830343b953.png)
