### PR TITLE
Switch to Ayatana Indicators

### DIFF
--- a/Telegram/SourceFiles/platform/linux/linux_libs.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_libs.cpp
@@ -234,14 +234,14 @@ void start() {
 	bool gtkLoaded = false;
 	bool indicatorLoaded = false;
 	QLibrary lib_gtk, lib_indicator;
-	if (loadLibrary(lib_indicator, "appindicator3", 1)) {
+	if (loadLibrary(lib_indicator, "ayatana-appindicator3", 1) || loadLibrary(lib_indicator, "appindicator3", 1)) {
 		if (loadLibrary(lib_gtk, "gtk-3", 0)) {
 			gtkLoaded = setupGtkBase(lib_gtk);
 			indicatorLoaded = setupAppIndicator(lib_indicator);
 		}
 	}
 	if (!gtkLoaded || !indicatorLoaded) {
-		if (loadLibrary(lib_indicator, "appindicator", 1)) {
+		if (loadLibrary(lib_indicator, "ayatana-appindicator", 1) || loadLibrary(lib_indicator, "appindicator", 1)) {
 			if (loadLibrary(lib_gtk, "gtk-x11-2.0", 0)) {
 				gtkLoaded = indicatorLoaded = false;
 				gtkLoaded = setupGtkBase(lib_gtk);

--- a/Telegram/SourceFiles/platform/linux/linux_libs.h
+++ b/Telegram/SourceFiles/platform/linux/linux_libs.h
@@ -10,7 +10,11 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #ifndef TDESKTOP_DISABLE_GTK_INTEGRATION
 extern "C" {
 #undef signals
+#ifdef TDESKTOP_USE_AYATANA_INDICATORS
+#include <libayatana-appindicator/app-indicator.h>
+#else
 #include <libappindicator/app-indicator.h>
+#endif
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
 #define signals public

--- a/Telegram/gyp/telegram_linux.gypi
+++ b/Telegram/gyp/telegram_linux.gypi
@@ -96,11 +96,20 @@
         ],
       }], ['not_need_gtk!="True"', {
         'cflags_cc': [
-          '<!(pkg-config 2> /dev/null --cflags appindicator-0.1)',
           '<!(pkg-config 2> /dev/null --cflags gtk+-2.0)',
           '<!(pkg-config 2> /dev/null --cflags glib-2.0)',
           '<!(pkg-config 2> /dev/null --cflags dee-1.0)',
         ],
+      }], ['<!(pkg-config ayatana-appindicator3-0.1; echo $?) == 0', {
+        'cflags_cc': [ '<!(pkg-config --cflags ayatana-appindicator3-0.1)' ],
+        'defines': [ 'TDESKTOP_USE_AYATANA_INDICATORS' ],
+      }], ['<!(pkg-config ayatana-appindicator-0.1; echo $?) == 0', {
+        'cflags_cc': [ '<!(pkg-config --cflags ayatana-appindicator-0.1)' ],
+        'defines': [ 'TDESKTOP_USE_AYATANA_INDICATORS' ],
+      }], ['<!(pkg-config appindicator3-0.1; echo $?) == 0', {
+        'cflags_cc': [ '<!(pkg-config --cflags appindicator3-0.1)' ],
+      }], ['<!(pkg-config appindicator-0.1; echo $?) == 0', {
+        'cflags_cc': [ '<!(pkg-config --cflags appindicator-0.1)' ],
       }]
     ],
   }]],


### PR DESCRIPTION
Ayatana AppIndicator is a fork of Canonical's AppIndicator maintained by Debian community.
More info: https://lists.debian.org/debian-devel/2018/03/msg00506.html