### PR TITLE
Add option for message formatting (-- to ‏‎−, >> to », << to «) in "Settings" window

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -296,6 +296,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 "lng_settings_section_chat_settings" = "Chat Settings";
 "lng_settings_replace_emojis" = "Replace emoji";
+"lng_settings_message_formatting" = "Message formatting";
 "lng_settings_suggest_by_emoji" = "Suggest popular stickers by emoji";
 "lng_settings_view_emojis" = "View list";
 "lng_settings_send_enter" = "Send by Enter";

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -296,7 +296,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 "lng_settings_section_chat_settings" = "Chat Settings";
 "lng_settings_replace_emojis" = "Replace emoji";
-"lng_settings_message_formatting" = "Message formatting";
+"lng_settings_message_formatting" = "Replace double chars (<<, >>, --)";
 "lng_settings_suggest_by_emoji" = "Suggest popular stickers by emoji";
 "lng_settings_view_emojis" = "View list";
 "lng_settings_send_enter" = "Send by Enter";

--- a/Telegram/SourceFiles/settings.cpp
+++ b/Telegram/SourceFiles/settings.cpp
@@ -41,6 +41,7 @@ int32 gLastUpdateCheck = 0;
 bool gNoStartUpdate = false;
 bool gStartToSettings = false;
 bool gReplaceEmojis = true;
+bool gMessageFormatting = true;
 
 bool gCtrlEnter = false;
 

--- a/Telegram/SourceFiles/settings.h
+++ b/Telegram/SourceFiles/settings.h
@@ -101,6 +101,7 @@ DeclareSetting(int32, LastUpdateCheck);
 DeclareSetting(bool, NoStartUpdate);
 DeclareSetting(bool, StartToSettings);
 DeclareSetting(bool, ReplaceEmojis);
+DeclareSetting(bool, MessageFormatting);
 DeclareReadSetting(bool, ManyInstance);
 
 DeclareSetting(QByteArray, LocalSalt);

