### PR TITLE
Refactored key handler in mediaview.cpp.

### DIFF
--- a/Telegram/SourceFiles/mediaview.cpp
+++ b/Telegram/SourceFiles/mediaview.cpp
@@ -2445,9 +2445,10 @@ void MediaView::paintThemePreview(Painter &p, QRect clip) {
 }
 
 void MediaView::keyPressEvent(QKeyEvent *e) {
+	const auto ctrl = e->modifiers().testFlag(Qt::ControlModifier);
 	if (_clipController) {
-		auto toggle1 = (e->key() == Qt::Key_F && e->modifiers().testFlag(Qt::ControlModifier));
-		auto toggle2 = (e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return) && (e->modifiers().testFlag(Qt::AltModifier) || e->modifiers().testFlag(Qt::ControlModifier));
+		auto toggle1 = (e->key() == Qt::Key_F && ctrl);
+		auto toggle2 = (e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return) && (e->modifiers().testFlag(Qt::AltModifier) || ctrl);
 		if (toggle1 || toggle2) {
 			onVideoToggleFullScreen();
 			return;
@@ -2469,7 +2470,7 @@ void MediaView::keyPressEvent(QKeyEvent *e) {
 		}
 	} else if (e == QKeySequence::Save || e == QKeySequence::SaveAs) {
 		onSaveAs();
-	} else if (e->key() == Qt::Key_Copy || (e->key() == Qt::Key_C && e->modifiers().testFlag(Qt::ControlModifier))) {
+	} else if (e->key() == Qt::Key_Copy || (e->key() == Qt::Key_C && ctrl)) {
 		onCopy();
 	} else if (e->key() == Qt::Key_Enter || e->key() == Qt::Key_Return || e->key() == Qt::Key_Space) {
 		if (_doc && !_doc->loading() && (fileBubbleShown() || !_doc->loaded())) {
@@ -2487,12 +2488,12 @@ void MediaView::keyPressEvent(QKeyEvent *e) {
 			activateControls();
 		}
 		moveToNext(1);
-	} else if (e->modifiers().testFlag(Qt::ControlModifier) && (e->key() == Qt::Key_Plus || e->key() == Qt::Key_Equal || e->key() == ']' || e->key() == Qt::Key_Asterisk || e->key() == Qt::Key_Minus || e->key() == Qt::Key_Underscore || e->key() == Qt::Key_0)) {
+	} else if (ctrl) {
 		if (e->key() == Qt::Key_Plus || e->key() == Qt::Key_Equal || e->key() == Qt::Key_Asterisk || e->key() == ']') {
 			zoomIn();
 		} else if (e->key() == Qt::Key_Minus || e->key() == Qt::Key_Underscore) {
 			zoomOut();
-		} else {
+		} else if (e->key() == Qt::Key_0) {
 			zoomReset();
 		}
 	}


### PR DESCRIPTION
`MediaView::keyPressEvent` method has huge unnecessary condition at the last `} else if ` step. 
It completely repeats all terms of internal conditions and makes the expression more complicated and less readable.
All enumeration of conditions on 2490 line can be safely removed, just leave the `Qt::ControlModifier` check.