### PR TITLE
Don't mess up text I am sending

### DIFF
--- a/Telegram/SourceFiles/ui/text/text_entity.cpp
+++ b/Telegram/SourceFiles/ui/text/text_entity.cpp
@@ -2201,11 +2201,11 @@ void PrepareForSending(TextWithEntities &result, int32 flags) {
 		ParseEntities(result, flags);
 	}
 
-	ReplaceStringWithChar(qstr("--"), QChar(8212), result, true);
-	ReplaceStringWithChar(qstr("<<"), QChar(171), result);
-	ReplaceStringWithChar(qstr(">>"), QChar(187), result);
-
 	if (cReplaceEmojis()) {
+		ReplaceStringWithChar(qstr("--"), QChar(8212), result, true);
+        	ReplaceStringWithChar(qstr("<<"), QChar(171), result);
+        	ReplaceStringWithChar(qstr(">>"), QChar(187), result);
+		
 		Ui::Emoji::ReplaceInText(result);
 	}
 


### PR DESCRIPTION
Emoji replacement is optional so << >> and -- shouldn't be replacing by Unicode characters either! If you must have this feature implemented, please make it configurable.