### PR TITLE
snap: fix building and use content-interfaces for assets

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -453,6 +453,7 @@ void RegisterCustomScheme() {
 			s << "Type=Application\n";
 			s << "Categories=Network;InstantMessaging;Qt;\n";
 			s << "MimeType=x-scheme-handler/tg;\n";
+			s << "Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;\n";
 			f.close();
 
 			if (_psRunCommand("desktop-file-install --dir=" + EscapeShell(QFile::encodeName(home + qsl(".local/share/applications"))) + " --delete-original " + EscapeShell(QFile::encodeName(file)))) {

--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -9,3 +9,4 @@ StartupWMClass=TelegramDesktop
 Type=Application
 Categories=Network;InstantMessaging;Qt;
 MimeType=x-scheme-handler/tg;
+Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -106,10 +106,11 @@ parts:
     override-build: |
       set -xe
       snapcraftctl build
+      part_src=$SNAPCRAFT_PART_INSTALL/../src
       snap_gui=$SNAPCRAFT_STAGE/../snap/gui
       mkdir -vp $snap_gui
-      cp -v lib/xdg/telegramdesktop.desktop $snap_gui
-      cp -v Telegram/Resources/art/icon512@2x.png $snap_gui/icon.png
+      cp -v $part_src/lib/xdg/telegramdesktop.desktop $snap_gui
+      cp -v $part_src/Telegram/Resources/art/icon512@2x.png $snap_gui/icon.png
       sed -i "s|^Icon=.*|Icon=\${SNAP}/meta/gui/icon.png|g" $snap_gui/telegramdesktop.desktop
       echo "Keywords=tg;chat;im;messaging;messenger;" >> $snap_gui/telegramdesktop.desktop
     after:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,20 @@ apps:
       - removable-media
       - unity7
 
+plugs:
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/usr/share/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/usr/share/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/usr/share/sounds
+    default-provider: gtk-common-themes
+
 parts:
   telegram:
     plugin: gyp-cmake
@@ -122,10 +136,18 @@ parts:
       - libpulse0
       - libunity9
     after: [desktop-gtk3]
-    stage: [-./usr/share/fonts/**]
+    stage:
+      - -./usr/share/fonts/**
+      - -./usr/share/themes/**
+      - -./usr/share/icons/**
+      - -./usr/share/sounds/**
 
   desktop-gtk3:
-    stage: [-./usr/share/fonts/**]
+    stage:
+      - -./usr/share/fonts/**
+      - -./usr/share/themes/**
+      - -./usr/share/icons/**
+      - -./usr/share/sounds/**
     override-build: |
       set -xe
       snapcraftctl build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -112,7 +112,6 @@ parts:
       cp -v $part_src/lib/xdg/telegramdesktop.desktop $snap_gui
       cp -v $part_src/Telegram/Resources/art/icon512@2x.png $snap_gui/icon.png
       sed -i "s|^Icon=.*|Icon=\${SNAP}/meta/gui/icon.png|g" $snap_gui/telegramdesktop.desktop
-      echo "Keywords=tg;chat;im;messaging;messenger;" >> $snap_gui/telegramdesktop.desktop
     after:
       - breakpad
       - ffmpeg


### PR DESCRIPTION
Reduce the snap size by not providing themes, and fix installation of desktop and icon.

Also, added desktop keywords for all the platforms.