### PR TITLE
Allow UnityCounters for KDE5 resolves #4554

### DIFF
--- a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.cpp
@@ -121,7 +121,7 @@ bool PreferAppIndicatorTrayIcon() {
 }
 
 bool TryUnityCounter() {
-	return IsUnity() || IsPantheon() || IsUbuntu();
+	return IsUnity() || IsPantheon() || IsUbuntu() || IsKDE5();
 }
 
 } // namespace DesktopEnvironment


### PR DESCRIPTION
UnityCounters is supported by KDE5 IconOnlyManager and Latte-dock, but using `env XDG_CURRENT_DESKTOP=Unity` causes some problems. This minimalistic change allows comfortable use Telegram in KDE5