### PR TITLE
Add caption to first item of album istead of sending separated message.

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -4309,7 +4309,7 @@ void ApiWrap::sendFiles(
 		return list.files.front().mime == qstr("image/webp");
 	};
 	if ((list.files.size() > 1 || isSticker())
-		&& !caption.text.isEmpty()) {
+		&& !caption.text.isEmpty() && !album) {
 		auto message = MessageToSend(options.history);
 		message.textWithTags = std::move(caption);
 		message.replyTo = options.replyTo;
@@ -4344,6 +4344,7 @@ void ApiWrap::sendFiles(
 			to,
 			caption,
 			album));
+		caption = TextWithTags();
 	}
 	if (album) {
 		_sendingAlbums.emplace(album->groupId, album);


### PR DESCRIPTION
Since appeared the albums in Telegram, for some reasons desktop client sends caption before album.
This pull request adds caption to first item of album to see caption under whole album.

What I do:
![image](https://user-images.githubusercontent.com/4051126/41595280-d83b9368-73ce-11e8-9c4c-04328f8f9c8b.png)

What I get now:
![image](https://user-images.githubusercontent.com/4051126/41595310-ff2efcb2-73ce-11e8-8538-4a04b8868ff4.png)

What I get after my patch:
![image](https://user-images.githubusercontent.com/4051126/41595331-11639276-73cf-11e8-9a21-45f80803a90f.png)