### PR TITLE
Fixed editing of the last message on KeyUp.

### DIFF
--- a/Telegram/SourceFiles/history/history.cpp
+++ b/Telegram/SourceFiles/history/history.cpp
@@ -18,6 +18,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "styles/style_dialogs.h"
 #include "data/data_drafts.h"
 #include "data/data_session.h"
+#include "data/data_media_types.h"
 #include "lang/lang_keys.h"
 #include "apiwrap.h"
 #include "mainwidget.h"
@@ -2405,6 +2406,10 @@ HistoryItem *History::lastSentMessage() const {
 	for (const auto &block : base::reversed(blocks)) {
 		for (const auto &message : base::reversed(block->messages)) {
 			const auto item = message->data();
+			// Skip if message is video message or sticker.
+			if (const auto media = item->media()) {
+				if (!media->allowsEditCaption()) continue;
+			}
 			if (IsServerMsgId(item->id)
 				&& !item->serviceMsg()
 				&& (item->out() || peer->isSelf())) {


### PR DESCRIPTION
This small PR fixes an issue that has been around for a long time.
Use case: if the user sends a message, then sends sticker, and then presses the KeyUp, the message editing does not work. The same goes for video-messages and call-messages.

Here's an illustration. Client on the left is before patch, client on the right is after patch.


![2018-11-11_02-56-22](https://user-images.githubusercontent.com/4051126/48307472-6fca1000-e55e-11e8-944a-421ddc67a031.gif)
