### PR TITLE
Update OpenAL-Soft

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -40,7 +40,7 @@ FFMPEG_PATH="$BUILD/ffmpeg"
 FFMPEG_CACHE_VERSION="3"
 
 OPENAL_PATH="$BUILD/openal-soft"
-OPENAL_CACHE_VERSION="3"
+OPENAL_CACHE_VERSION="4"
 
 GYP_DEFINES=""
 
@@ -476,6 +476,8 @@ buildOpenAL() {
 
   cd "$EXTERNAL"
   git clone https://github.com/kcat/openal-soft.git
+  cd openal-soft
+  git checkout openal-soft-1.19.1
 
   cd "$EXTERNAL/openal-soft/build"
   cmake \

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -472,7 +472,7 @@ buildOpenAL() {
     rm -rf "$EXTERNAL/openal-soft"
   fi
   cd $OPENAL_PATH
-  rm -rf *
+  sudo rm -rf *
 
   cd "$EXTERNAL"
   git clone https://github.com/kcat/openal-soft.git

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -89,7 +89,7 @@ Go to ***BuildPath*** and run
 
     git clone git://repo.or.cz/openal-soft.git
     cd openal-soft
-    git checkout v1.18
+    git checkout openal-soft-1.19.1
     cd build
     cmake -D LIBTYPE:STRING=STATIC ..
     make $MAKE_THREADS_CNT

--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -89,7 +89,7 @@ Open **x86 Native Tools Command Prompt for VS 2017.bat**, go to ***BuildPath*** 
 
     git clone git://repo.or.cz/openal-soft.git
     cd openal-soft
-    git checkout 18bb46163af
+    git checkout openal-soft-1.19.1
     cd build
     cmake -G "Visual Studio 15 2017" -D LIBTYPE:STRING=STATIC -D FORCE_STATIC_VCRT:STRING=ON ..
     msbuild OpenAL32.vcxproj /property:Configuration=Debug

--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -87,7 +87,9 @@ Go to ***BuildPath*** and run
     cd ..
 
     git clone git://repo.or.cz/openal-soft.git
-    cd openal-soft/build
+    cd openal-soft
+    git checkout openal-soft-1.19.1
+    cd build
     cmake -D LIBTYPE:STRING=STATIC -D CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.8 ..
     make -j4
     sudo make install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,7 +287,7 @@ parts:
   openal:
     source: https://github.com/kcat/openal-soft.git
     source-depth: 1
-    source-branch: v1.18
+    source-branch: v1.19
     plugin: cmake
     build-packages:
       - oss4-dev


### PR DESCRIPTION
#5307 requires OpenAL version 1.19.

This PR bumps the version at all places that I found. I left out old documentation such as `docs/building-xcode-old.md` though.
There is still a missing version bump in https://github.com/telegramdesktop/dependencies_windows (upload 1.19 build of OpenAL), but this should be the only thing missing and I will leave this one to you @john-preston, because it looks like you [patched](https://github.com/telegramdesktop/dependencies_windows/commit/4ff6c54484fc28372d1738162ae517fb056ee6af#diff-84b6d6b47ee0d8fe0a4a2c37f9981d76) it slightly.

After that, #5307 should be working on all platforms.

Note, that the travis build currently follows the HEAD of the openal-soft master branch. I changed it to a stable tag, just like it is already the case in all documentation.