### PR TITLE
allow a customized BUILD_DIR in install.bat

### DIFF
--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -1,6 +1,6 @@
 @echo off
 
-SET BUILD_DIR=C:\TBuild
+IF "%BUILD_DIR%"=="" SET BUILD_DIR=C:\TBuild
 SET LIB_DIR=%BUILD_DIR%\Libraries
 SET SRC_DIR=%BUILD_DIR%\tdesktop
 SET QT_VERSION=5_6_2
@@ -45,7 +45,7 @@ GOTO:EOF
     git clone https://chromium.googlesource.com/external/gyp
     cd gyp
     git checkout a478c1ab51
-    SET PATH=%PATH%;C:\TBuild\Libraries\gyp;C:\TBuild\Libraries\ninja;
+    SET PATH=%PATH%;%BUILD_DIR%\Libraries\gyp;%BUILD_DIR%\Libraries\ninja;
     cd %SRC_DIR%
     git submodule init
     git submodule update


### PR DESCRIPTION
This is a very simple change that allow people to build Telegram like AppVeyor does it, but not in C:\TBuild (often C is "System Reserved" and cannot be used). Instead you can build it anywhere (from the visual studio 2017 x86 command prompt) like this:

    >set BUILD_DIR=%CD%
    >git clone https://github.com/telegramdesktop/tdesktop.git
    >cd tdesktop
    >.\.appveyor\install.bat
    >msbuild Telegram\Telegram.sln /property:Configuration=Debug /p:Platform=Win32

Some notes:

- I replaced all C:\TBuild with %BUILD_DIR%, even if it is decided not to merge this, keep that.
- %BUILD_DIR%\Libraries\prepare.bat might fail to extract the 7z Qt libraries for some reason (even if 7z.exe is in PATH) this has not been fixed