### PR TITLE
Added Release information to the AppStream file

### DIFF
--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -22,4 +22,13 @@
     <provides>
         <binary>telegram-desktop</binary>
     </provides>
+    <releases>
+        <release version="1.2.3 alpha" date="2017-12-17">
+            <description>
+                <ul>
+                    <li>Several crash fixes</li>
+                </ul>
+            </description>
+        </release>
+    </releases>
 </component>


### PR DESCRIPTION
Added Release information to the AppStream file, pre-populated with release notes from the latest release (1.2.3 alpha).

This brings the following benefits for Telegram developers:
- Greater control over release messaging and communication
- Users get changelogs without downstream packagers having to manually parse your changelog.txt file (which is extra work so they might not do it)
- Software Center apps display version numbers without downstream packagers having to manually find out what it is (which is extra work so they might not do it)

It also requires some work going forward: every new release will require a new `<release>` tag in the AppStream file.

Relevant documentation for this part of the AppStream spec: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description