### PR TITLE
 Small refactor of an editing of the last message on KeyUp.

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -5152,16 +5152,16 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 		}
 	} else if (e->key() == Qt::Key_Up) {
 		if (!(e->modifiers() & (Qt::ShiftModifier | Qt::MetaModifier | Qt::ControlModifier))) {
-			const auto item = _history
-				? _history->lastSentMessage()
-				: nullptr;
-			if (item
-				&& item->allowsEdit(unixtime())
-				&& _field->empty()
+			if (_field->empty()
 				&& !_editMsgId
 				&& !_replyToId) {
-				editMessage(item);
-				return;
+				const auto item = _history
+					? _history->lastSentMessage()
+					: nullptr;
+				if (item && item->allowsEdit(unixtime())) {
+					editMessage(item);
+					return;
+				}
 			}
 			_scroll->keyPressEvent(e);
 		} else if ((e->modifiers() & (Qt::ShiftModifier | Qt::MetaModifier | Qt::ControlModifier)) == Qt::ControlModifier) {


### PR DESCRIPTION
This PR just slightly optimizes the way KeyUp editing code works.
At the moment the code works in such a way that the `lastSentMessage()` method is called first, which has within a double `for` loop, and only after loops complete the work, there are other simple checks, such as `_field->empty()`.
So it makes sense to swap these conditions.
Fistly simple checks.
```
if (_field->empty() && !_editMsgId && !_replyToId) {
```
And if it's ok, start looking for the last message through the loops.
```
const auto item = _history ? _history->lastSentMessage() : nullptr;
```


