### PR TITLE
Fixed display SendFilesBox via historyAttach button.

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -3066,11 +3066,7 @@ void HistoryWidget::chooseAttach() {
 			auto list = Storage::PrepareMediaList(
 				result.paths,
 				st::sendMediaPreviewSize);
-			if (list.allFilesForCompress || list.albumIsPossible) {
-				confirmSendingFiles(std::move(list), CompressConfirm::Auto);
-			} else if (!showSendingFilesError(list)) {
-				uploadFiles(std::move(list), SendMediaType::File);
-			}
+			confirmSendingFiles(std::move(list), CompressConfirm::Auto);
 		}
 	}));
 }


### PR DESCRIPTION
Sending files via drag and drop and via the attachment button does not work the same way.
If the user drag'n'drops file, the SendFilesBox appears, it works for any type of file, whether it's a photo, a video or document.
If the user opens file via attachment button (or `Ctrl + O`), the SendFilesBox appears only if file is a photo. If file is a document or video, it's uploaded immediately without any boxes.

In the code. 
Method `chooseAttach()` has unnecessary condition that cuts off all non-photo files.
https://github.com/telegramdesktop/tdesktop/blob/0f67f75bed0cc12f354450ffd032e8bdeaa4f15a/Telegram/SourceFiles/history/history_widget.cpp#L3066-L3073

Drag'n'drop method has no this condition and just calls `confirmSendingFiles()`.
https://github.com/telegramdesktop/tdesktop/blob/0f67f75bed0cc12f354450ffd032e8bdeaa4f15a/Telegram/SourceFiles/history/history_widget.cpp#L351-L358


So if we remove unnecessary condition, then everything will work fine with any type of file, whether it's a photo, a video, a document or a combination of them, like a sending files via drag and drop.

This PR only affects local file paths and does not affect the `remoteContent`.