### PR TITLE
Add forgotten include

### DIFF
--- a/Telegram/SourceFiles/base/algorithm.h
+++ b/Telegram/SourceFiles/base/algorithm.h
@@ -7,6 +7,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #pragma once
 
+#include <utility>
+
 namespace base {
 
 template <typename Type>


### PR DESCRIPTION
Without this it can't build. It will only build if you get lucky and the other files are included in the right order and one of them has `utility` included.