### PR TITLE
Prefer AppIndicator if DBus interface is available

### DIFF
--- a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
@@ -20,6 +20,8 @@ Copyright (c) 2014-2017 John Preston, https://desktop.telegram.org
 */
 #include "platform/linux/linux_desktop_environment.h"
 
+#include <QDBusInterface>
+
 namespace Platform {
 namespace DesktopEnvironment {
 namespace {
@@ -120,7 +122,8 @@ bool TryQtTrayIcon() {
 }
 
 bool PreferAppIndicatorTrayIcon() {
-	return IsXFCE() || IsUnity();
+	return IsXFCE() || IsUnity() ||
+	       (IsGnome() && QDBusInterface("org.kde.StatusNotifierWatcher", "/").isValid());
 }
 
 bool TryUnityCounter() {

--- a/Telegram/gyp/qt.gypi
+++ b/Telegram/gyp/qt.gypi
@@ -196,6 +196,7 @@
     '<(qt_loc)/include',
     '<(qt_loc)/include/QtCore',
     '<(qt_loc)/include/QtGui',
+    '<(qt_loc)/include/QtDBus',
     '<(qt_loc)/include/QtCore/<(qt_version)',
     '<(qt_loc)/include/QtGui/<(qt_version)',
     '<(qt_loc)/include/QtCore/<(qt_version)/QtCore',


### PR DESCRIPTION
Starting with Ubuntu 17.10 the interface will be provided by an
extension (shipped by default):

https://github.com/ubuntu/gnome-shell-extension-appindicator

Legacy tray icons have been completely removed in GNOME 3.26. By
checking the interface, this will allow users of other distributions
with GNOME to also use Telegram's indicator with the extension.

I have tested the Qt code snippet (it correctly detects if the extension is enabled), but couldn't test it with Telegram, as setting up the build environment seems to require Ubuntu 12.04 (and I'm running Fedora).

Previous PR: #3928