### PR TITLE
Fixed skipping message with MediaWebPage on KeyUp.

### DIFF
--- a/Telegram/SourceFiles/history/history.cpp
+++ b/Telegram/SourceFiles/history/history.cpp
@@ -2408,7 +2408,10 @@ HistoryItem *History::lastSentMessage() const {
 			const auto item = message->data();
 			// Skip if message is video message or sticker.
 			if (const auto media = item->media()) {
-				if (!media->allowsEditCaption()) continue;
+				// Skip only if media is not webpage.
+				if (!media->webpage() && !media->allowsEditCaption()) {
+					continue;
+				}
 			}
 			if (IsServerMsgId(item->id)
 				&& !item->serviceMsg()


### PR DESCRIPTION
After my last patch (https://github.com/telegramdesktop/tdesktop/pull/5377) editing message on KeyUp now ignores messages with MediaWebPage.
So, the easiest way to fix this is to add a condition in the same place.
Of course we can add `bool MediaWebPage::allowsEditCaption()` and make it to return `true`, but this leads to the addition of unwanted code to `HistoryWidget::editMessage()`.

Sorry I didn't handle it right away. ¯\\\_(ツ)_/¯

![2018-12-01_20-08-52](https://user-images.githubusercontent.com/4051126/49330941-f646a000-f5a6-11e8-8b57-952c9998dda4.gif)
