### PR TITLE
allow a customized BUILD_DIR in install.bat

### DIFF
--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -5,6 +5,8 @@ SET LIB_DIR=%BUILD_DIR%\Libraries
 SET SRC_DIR=%BUILD_DIR%\tdesktop
 SET QT_VERSION=5_6_2
 
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" x86
+
 call:configureBuild
 call:getDependencies
 call:setupGYP

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -5,7 +5,13 @@ SET LIB_DIR=%BUILD_DIR%\Libraries
 SET SRC_DIR=%BUILD_DIR%\tdesktop
 SET QT_VERSION=5_6_2
 
-call "%VS2017INSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" x86
+if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" (
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" x86
+) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" (
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" (
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+)
 
 call:configureBuild
 call:getDependencies

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -1,11 +1,11 @@
 @echo off
 
-SET BUILD_DIR=C:\TBuild
+IF "%BUILD_DIR%"=="" SET BUILD_DIR=C:\TBuild
 SET LIB_DIR=%BUILD_DIR%\Libraries
 SET SRC_DIR=%BUILD_DIR%\tdesktop
 SET QT_VERSION=5_6_2
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" x86
+call "%VS2017INSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" x86
 
 call:configureBuild
 call:getDependencies
@@ -45,7 +45,7 @@ GOTO:EOF
     git clone https://chromium.googlesource.com/external/gyp
     cd gyp
     git checkout a478c1ab51
-    SET PATH=%PATH%;C:\TBuild\Libraries\gyp;C:\TBuild\Libraries\ninja;
+    SET PATH=%PATH%;%BUILD_DIR%\Libraries\gyp;%BUILD_DIR%\Libraries\ninja;
     cd %SRC_DIR%
     git submodule init
     git submodule update

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -5,14 +5,6 @@ SET LIB_DIR=%BUILD_DIR%\Libraries
 SET SRC_DIR=%BUILD_DIR%\tdesktop
 SET QT_VERSION=5_6_2
 
-if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" (
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" x86
-) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" (
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
-) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" (
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
-)
-
 call:configureBuild
 call:getDependencies
 call:setupGYP


### PR DESCRIPTION
This is a very simple change that allow people to build Telegram like AppVeyor does it, but not in `C:\TBuild` (often C is "System Reserved" and cannot be used). Instead you can build it anywhere (from the visual studio 2017 x86 command prompt) like this:

```
>set BUILD_DIR=%CD%
>git clone https://github.com/telegramdesktop/tdesktop.git
>cd tdesktop
>.\.appveyor\install.bat
>msbuild Telegram\Telegram.sln /property:Configuration=Debug /p:Platform=Win32
```

Some notes:

- I replaced all `C:\TBuild` with `%BUILD_DIR%`, even if it is decided not to merge this, keep that.
- Previously you **needed** VS2017 Professional, `%VS2017INSTALLDIR%` points to the relevant path for your installation so it also works for Community/Enterprise
- `%BUILD_DIR%\Libraries\prepare.bat` might fail to extract the 7z Qt libraries for some reason (even if `7z.exe` is in `PATH`) this has not been fixed

Signed-off-by: Duncan Ogilvie <mr.exodia.tpodt@gmail.com> (github: mrexodia)