--- a/Telegram/SourceFiles/settings/settings_chat_settings_widget.cpp
+++ b/Telegram/SourceFiles/settings/settings_chat_settings_widget.cpp
@@ -141,6 +141,7 @@ void ChatSettingsWidget::createControls() {
 	style::margins slidedPadding(0, marginSub.bottom() / 2, 0, marginSub.bottom() - (marginSub.bottom() / 2));
 
 	createChildRow(_replaceEmoji, marginSmall, lang(lng_settings_replace_emojis), [this](bool) { toggleReplaceEmoji(); }, cReplaceEmojis());
+	createChildRow(_messageFormat, marginSkip, lang(lng_settings_message_formatting), [this](bool) { toggleMessageFormat(); }, cMessageFormatting());
 	createChildRow(_suggestByEmoji, marginSkip, lang(lng_settings_suggest_by_emoji), [this](bool) { toggleSuggestStickersByEmoji(); }, Global::SuggestStickersByEmoji());
 
 #ifndef OS_WIN_STORE
@@ -171,6 +172,11 @@ void ChatSettingsWidget::createControls() {
 
 void ChatSettingsWidget::toggleReplaceEmoji() {
 	cSetReplaceEmojis(_replaceEmoji->checked());
+	Local::writeUserSettings();
+}
+
+void ChatSettingsWidget::toggleMessageFormat() {
+	cSetMessageFormatting(_messageFormat->checked());
 	Local::writeUserSettings();
 }
 

--- a/Telegram/SourceFiles/settings/settings_chat_settings_widget.cpp
+++ b/Telegram/SourceFiles/settings/settings_chat_settings_widget.cpp
@@ -141,7 +141,7 @@ void ChatSettingsWidget::createControls() {
 	style::margins slidedPadding(0, marginSub.bottom() / 2, 0, marginSub.bottom() - (marginSub.bottom() / 2));
 
 	createChildRow(_replaceEmoji, marginSmall, lang(lng_settings_replace_emojis), [this](bool) { toggleReplaceEmoji(); }, cReplaceEmojis());
-	createChildRow(_messageFormat, marginSkip, lang(lng_settings_message_formatting), [this](bool) { toggleMessageFormat(); }, cMessageFormatting());
+	createChildRow(_messageFormat, marginSmall, lang(lng_settings_message_formatting), [this](bool) { toggleMessageFormat(); }, cMessageFormatting());
 	createChildRow(_suggestByEmoji, marginSkip, lang(lng_settings_suggest_by_emoji), [this](bool) { toggleSuggestStickersByEmoji(); }, Global::SuggestStickersByEmoji());
 
 #ifndef OS_WIN_STORE

--- a/Telegram/SourceFiles/settings/settings_chat_settings_widget.h
+++ b/Telegram/SourceFiles/settings/settings_chat_settings_widget.h
@@ -94,9 +94,11 @@ private:
 	void createControls();
 
 	void toggleReplaceEmoji();
+	void toggleMessageFormat();
 	void toggleSuggestStickersByEmoji();
 
 	Ui::Checkbox *_replaceEmoji = nullptr;
+	Ui::Checkbox *_messageFormat = nullptr;
 	Ui::Checkbox *_suggestByEmoji = nullptr;
 	Ui::Checkbox *_dontAskDownloadPath = nullptr;
 

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -543,6 +543,7 @@ enum {
 	dbiDcOptionOld = 0x27,
 	dbiTryIPv6 = 0x28,
 	dbiSongVolume = 0x29,
+	dbiMessageFormatting = 0x2a,
 	dbiWindowsNotificationsOld = 0x30,
 	dbiIncludeMuted = 0x31,
 	dbiMegagroupSizeMax = 0x32,
@@ -1366,6 +1367,14 @@ bool _readSetting(quint32 blockId, QDataStream &stream, int version, ReadSetting
 		cSetReplaceEmojis(v == 1);
 	} break;
 
+	case dbiMessageFormatting: {
+		qint32 v;
+		stream >> v;
+		if (!_checkStreamStatus(stream)) return false;
+
+		cSetMessageFormatting(v == 1);
+	} break;
+
 	case dbiDefaultAttach: {
 		qint32 v;
 		stream >> v;
@@ -1802,6 +1811,7 @@ void _writeUserSettings() {
 	data.stream << quint32(dbiAdaptiveForWide) << qint32(Global::AdaptiveForWide() ? 1 : 0);
 	data.stream << quint32(dbiAutoLock) << qint32(Global::AutoLock());
 	data.stream << quint32(dbiReplaceEmojis) << qint32(cReplaceEmojis() ? 1 : 0);
+	data.stream << quint32(dbiMessageFormatting) << qint32(cMessageFormatting() ? 1 : 0);
 	data.stream << quint32(dbiSoundNotify) << qint32(Global::SoundNotify());
 	data.stream << quint32(dbiIncludeMuted) << qint32(Global::IncludeMuted());
 	data.stream << quint32(dbiDesktopNotify) << qint32(Global::DesktopNotify());

--- a/Telegram/SourceFiles/ui/text/text_entity.cpp
+++ b/Telegram/SourceFiles/ui/text/text_entity.cpp
@@ -2201,9 +2201,11 @@ void PrepareForSending(TextWithEntities &result, int32 flags) {
 		ParseEntities(result, flags);
 	}
 
-	ReplaceStringWithChar(qstr("--"), QChar(8212), result, true);
-	ReplaceStringWithChar(qstr("<<"), QChar(171), result);
-	ReplaceStringWithChar(qstr(">>"), QChar(187), result);
+	if (cMessageFormatting()) {
+		ReplaceStringWithChar(qstr("--"), QChar(8212), result, true);
+		ReplaceStringWithChar(qstr("<<"), QChar(171), result);
+		ReplaceStringWithChar(qstr(">>"), QChar(187), result);
+	}
 
 	if (cReplaceEmojis()) {
 		Ui::Emoji::ReplaceInText(result);


### PR DESCRIPTION
this closes #522  because add an option in settings to disable message formatting, it's enable by default so it's not a problem for people than use it.