### PR TITLE
Update building-xcode.md

### DIFF
--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -89,6 +89,7 @@ Go to ***BuildPath*** and run
 
     git clone https://chromium.googlesource.com/external/gyp
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+    export PATH=`pwd`/depot_tools:"$PATH"    
     cd gyp
     git checkout 702ac58e47
     git apply ../../tdesktop/Telegram/Patches/gyp.diff

--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -89,7 +89,7 @@ Go to ***BuildPath*** and run
 
     git clone https://chromium.googlesource.com/external/gyp
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-    export PATH=`pwd`/depot_tools:"$PATH"    
+    export PATH="$PWD/depot_tools:$PATH" 
     cd gyp
     git checkout 702ac58e47
     git apply ../../tdesktop/Telegram/Patches/gyp.diff


### PR DESCRIPTION
Add depot_tools in $PATH, otherwise "crashpad" not compile.