### PR TITLE
Fix IME being interrupted after reconnection

### DIFF
--- a/Telegram/SourceFiles/mainwindow.cpp
+++ b/Telegram/SourceFiles/mainwindow.cpp
@@ -460,6 +460,7 @@ void MainWindow::ui_hideMediaPreview() {
 void MainWindow::showConnecting(const QString &text, const QString &reconnect) {
 	if (_connecting) {
 		_connecting->set(text, reconnect);
+		_connecting->show();
 	} else {
 		_connecting.create(bodyWidget(), text, reconnect);
 		_connecting->show();
@@ -470,7 +471,7 @@ void MainWindow::showConnecting(const QString &text, const QString &reconnect) {
 
 void MainWindow::hideConnecting() {
 	if (_connecting) {
-		_connecting.destroyDelayed();
+		_connecting->hide();
 	}
 }
 


### PR DESCRIPTION
![ime_issue](https://user-images.githubusercontent.com/3953982/30167381-c89e1408-9418-11e7-8535-d913eb069dba.gif)
Notice how the words were duplicated right after the "Connecting..." message disappeared.

I think this bug is somehow related to the deletion of `ConnectingWidget` (or `QWidget`).
I was able to fix it by only hiding it instead.

**Operating system:** Windows 10 x64