### PR TITLE
Fix wrong uname flag used

### DIFF
--- a/Telegram/gyp/linux_glibc_wraps.gyp
+++ b/Telegram/gyp/linux_glibc_wraps.gyp
@@ -14,7 +14,7 @@
     'sources': [
       '../SourceFiles/platform/linux/linux_glibc_wraps.c',
     ],
-    'conditions': [[ '"<!(uname -p)" == "x86_64" or "<!(uname -p)" == "aarch64"', {
+    'conditions': [[ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "aarch64"', {
       'sources': [
         '../SourceFiles/platform/linux/linux_glibc_wraps_64.c',
       ],

--- a/Telegram/gyp/settings_linux.gypi
+++ b/Telegram/gyp/settings_linux.gypi
@@ -25,7 +25,7 @@
         ],
       },
       'conditions': [
-        [ '"<!(uname -p)" == "x86_64" or "<!(uname -p)" == "aarch64"', {
+        [ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "aarch64"', {
           'defines': [
             'Q_OS_LINUX64',
           ],


### PR DESCRIPTION
This is required because uname -p actually returns "unknown" for some hardware. The uname help documents this by stating that -p is non-portable. The -m flag is the one to use.