### PR TITLE
Let emoji suggestions be case insensitive

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
@@ -401,7 +401,7 @@ QString SuggestionsController::getEmojiQuery() {
 			}
 			position -= from;
 			_queryStartPosition = from;
-			return fragment.text();
+			return fragment.text().toLower();
 		}
 		return QString();
 	};
@@ -412,7 +412,7 @@ QString SuggestionsController::getEmojiQuery() {
 	}
 
 	auto isSuggestionChar = [](QChar ch) {
-		return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || (ch == '_') || (ch == '-') || (ch == '+');
+		return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || (ch == '_') || (ch == '-') || (ch == '+');
 	};
 	auto isGoodCharBeforeSuggestion = [isSuggestionChar](QChar ch) {
 		return !isSuggestionChar(ch) || (ch == 0);


### PR DESCRIPTION
## What?
All this patch does is to allow emojis beeing suggested - even if their names were spelled using uppercase letters.

![telegram_patch](https://user-images.githubusercontent.com/3193006/36353429-adf99508-14c6-11e8-94f0-2966ca8b8f46.gif)

## Why?
As mentioned in #3985 and in #3748 it can happen
that users of a non-US keyboard type the emoji's name
in uppercase letters because the fastest way of typing e.g. `:relaxed:` involves using the
[Shift] key, which can lead (due to fast/bad typing) to writing the first
letters of the emoji's name in capitals. Telegram does currently not come up
with a suggestion at this point and one is forced to correct the first few letters - making
it quite inconvenient.


## Conflicts
This patch should not be in conflict with anything. Also, the emoji names used are case-insensitive. (Meaning that there cannot be a "wrong" suggestion due to this patch)

## Consequences 
This closes #3985 and partially resolves #3748 

## Tests done
Compilation is successful and the suggestion works as expected. (See the GIF in the first paragraph)