### PR TITLE
Fix build instructions

### DIFF
--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -16,6 +16,11 @@ Go to ***BuildPath*** and run
 
     MACOSX_DEPLOYMENT_TARGET=10.8
 
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    brew install automake fdk-aac git lame libass libtool libvorbis libvpx opus sdl shtool texi2html theora wget x264 xvid yasm automake libtool
+
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
     git clone --recursive https://github.com/telegramdesktop/tdesktop.git
 
     cd Libraries
@@ -64,9 +69,6 @@ Go to ***BuildPath*** and run
     sudo make install
     cd ..
 
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    brew install automake fdk-aac git lame libass libtool libvorbis libvpx opus sdl shtool texi2html theora wget x264 xvid yasm
-
     git clone https://github.com/FFmpeg/FFmpeg.git ffmpeg
     cd ffmpeg
     git checkout release/3.4
@@ -85,7 +87,7 @@ Go to ***BuildPath*** and run
     cmake -D LIBTYPE:STRING=STATIC -D CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.8 ..
     make -j4
     sudo make install
-    cd ..
+    cd ../..
 
     git clone https://chromium.googlesource.com/external/gyp
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
@@ -130,8 +132,8 @@ Go to ***BuildPath*** and run
 
 ### Building the project
 
-Go to ***BuildPath*/tdesktop/Telegram** and run
+Go to ***BuildPath*/tdesktop/Telegram/gyp** and run
 
-    gyp/refresh.sh
+    ./refresh.sh
 
 Then launch Xcode, open ***BuildPath*/tdesktop/Telegram/Telegram.xcodeproj** and build for Debug / Release.

--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -132,7 +132,7 @@ Go to ***BuildPath*** and run
 
 ### Building the project
 
-Go to ***BuildPath*/tdesktop/Telegram/** and run
+Go to ***BuildPath*/tdesktop/Telegram** and run
 
     gyp/refresh.sh
 

--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -132,8 +132,8 @@ Go to ***BuildPath*** and run
 
 ### Building the project
 
-Go to ***BuildPath*/tdesktop/Telegram/gyp** and run
+Go to ***BuildPath*/tdesktop/Telegram/** and run
 
-    ./refresh.sh
+    gyp/refresh.sh
 
 Then launch Xcode, open ***BuildPath*/tdesktop/Telegram/Telegram.xcodeproj** and build for Debug / Release.


### PR DESCRIPTION
Current instructions won't work if followed blindly. Also, there is a fix for xcode-select using the wrong binaries.