### PR TITLE
Fixed display of files with 'audio/' MIME in Shared Media.

### DIFF
--- a/Telegram/SourceFiles/data/data_document.cpp
+++ b/Telegram/SourceFiles/data/data_document.cpp
@@ -1292,7 +1292,13 @@ bool DocumentData::isAudioFile() const {
 	} else if (isSong()) {
 		return true;
 	}
-	return _mimeString.startsWith(qstr("audio/"), Qt::CaseInsensitive);
+	const auto prefix = qstr("audio/");
+	if (!_mimeString.startsWith(prefix, Qt::CaseInsensitive)) {
+		return false;
+	}
+	const auto left = _mimeString.midRef(prefix.size()).toString();
+	const auto types = { qstr("x-wav"), qstr("wav"), qstr("mp4") };
+	return ranges::find(types, left) != end(types);
 }
 
 bool DocumentData::isSharedMediaMusic() const {

--- a/Telegram/SourceFiles/overview/overview_layout.cpp
+++ b/Telegram/SourceFiles/overview/overview_layout.cpp
@@ -888,7 +888,7 @@ Document::Document(
 
 void Document::initDimensions() {
 	_maxw = _st.maxWidth;
-	if (_data->isAudioFile()) {
+	if (_data->isSong()) {
 		_minh = _st.songPadding.top() + _st.songThumbSize + _st.songPadding.bottom();
 	} else {
 		_minh = _st.filePadding.top() + _st.fileThumbSize + _st.filePadding.bottom() + st::lineWidth;
@@ -913,7 +913,7 @@ void Document::paint(Painter &p, const QRect &clip, TextSelection selection, con
 	int32 nameleft = 0, nametop = 0, nameright = 0, statustop = 0, datetop = -1;
 	bool wthumb = withThumb();
 
-	auto isSong = _data->isAudioFile();
+	auto isSong = _data->isSong();
 	if (isSong) {
 		nameleft = _st.songPadding.left() + _st.songThumbSize + _st.songPadding.right();
 		nameright = _st.songPadding.left();
@@ -1063,7 +1063,7 @@ TextState Document::getState(
 	const auto loaded = _data->loaded();
 	const auto wthumb = withThumb();
 
-	if (_data->isAudioFile()) {
+	if (_data->isSong()) {
 		const auto nameleft = _st.songPadding.left() + _st.songThumbSize + _st.songPadding.right();
 		const auto nameright = _st.songPadding.left();
 		const auto namewidth = std::min(
@@ -1173,13 +1173,13 @@ bool Document::dataLoaded() const {
 }
 
 bool Document::iconAnimated() const {
-	return _data->isAudioFile()
+	return _data->isSong()
 		|| !_data->loaded()
 		|| (_radial && _radial->animating());
 }
 
 bool Document::withThumb() const {
-	return !_data->isAudioFile()
+	return !_data->isSong()
 		&& !_data->thumb->isNull()
 		&& _data->thumb->width()
 		&& _data->thumb->height()
@@ -1196,7 +1196,7 @@ bool Document::updateStatusText() {
 	} else if (_data->loading()) {
 		statusSize = _data->loadOffset();
 	} else if (_data->loaded()) {
-		if (_data->isAudioFile()) {
+		if (_data->isSong()) {
 			statusSize = FileStatusSizeLoaded;
 			using State = Media::Player::State;
 			auto state = Media::Player::mixer()->currentState(AudioMsgId::Type::Song);


### PR DESCRIPTION
This PR fixes display of files with "audio/" MIME in Shared Media.
  
`DocumentData::isAudioFile()` checks the MIME, which leads to incorrect display of files involved in the audio.
Ordinary playlist files, such as m3u, are perceived by Telegram as playable files. After click on this file, Telegram tries to play it, but gets fail.
  
As far as I understand, Telegram does not need to check the "audio/" MIME at all, since file type is received from the server; even if the mp3 file is without an extension, it will still play perfectly and will be placed in "Audio files" category.

So, we have to remove `_mimeString.startsWith(qstr("audio/"), Qt::CaseInsensitive);`, but then `isAudioFile()` will return true only in one case, when `isSong()` is true. And we can safely combine `isSong()` and `isAudioFile()` in single method.

If you think these changes should be separated into two pull requests, I will do it.

Despite the fact that many methods are replaced here, this pull request does not break anything, all the displays in the history, dialogs and Shared Media work correctly.


Before patch:
![image](https://user-images.githubusercontent.com/4051126/47860381-725f9380-de01-11e8-80a4-4a3df06818e2.png)

After patch:
![image](https://user-images.githubusercontent.com/4051126/47860638-0df10400-de02-11e8-8dbd-3892b245ca2c.png)
