### PR TITLE
 Stripping @ in url

### DIFF
--- a/Telegram/SourceFiles/application.cpp
+++ b/Telegram/SourceFiles/application.cpp
@@ -87,6 +87,9 @@ bool InternalPassportLink(const QString &url) {
 			usernameMatch->captured(1),
 			UrlParamNameTransform::ToLower).value(qsl("domain"))
 		: QString();
+	if (!usernameValue.isEmpty() && usernameValue.front()=="@") {
+		usernameValue=usernameValue.mid(1);
+	}
 	const auto authLegacy = (usernameValue == qstr("telegrampassport"));
 	return authMatch->hasMatch() || authLegacy;
 }


### PR DESCRIPTION
#5418 If we copy username it includes '@'. If we add t.me before it to generate link,it would be easy since username doesn't contain '@' there is no problem.