### PR TITLE
Added Snappy as supported system

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The source code is published under GPLv3 with OpenSSL exception, the license is 
 * Mac OS X 10.6 - Mac OS X 10.7 (separate build)
 * Ubuntu 12.04 - Ubuntu 18.04
 * Fedora 22 - Fedora 28
+* [Snappy](https://snapcraft.io/telegram-desktop)
 
 ## Third-party
 


### PR DESCRIPTION
Snaps are universal linux packages so I think we should add this because every system which supports snappy also supports Telegram Desktop