### PR TITLE
Show Emoji replacement tooltip on hover

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.h
+++ b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.h
@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "chat_helpers/tabbed_selector.h"
+#include "ui/widgets/tooltip.h"
 
 namespace Window {
 class Controller;
@@ -74,7 +75,7 @@ private:
 
 };
 
-class EmojiListWidget : public TabbedSelector::Inner {
+class EmojiListWidget : public TabbedSelector::Inner, public Ui::AbstractTooltipShower {
 	Q_OBJECT
 
 public:
@@ -88,6 +89,10 @@ public:
 
 	void showEmojiSection(Section section);
 	Section currentSection(int yOffset) const;
+
+	// Ui::AbstractTooltipShower interface.
+	QString tooltipText() const override;
+	QPoint tooltipPos() const override;
 
 public slots:
 	void onShowPicker();


### PR DESCRIPTION
@john-preston 
Hi, this pull request adds a tooltip to the emojis, that shows the replacement text to type in when using the keyboard. This feature was requested by multiple users.
Of course this is entirely disabled, if the user disables "Suggest Emoji Replacements".

I use the `GetAllReplacements()` list to find the replacement text, if you know a better or faster way to get it, I am happy to incorporate that. :)

I hope I followed all your guidelines, if not feel free to point out any changes.

![alt text](https://i.imgur.com/qSxNgAB.png)