### PR TITLE
Fixed an editing of own unsupported messages.

### DIFF
--- a/Telegram/SourceFiles/history/history_item.cpp
+++ b/Telegram/SourceFiles/history/history_item.cpp
@@ -63,6 +63,7 @@ not_null<HistoryItem*> CreateUnsupportedMessage(
 	text.entities.push_front(
 		EntityInText(EntityInTextItalic, 0, text.text.size()));
 	flags &= ~MTPDmessage::Flag::f_post_author;
+	flags |= MTPDmessage_ClientFlag::f_is_unsupported;
 	return new HistoryMessage(
 		history,
 		msgId,

--- a/Telegram/SourceFiles/history/history_message.cpp
+++ b/Telegram/SourceFiles/history/history_message.cpp
@@ -603,7 +603,8 @@ bool HistoryMessage::isTooOldForEdit(TimeId now) const {
 bool HistoryMessage::allowsEdit(TimeId now) const {
 	return canStopPoll()
 		&& !isTooOldForEdit(now)
-		&& (!_media || _media->allowsEdit());
+		&& (!_media || _media->allowsEdit())
+		&& !isUnsupportedMessage();
 }
 
 bool HistoryMessage::uploading() const {

--- a/Telegram/SourceFiles/history/history_message.h
+++ b/Telegram/SourceFiles/history/history_message.h
@@ -149,6 +149,9 @@ private:
 		return _flags & MTPDmessage_ClientFlag::f_has_admin_badge;
 	}
 	bool isTooOldForEdit(TimeId now) const;
+	bool isUnsupportedMessage() const {
+		return _flags & MTPDmessage_ClientFlag::f_is_unsupported;
+	}
 
 	// For an invoice button we replace the button text with a "Receipt" key.
 	// It should show the receipt for the payed invoice. Still let mobile apps do that.

--- a/Telegram/SourceFiles/mtproto/type_utils.h
+++ b/Telegram/SourceFiles/mtproto/type_utils.h
@@ -68,8 +68,8 @@ enum class MTPDmessage_ClientFlag : uint32 {
 	// message has an admin badge in supergroup
 	f_has_admin_badge = (1U << 20),
 
-	//// message is not displayed because it is part of a group
-	//f_hidden_by_group = (1U << 19),
+	// message is unsupported by a current version of client
+	f_is_unsupported = (1U << 19),
 
 	// update this when adding new client side flags
 	MIN_FIELD = (1U << 19),


### PR DESCRIPTION
This PR fixes an issue, when a user can edit own unsupported messages (sent from an other client).
Of course after a resending of the edited message user receives `You cannot edit this message` alert. 
I think this is not right that the user has the ability to go into edit mode.

![image](https://user-images.githubusercontent.com/4051126/50425056-726b9500-0880-11e9-9e59-bd23923a5662.png)


In the code.
I think it makes no sense to create a new subclass of unsupported message, just add one bool variable.
As I could see in other classes, it's normal to create a setter, that will be called from only one place. 
For example:

https://github.com/telegramdesktop/tdesktop/blob/e5536880fb9de5a46cc261e1f38c36230ec9f1c4/Telegram/SourceFiles/boxes/peer_list_box.h#L140-L145


I'm not sure that `!_isUnsupportedMessage` condition should be placed in `isTooOldForEdit()` method, so, unfortunately, I had to complicate a little the condition that you have recently simplified (by a moving of some things to `canStopPoll()`) in the `allowsEdit()` method.