### PR TITLE
Add call settings

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -331,6 +331,20 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_bg_tile" = "Tile background";
 "lng_settings_adaptive_wide" = "Adaptive layout for wide screens";
 
+"lng_settings_section_call_settings" = "Calls Settings";
+"lng_settings_call_section_output" = "Speakers and headphones";
+"lng_settings_call_section_input" = "Microphone";
+"lng_settings_call_input_device" = "Input device";
+"lng_settings_call_output_device" = "Output device";
+"lng_settings_call_input_volume" = "Input volume: {percent}%";
+"lng_settings_call_output_volume" = "Output volume: {percent}%";
+"lng_settings_call_test_mic" = "Test microphone";
+"lng_settings_call_stop_mic_test" = "Stop test";
+"lng_settings_call_section_other" = "Other settings";
+"lng_settings_call_open_system_prefs" = "Open system sound preferences";
+"lng_settings_call_device_default" = "Default";
+"lng_settings_call_audio_ducking" = "Mute other sounds during calls";
+
 "lng_settings_language" = "Language";
 "lng_settings_default_scale" = "Default interface scale";
 "lng_settings_connection_type" = "Connection type";
@@ -1871,6 +1885,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 "lng_linux_menu_undo" = "Undo";
 "lng_linux_menu_redo" = "Redo";
+
+"lng_lunux_no_audio_prefs" = "You don't have any audio configuration applications installed.";
 
 // Mac specific
 

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1886,7 +1886,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_linux_menu_undo" = "Undo";
 "lng_linux_menu_redo" = "Redo";
 
-"lng_lunux_no_audio_prefs" = "You don't have any audio configuration applications installed.";
+"lng_linux_no_audio_prefs" = "You don't have any audio configuration applications installed.";
 
 // Mac specific
 

--- a/Telegram/SourceFiles/boxes/single_choice_box.cpp
+++ b/Telegram/SourceFiles/boxes/single_choice_box.cpp
@@ -17,7 +17,7 @@ void SingleChoiceBox::prepare() {
 	setTitle(langFactory(_title));
 
 	addButton(langFactory(lng_box_ok), [this] { closeBox(); });
-	
+
 	auto group = std::make_shared<Ui::RadiobuttonGroup>(_initialSelection);
 	auto y = st::boxOptionListPadding.top() + st::autolockButton.margin.top();
 	auto count = int(_optionTexts.size());

--- a/Telegram/SourceFiles/boxes/single_choice_box.cpp
+++ b/Telegram/SourceFiles/boxes/single_choice_box.cpp
@@ -22,8 +22,8 @@ void SingleChoiceBox::prepare() {
 	auto y = st::boxOptionListPadding.top() + st::autolockButton.margin.top();
 	auto count = int(_optionTexts.size());
 	_options.reserve(count);
-	int i=0;
-	for (auto text : _optionTexts) {
+	auto i = 0;
+	for (const auto &text : _optionTexts) {
 		_options.emplace_back(this, group, i, text, st::autolockButton);
 		_options.back()->moveToLeft(st::boxPadding.left() + st::boxOptionListPadding.left(), y);
 		y += _options.back()->heightNoMargins() + st::boxOptionListSkip;
@@ -36,3 +36,4 @@ void SingleChoiceBox::prepare() {
 
 	setDimensions(st::autolockWidth, st::boxOptionListPadding.top() + count * _options.back()->heightNoMargins() + (count - 1) * st::boxOptionListSkip + st::boxOptionListPadding.bottom() + st::boxPadding.bottom());
 }
+

--- a/Telegram/SourceFiles/boxes/single_choice_box.cpp
+++ b/Telegram/SourceFiles/boxes/single_choice_box.cpp
@@ -1,0 +1,38 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "boxes/single_choice_box.h"
+
+#include "lang/lang_keys.h"
+#include "storage/localstorage.h"
+#include "mainwindow.h"
+#include "ui/widgets/checkbox.h"
+#include "styles/style_boxes.h"
+
+void SingleChoiceBox::prepare() {
+	setTitle(langFactory(_title));
+
+	addButton(langFactory(lng_box_ok), [this] { closeBox(); });
+	
+	auto group = std::make_shared<Ui::RadiobuttonGroup>(_initialSelection);
+	auto y = st::boxOptionListPadding.top() + st::autolockButton.margin.top();
+	auto count = int(_optionTexts.size());
+	_options.reserve(count);
+	int i=0;
+	for (auto text : _optionTexts) {
+		_options.emplace_back(this, group, i, text, st::autolockButton);
+		_options.back()->moveToLeft(st::boxPadding.left() + st::boxOptionListPadding.left(), y);
+		y += _options.back()->heightNoMargins() + st::boxOptionListSkip;
+		i++;
+	}
+	group->setChangedCallback([this](int value) {
+		_callback(value);
+		closeBox();
+	});
+
+	setDimensions(st::autolockWidth, st::boxOptionListPadding.top() + count * _options.back()->heightNoMargins() + (count - 1) * st::boxOptionListSkip + st::boxOptionListPadding.bottom() + st::boxPadding.bottom());
+}

--- a/Telegram/SourceFiles/boxes/single_choice_box.h
+++ b/Telegram/SourceFiles/boxes/single_choice_box.h
@@ -1,0 +1,34 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include "boxes/abstract_box.h"
+#include <vector>
+
+enum LangKey : int;
+
+namespace Ui {
+class Radiobutton;
+} // namespace Ui
+
+class SingleChoiceBox : public BoxContent {
+public:
+	SingleChoiceBox(QWidget*, LangKey title, std::vector<QString> optionTexts, int initialSelection, Fn<void(int)> callback) : _title(title), _optionTexts(optionTexts), _initialSelection(initialSelection), _callback(callback) {
+	}
+
+protected:
+	void prepare() override;
+
+private:
+	LangKey _title;
+	std::vector<QString> _optionTexts;
+	int _initialSelection;
+	Fn<void(int)> _callback;
+	std::vector<object_ptr<Ui::Radiobutton>> _options;
+
+};

--- a/Telegram/SourceFiles/boxes/single_choice_box.h
+++ b/Telegram/SourceFiles/boxes/single_choice_box.h
@@ -27,8 +27,9 @@ protected:
 private:
 	LangKey _title;
 	std::vector<QString> _optionTexts;
-	int _initialSelection;
+	int _initialSelection = 0;
 	Fn<void(int)> _callback;
 	std::vector<object_ptr<Ui::Radiobutton>> _options;
 
 };
+

--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++ b/Telegram/SourceFiles/calls/calls_call.cpp
@@ -539,6 +539,7 @@ void Call::createAndStartController(const MTPDphoneCall &call) {
 #endif // Q_OS_MAC
 	config.enableNS = true;
 	config.enableAGC = true;
+	config.enableVolumeControl = true;
 	config.initTimeout = Global::CallConnectTimeoutMs() / 1000;
 	config.recvTimeout = Global::CallPacketTimeoutMs() / 1000;
 	if (Logs::DebugEnabled()) {
@@ -587,6 +588,13 @@ void Call::createAndStartController(const MTPDphoneCall &call) {
 		call.is_p2p_allowed(),
 		protocol.vmax_layer.v);
 	_controller->SetConfig(config);
+	_controller->SetCurrentAudioOutput(Global::CallOutputDeviceID().toStdString());
+	_controller->SetCurrentAudioInput(Global::CallInputDeviceID().toStdString());
+	_controller->SetOutputVolume(Global::CallOutputVolume()/100.0f);
+	_controller->SetInputVolume(Global::CallInputVolume()/100.0f);
+#ifdef Q_OS_MAC
+	_controller->SetAudioOutputDuckingEnabled(Global::CallAudioDuckingEnabled());
+#endif
 	_controller->SetEncryptionKey(reinterpret_cast<char*>(_authKey.data()), (_type == Type::Outgoing));
 	_controller->SetCallbacks(callbacks);
 	if (Global::UseProxyForCalls()
@@ -750,6 +758,32 @@ void Call::setState(State state) {
 		}
 	}
 }
+	
+void Call::setCurrentAudioDevice(bool input, std::string deviceID){
+	if(_controller){
+		if(input)
+			_controller->SetCurrentAudioInput(deviceID);
+		else
+			_controller->SetCurrentAudioOutput(deviceID);
+	}
+}
+
+void Call::setAudioVolume(bool input, float level){
+	if(_controller){
+		if(input)
+			_controller->SetInputVolume(level);
+		else
+			_controller->SetOutputVolume(level);
+	}
+}
+
+void Call::setAudioDuckingEnabled(bool enabled){
+#ifdef Q_OS_MAC
+	if(_controller){
+		_controller->SetAudioOutputDuckingEnabled(enabled);
+	}
+#endif
+}
 
 void Call::finish(FinishType type, const MTPPhoneCallDiscardReason &reason) {
 	Expects(type != FinishType::None);
@@ -844,7 +878,7 @@ Call::~Call() {
 	destroyController();
 }
 
-void UpdateConfig(const std::map<std::string, std::string> &data) {
+void UpdateConfig(const std::string& data) {
 	tgvoip::ServerConfig::GetSharedInstance()->Update(data);
 }
 

--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++ b/Telegram/SourceFiles/calls/calls_call.cpp
@@ -758,7 +758,7 @@ void Call::setState(State state) {
 		}
 	}
 }
-	
+
 void Call::setCurrentAudioDevice(bool input, std::string deviceID){
 	if (_controller) {
 		if (input) {

--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++ b/Telegram/SourceFiles/calls/calls_call.cpp
@@ -760,26 +760,28 @@ void Call::setState(State state) {
 }
 	
 void Call::setCurrentAudioDevice(bool input, std::string deviceID){
-	if(_controller){
-		if(input)
+	if (_controller) {
+		if (input) {
 			_controller->SetCurrentAudioInput(deviceID);
-		else
+		} else {
 			_controller->SetCurrentAudioOutput(deviceID);
+		}
 	}
 }
 
 void Call::setAudioVolume(bool input, float level){
-	if(_controller){
-		if(input)
+	if (_controller) {
+		if(input) {
 			_controller->SetInputVolume(level);
-		else
+		} else {
 			_controller->SetOutputVolume(level);
+		}
 	}
 }
 
 void Call::setAudioDuckingEnabled(bool enabled){
 #ifdef Q_OS_MAC
-	if(_controller){
+	if (_controller) {
 		_controller->SetAudioOutputDuckingEnabled(enabled);
 	}
 #endif

--- a/Telegram/SourceFiles/calls/calls_call.h
+++ b/Telegram/SourceFiles/calls/calls_call.h
@@ -121,6 +121,10 @@ public:
 	bytes::vector getKeyShaForFingerprint() const;
 
 	QString getDebugLog() const;
+	
+	void setCurrentAudioDevice(bool input, std::string deviceID);
+	void setAudioVolume(bool input, float level);
+	void setAudioDuckingEnabled(bool enabled);
 
 	~Call();
 
@@ -211,6 +215,6 @@ private:
 
 };
 
-void UpdateConfig(const std::map<std::string, std::string> &data);
+void UpdateConfig(const std::string& data);
 
 } // namespace Calls

--- a/Telegram/SourceFiles/calls/calls_instance.cpp
+++ b/Telegram/SourceFiles/calls/calls_instance.cpp
@@ -189,7 +189,8 @@ void Instance::refreshServerConfig() {
 		_serverConfigRequestId = 0;
 		_lastServerConfigUpdateTime = getms(true);
 
-		UpdateConfig(std::string(result.c_dataJSON().vdata.v));
+		const auto &json = result.c_dataJSON().vdata.v;
+		UpdateConfig(std::string(json.data(), json.size()));
 	}).fail([this](const RPCError &error) {
 		_serverConfigRequestId = 0;
 	}).send();

--- a/Telegram/SourceFiles/calls/calls_instance.cpp
+++ b/Telegram/SourceFiles/calls/calls_instance.cpp
@@ -243,7 +243,7 @@ bool Instance::alreadyInCall() {
 	return (_currentCall && _currentCall->state() != Call::State::Busy);
 }
 
-Call* Instance::currentCall(){
+Call *Instance::currentCall() {
 	return _currentCall.get();
 }
 

--- a/Telegram/SourceFiles/calls/calls_instance.cpp
+++ b/Telegram/SourceFiles/calls/calls_instance.cpp
@@ -189,53 +189,7 @@ void Instance::refreshServerConfig() {
 		_serverConfigRequestId = 0;
 		_lastServerConfigUpdateTime = getms(true);
 
-		auto configUpdate = std::map<std::string, std::string>();
-		auto bytes = bytes::make_span(result.c_dataJSON().vdata.v);
-		auto error = QJsonParseError { 0, QJsonParseError::NoError };
-		auto document = QJsonDocument::fromJson(QByteArray::fromRawData(reinterpret_cast<const char*>(bytes.data()), bytes.size()), &error);
-		if (error.error != QJsonParseError::NoError) {
-			LOG(("API Error: Failed to parse call config JSON, error: %1").arg(error.errorString()));
-			return;
-		} else if (!document.isObject()) {
-			LOG(("API Error: Not an object received in call config JSON."));
-			return;
-		}
-
-		auto parseValue = [](QJsonValueRef data) -> std::string {
-			switch (data.type()) {
-			case QJsonValue::String: return data.toString().toStdString();
-			case QJsonValue::Double: return QString::number(data.toDouble(), 'f').toStdString();
-			case QJsonValue::Bool: return data.toBool() ? "true" : "false";
-			case QJsonValue::Null: {
-				LOG(("API Warning: null field in call config JSON."));
-			} return "null";
-			case QJsonValue::Undefined: {
-				LOG(("API Warning: undefined field in call config JSON."));
-			} return "undefined";
-			case QJsonValue::Object:
-			case QJsonValue::Array: {
-				LOG(("API Warning: complex field in call config JSON."));
-				QJsonDocument serializer;
-				if (data.isArray()) {
-					serializer.setArray(data.toArray());
-				} else {
-					serializer.setObject(data.toObject());
-				}
-				auto byteArray = serializer.toJson(QJsonDocument::Compact);
-				return std::string(byteArray.constData(), byteArray.size());
-			} break;
-			}
-			Unexpected("Type in Json parse.");
-		};
-
-		auto object = document.object();
-		for (auto i = object.begin(), e = object.end(); i != e; ++i) {
-			auto key = i.key().toStdString();
-			auto value = parseValue(i.value());
-			configUpdate[key] = value;
-		}
-
-		UpdateConfig(configUpdate);
+		UpdateConfig(std::string(result.c_dataJSON().vdata.v));
 	}).fail([this](const RPCError &error) {
 		_serverConfigRequestId = 0;
 	}).send();
@@ -287,6 +241,10 @@ void Instance::handleCallUpdate(const MTPPhoneCall &call) {
 
 bool Instance::alreadyInCall() {
 	return (_currentCall && _currentCall->state() != Call::State::Busy);
+}
+
+Call* Instance::currentCall(){
+	return _currentCall.get();
 }
 
 void Instance::requestMicrophonePermissionOrFail(Fn<void()> onSuccess) {

--- a/Telegram/SourceFiles/calls/calls_instance.h
+++ b/Telegram/SourceFiles/calls/calls_instance.h
@@ -27,6 +27,7 @@ public:
 	void startOutgoingCall(not_null<UserData*> user);
 	void handleUpdate(const MTPDupdatePhoneCall &update);
 	void showInfoPanel(not_null<Call*> call);
+	Call* currentCall();
 
 	base::Observable<Call*> &currentCallChanged() {
 		return _currentCallChanged;

--- a/Telegram/SourceFiles/facades.cpp
+++ b/Telegram/SourceFiles/facades.cpp
@@ -661,6 +661,11 @@ struct Data {
 	base::Observable<void> UnreadCounterUpdate;
 	base::Observable<void> PeerChooseCancel;
 
+	QString CallOutputDeviceID = qsl("default");
+	QString CallInputDeviceID = qsl("default");
+	int CallOutputVolume = 100;
+	int CallInputVolume = 100;
+	bool CallAudioDuckingEnabled = true;
 };
 
 } // namespace internal
@@ -789,6 +794,12 @@ DefineRefVar(Global, base::Variable<DBIWorkMode>, WorkMode);
 
 DefineRefVar(Global, base::Observable<void>, UnreadCounterUpdate);
 DefineRefVar(Global, base::Observable<void>, PeerChooseCancel);
+	
+DefineVar(Global, QString, CallOutputDeviceID);
+DefineVar(Global, QString, CallInputDeviceID);
+DefineVar(Global, int, CallOutputVolume);
+DefineVar(Global, int, CallInputVolume);
+DefineVar(Global, bool, CallAudioDuckingEnabled);
 
 rpl::producer<bool> ReplaceEmojiValue() {
 	return rpl::single(

--- a/Telegram/SourceFiles/facades.h
+++ b/Telegram/SourceFiles/facades.h
@@ -323,6 +323,12 @@ DeclareRefVar(base::Variable<DBIWorkMode>, WorkMode);
 
 DeclareRefVar(base::Observable<void>, UnreadCounterUpdate);
 DeclareRefVar(base::Observable<void>, PeerChooseCancel);
+	
+DeclareVar(QString, CallOutputDeviceID);
+DeclareVar(QString, CallInputDeviceID);
+DeclareVar(int, CallOutputVolume);
+DeclareVar(int, CallInputVolume);
+DeclareVar(bool, CallAudioDuckingEnabled);
 
 rpl::producer<bool> ReplaceEmojiValue();
 

--- a/Telegram/SourceFiles/info/info_top_bar.cpp
+++ b/Telegram/SourceFiles/info/info_top_bar.cpp
@@ -611,6 +611,8 @@ rpl::producer<QString> TitleValue(
 				return lng_settings_advanced;
 			case Section::SettingsType::Chat:
 				return lng_settings_section_chat_settings;
+			case Section::SettingsType::Calls:
+				return lng_settings_section_call_settings;
 			}
 			Unexpected("Bad settings type in Info::TitleValue()");
 		}

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -489,23 +489,23 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
 void OpenSystemSettingsForPermission(PermissionType type) {
 }
 
-bool OpenSystemSettings(SystemSettingsType type){
-	if(type==SystemSettingsType::Audio){
+bool OpenSystemSettings(SystemSettingsType type) {
+	if (type == SystemSettingsType::Audio) {
 		bool succeeded = false;
-		if(DesktopEnvironment::IsUnity()){
+		if (DesktopEnvironment::IsUnity()) {
 			succeeded |= QProcess::startDetached(qsl("unity-control-center sound"));
-		}else if(DesktopEnvironment::IsKDE()){
+		} else if (DesktopEnvironment::IsKDE()) {
 			succeeded |= QProcess::startDetached(qsl("kcmshell5 kcm_pulseaudio"));
-			if(!succeeded){
+			if (!succeeded) {
 				succeeded |= QProcess::startDetached(qsl("kcmshell4 phonon"));
 			}
-		}else if(DesktopEnvironment::IsGnome()){
+		} else if (DesktopEnvironment::IsGnome()) {
 			succeeded |= QProcess::startDetached(qsl("gnome-control-center sound"));
 		}
-		if(!succeeded){
+		if (!succeeded) {
 			succeeded |= QProcess::startDetached(qsl("pavucontrol"));
 		}
-		if(!succeeded){
+		if (!succeeded) {
 			succeeded |= QProcess::startDetached(qsl("alsamixergui"));
 		}
 		return succeeded;

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "application.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
+#include "platform/linux/linux_desktop_environment.h"
 #include "platform/linux/file_utilities_linux.h"
 #include "platform/platform_notifications_manager.h"
 #include "storage/localstorage.h"
@@ -486,6 +487,30 @@ void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCal
 }
 
 void OpenSystemSettingsForPermission(PermissionType type) {
+}
+
+bool OpenSystemSettings(SystemSettingsType type){
+	if(type==SystemSettingsType::Audio){
+		bool succeeded = false;
+		if(DesktopEnvironment::IsUnity()){
+			succeeded |= QProcess::startDetached(qsl("unity-control-center sound"));
+		}else if(DesktopEnvironment::IsKDE()){
+			succeeded |= QProcess::startDetached(qsl("kcmshell5 kcm_pulseaudio"));
+			if(!succeeded){
+				succeeded |= QProcess::startDetached(qsl("kcmshell4 phonon"));
+			}
+		}else if(DesktopEnvironment::IsGnome()){
+			succeeded |= QProcess::startDetached(qsl("gnome-control-center sound"));
+		}
+		if(!succeeded){
+			succeeded |= QProcess::startDetached(qsl("pavucontrol"));
+		}
+		if(!succeeded){
+			succeeded |= QProcess::startDetached(qsl("alsamixergui"));
+		}
+		return succeeded;
+	}
+	return true;
 }
 
 namespace ThirdParty {

--- a/Telegram/SourceFiles/platform/mac/specific_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/specific_mac.mm
@@ -332,6 +332,15 @@ void OpenSystemSettingsForPermission(PermissionType type) {
 #endif // OS_MAC_OLD
 }
 
+bool OpenSystemSettings(SystemSettingsType type) {
+	switch(type){
+		case SystemSettingsType::Audio:
+			[[NSWorkspace sharedWorkspace] openFile:@"/System/Library/PreferencePanes/Sound.prefPane"];
+			break;
+	}
+	return true;
+}
+
 } // namespace Platform
 
 void psNewVersion() {

--- a/Telegram/SourceFiles/platform/mac/specific_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/specific_mac.mm
@@ -333,7 +333,7 @@ void OpenSystemSettingsForPermission(PermissionType type) {
 }
 
 bool OpenSystemSettings(SystemSettingsType type) {
-	switch(type){
+	switch (type) {
 		case SystemSettingsType::Audio:
 			[[NSWorkspace sharedWorkspace] openFile:@"/System/Library/PreferencePanes/Sound.prefPane"];
 			break;

--- a/Telegram/SourceFiles/platform/platform_specific.h
+++ b/Telegram/SourceFiles/platform/platform_specific.h
@@ -22,6 +22,10 @@ enum class PermissionType {
 	Microphone,
 };
 
+enum class SystemSettingsType {
+	Audio,
+};
+
 void SetWatchingMediaKeys(bool watching);
 bool IsApplicationActive();
 void SetApplicationIcon(const QIcon &icon);
@@ -34,6 +38,7 @@ void RegisterCustomScheme();
 PermissionStatus GetPermissionStatus(PermissionType type);
 void RequestPermission(PermissionType type, Fn<void(PermissionStatus)> resultCallback);
 void OpenSystemSettingsForPermission(PermissionType type);
+bool OpenSystemSettings(SystemSettingsType type);
 
 QString SystemLanguage();
 QString SystemCountry();

--- a/Telegram/SourceFiles/platform/win/specific_win.cpp
+++ b/Telegram/SourceFiles/platform/win/specific_win.cpp
@@ -657,6 +657,13 @@ void OpenSystemSettingsForPermission(PermissionType type) {
 	}
 }
 
+bool OpenSystemSettings(SystemSettingsType type){
+	if(type==SystemSettingsType::Audio){
+		WinExec("control.exe mmsys.cpl", SW_SHOW);
+	}
+	return true;
+}
+
 } // namespace Platform
 
 void psNewVersion() {

--- a/Telegram/SourceFiles/platform/win/specific_win.cpp
+++ b/Telegram/SourceFiles/platform/win/specific_win.cpp
@@ -657,8 +657,8 @@ void OpenSystemSettingsForPermission(PermissionType type) {
 	}
 }
 
-bool OpenSystemSettings(SystemSettingsType type){
-	if(type==SystemSettingsType::Audio){
+bool OpenSystemSettings(SystemSettingsType type) {
+	if (type == SystemSettingsType::Audio) {
 		WinExec("control.exe mmsys.cpl", SW_SHOW);
 	}
 	return true;

--- a/Telegram/SourceFiles/settings/settings.style
+++ b/Telegram/SourceFiles/settings/settings.style
@@ -59,6 +59,7 @@ settingsIconInterfaceScale: icon {{ "settings_interface_scale", menuIconFg }};
 settingsIconFaq: icon {{ "settings_faq", menuIconFg }};
 settingsIconStickers: icon {{ "settings_stickers", menuIconFg }};
 settingsIconThemes: icon {{ "settings_themes", menuIconFg }};
+settingsIconCalls: icon {{ "settings_phone_number", menuIconFg }};
 
 settingsSetPhotoSkip: 7px;
 
@@ -191,3 +192,13 @@ settingsThemeMinSkip: 4px;
 autoDownloadLimitButton: InfoProfileButton(settingsButton) {
 	padding: margins(22px, 10px, 22px, 0px);
 }
+settingsAudioVolumeSlider: MediaSlider(defaultContinuousSlider) {
+    seekSize: size(15px, 15px);
+}
+settingsAudioVolumeSliderPadding: margins(23px, 5px, 20px, 10px);
+settingsAudioVolumeLabel: LabelSimple(defaultLabelSimple){
+    font: boxTextFont;
+    textFg: windowBoldFg;
+}
+settingsAudioVolumeLabelPadding: margins(22px, 11px, 22px, 11px);
+settingsLevelMeterPadding: margins(23px, 10px, 20px, 10px);

--- a/Telegram/SourceFiles/settings/settings.style
+++ b/Telegram/SourceFiles/settings/settings.style
@@ -196,7 +196,7 @@ settingsAudioVolumeSlider: MediaSlider(defaultContinuousSlider) {
     seekSize: size(15px, 15px);
 }
 settingsAudioVolumeSliderPadding: margins(23px, 5px, 20px, 10px);
-settingsAudioVolumeLabel: LabelSimple(defaultLabelSimple){
+settingsAudioVolumeLabel: LabelSimple(defaultLabelSimple) {
     font: boxTextFont;
     textFg: windowBoldFg;
 }

--- a/Telegram/SourceFiles/settings/settings_calls.cpp
+++ b/Telegram/SourceFiles/settings/settings_calls.cpp
@@ -1,0 +1,310 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "settings/settings_calls.h"
+
+#include "settings/settings_common.h"
+#include "ui/wrap/vertical_layout.h"
+#include "ui/wrap/slide_wrap.h"
+#include "ui/widgets/labels.h"
+#include "ui/widgets/checkbox.h"
+#include "ui/widgets/level_meter.h"
+#include "info/profile/info_profile_button.h"
+#include "boxes/single_choice_box.h"
+#include "boxes/confirm_box.h"
+#include "platform/platform_specific.h"
+#include "lang/lang_keys.h"
+#include "storage/localstorage.h"
+#include "layout.h"
+#include "styles/style_settings.h"
+#include "ui/widgets/continuous_sliders.h"
+#include "calls/calls_instance.h"
+
+#ifdef slots
+#undef slots
+#define NEED_TO_RESTORE_SLOTS
+#endif // slots
+
+#include <VoIPController.h>
+
+#ifdef NEED_TO_RESTORE_SLOTS
+#define slots Q_SLOTS
+#undef NEED_TO_RESTORE_SLOTS
+#endif // NEED_TO_RESTORE_SLOTS
+
+namespace Settings {
+
+Calls::Calls(QWidget *parent, UserData *self)
+: Section(parent) {
+	setupContent();
+}
+	
+Calls::~Calls(){
+	if(needWriteSettings){
+    	Local::writeUserSettings();
+	}
+}
+
+void Calls::sectionSaveChanges(FnMut<void()> done){
+	if(micTester){
+		micTester.reset();
+	}
+	done();
+}
+
+void Calls::setupContent() {
+	const auto content = Ui::CreateChild<Ui::VerticalLayout>(this);
+
+	QString currentOutputName;
+	if(Global::CallOutputDeviceID()==qsl("default")){
+		currentOutputName=lang(lng_settings_call_device_default);
+	}else{
+    	std::vector<tgvoip::AudioOutputDevice> outputDevices=tgvoip::VoIPController::EnumerateAudioOutputs();
+		currentOutputName=Global::CallOutputDeviceID();
+    	for(tgvoip::AudioOutputDevice& dev:outputDevices){
+    		if(QString::fromUtf8(dev.id.c_str())==Global::CallOutputDeviceID()){
+    			currentOutputName=QString::fromUtf8(dev.displayName.c_str());
+    			break;
+    		}
+    	}
+	}
+	
+	QString currentInputName;
+	if(Global::CallInputDeviceID()==qsl("default")){
+		currentInputName=lang(lng_settings_call_device_default);
+	}else{
+		std::vector<tgvoip::AudioInputDevice> inputDevices=tgvoip::VoIPController::EnumerateAudioInputs();
+		currentInputName=Global::CallInputDeviceID();
+		for(tgvoip::AudioInputDevice& dev:inputDevices){
+			if(QString::fromUtf8(dev.id.c_str())==Global::CallInputDeviceID()){
+				currentInputName=QString::fromUtf8(dev.displayName.c_str());
+				break;
+			}
+		}
+	}
+	
+	AddSkip(content);
+	AddSubsectionTitle(content, lng_settings_call_section_output);
+	const auto outputButton = AddButtonWithLabel(
+		   content,
+		   lng_settings_call_output_device,
+		   rpl::single(currentOutputName) | rpl::then(outputNameStream.events()),
+		   st::settingsButton);
+	outputButton->addClickHandler([this] {
+		int selectedOption=0;
+		std::vector<tgvoip::AudioOutputDevice> devices=tgvoip::VoIPController::EnumerateAudioOutputs();
+		std::vector<QString> options;
+		options.push_back(lang(lng_settings_call_device_default));
+		int i=1;
+		for(tgvoip::AudioOutputDevice& device:devices){
+			QString displayName=QString::fromUtf8(device.displayName.c_str());
+			options.push_back(displayName);
+			if(QString::fromUtf8(device.id.c_str())==Global::CallOutputDeviceID())
+				selectedOption=i;
+			i++;
+		}
+		Ui::show(Box<SingleChoiceBox>(lng_settings_call_output_device, options, selectedOption, [options, devices, this](int selectedOption){
+			QString name=options[selectedOption];
+			outputNameStream.fire(std::move(name));
+			std::string selectedDeviceID;
+			if(selectedOption==0){
+				selectedDeviceID="default";
+			}else{
+				selectedDeviceID=devices[selectedOption-1].id;
+			}
+			Global::SetCallOutputDeviceID(QString::fromStdString(selectedDeviceID));
+			Local::writeUserSettings();
+			
+			::Calls::Call* currentCall=::Calls::Current().currentCall();
+			if(currentCall){
+				currentCall->setCurrentAudioDevice(false, selectedDeviceID);
+			}
+		}));
+	});
+
+	const auto outputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel),
+									  st::settingsAudioVolumeLabelPadding);
+	const auto outputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider),
+									   st::settingsAudioVolumeSliderPadding);
+	auto updateOutputLabel=[outputLabel](int value){
+		QString percent=QString::number(value);
+		outputLabel->setText(lng_settings_call_output_volume(lt_percent, percent));
+	};
+	outputSlider->resize(st::settingsAudioVolumeSlider.seekSize);
+	outputSlider->setPseudoDiscrete(
+							  201,
+							  [](int val){
+								  return val;
+							  },
+    							Global::CallOutputVolume(),
+							  [updateOutputLabel, this](int value) {
+								  needWriteSettings=true;
+								  updateOutputLabel(value);
+								  Global::SetCallOutputVolume(value);
+			::Calls::Call* currentCall=::Calls::Current().currentCall();
+			if(currentCall){
+				currentCall->setAudioVolume(false, value/100.0f);
+			}
+							  });
+	updateOutputLabel(Global::CallOutputVolume());
+
+	AddSkip(content);
+	AddDivider(content);
+	AddSkip(content);
+	AddSubsectionTitle(content, lng_settings_call_section_input);
+	const auto inputButton = AddButtonWithLabel(
+		   content,
+		   lng_settings_call_input_device,
+			rpl::single(currentInputName) | rpl::then(inputNameStream.events()),
+    	   st::settingsButton);
+	inputButton->addClickHandler([this] {
+		int selectedOption=0;
+		std::vector<tgvoip::AudioInputDevice> devices=tgvoip::VoIPController::EnumerateAudioInputs();
+		std::vector<QString> options;
+		options.push_back(lang(lng_settings_call_device_default));
+		int i=1;
+		for(tgvoip::AudioInputDevice& device:devices){
+			QString displayName=QString::fromUtf8(device.displayName.c_str());
+			options.push_back(displayName);
+			if(QString::fromUtf8(device.id.c_str())==Global::CallInputDeviceID())
+				selectedOption=i;
+			i++;
+		}
+		Ui::show(Box<SingleChoiceBox>(lng_settings_call_input_device, options, selectedOption, [options, devices, this](int selectedOption){
+			QString name=options[selectedOption];
+			inputNameStream.fire(std::move(name));
+			std::string selectedDeviceID;
+			if(selectedOption==0){
+				selectedDeviceID="default";
+			}else{
+				selectedDeviceID=devices[selectedOption-1].id;
+			}
+			Global::SetCallInputDeviceID(QString::fromUtf8(selectedDeviceID.c_str()));
+			Local::writeUserSettings();
+			if(micTester){
+				stopTestingMicrophone();
+			}
+			::Calls::Call* currentCall=::Calls::Current().currentCall();
+			if(currentCall){
+				currentCall->setCurrentAudioDevice(true, selectedDeviceID);
+			}
+		}));
+	});
+	
+	const auto inputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel),
+										  st::settingsAudioVolumeLabelPadding);
+	const auto inputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider),
+										   st::settingsAudioVolumeSliderPadding);
+	auto updateInputLabel=[inputLabel](int value){
+		QString percent=QString::number(value);
+		inputLabel->setText(lng_settings_call_input_volume(lt_percent, percent));
+	};
+	inputSlider->resize(st::settingsAudioVolumeSlider.seekSize);
+	inputSlider->setPseudoDiscrete(101,
+		[](int val){
+			return val;
+		},
+    	Global::CallInputVolume(),
+		[updateInputLabel, this](int value) {
+		  needWriteSettings=true;
+			updateInputLabel(value);
+			Global::SetCallInputVolume(value);
+			::Calls::Call* currentCall=::Calls::Current().currentCall();
+			if(currentCall){
+				currentCall->setAudioVolume(true, value/100.0f);
+			}
+		});
+    updateInputLabel(Global::CallInputVolume());
+
+    micTestButton=AddButton(content, rpl::single(lang(lng_settings_call_test_mic)) | rpl::then(micTestTextStream.events()), st::settingsButton);
+
+    micTestLevel=content->add(object_ptr<Ui::LevelMeter>(content, st::defaultLevelMeter), st::settingsLevelMeterPadding);
+    micTestLevel->resize(QSize(0, st::defaultLevelMeter.height));
+
+	micTestButton->addClickHandler([this]{
+		if(!micTester){
+			requestPermissionAndStartTestingMicrophone();
+		}else{
+			stopTestingMicrophone();
+		}
+	});
+	levelUpdateTimer.setCallback([this](){
+		micTestLevel->setValue(micTester->GetAndResetLevel());
+	});
+
+	AddSkip(content);
+	AddDivider(content);
+	AddSkip(content);
+	AddSubsectionTitle(content, lng_settings_call_section_other);
+	
+#ifdef Q_OS_MAC
+	AddButton(
+			  content,
+			  lng_settings_call_audio_ducking,
+			  st::settingsButton
+			  )->toggleOn(
+						  rpl::single(Global::CallAudioDuckingEnabled())
+						  )->toggledValue(
+	) | rpl::filter([](bool enabled) {
+		return (enabled != Global::CallAudioDuckingEnabled());
+	}) | rpl::start_with_next([](bool enabled) {
+		Global::SetCallAudioDuckingEnabled(enabled);
+		Local::writeUserSettings();
+			::Calls::Call* currentCall=::Calls::Current().currentCall();
+			if(currentCall){
+				currentCall->setAudioDuckingEnabled(enabled);
+			}
+	}, content->lifetime());
+#endif // Q_OS_MAC
+	
+	const auto systemSettingsButton=AddButton(content, lng_settings_call_open_system_prefs, st::settingsButton);
+	systemSettingsButton->addClickHandler([]{
+		Platform::OpenSystemSettings(Platform::SystemSettingsType::Audio);
+	});
+	AddSkip(content);
+
+	Ui::ResizeFitChild(this, content);
+}
+
+void Calls::requestPermissionAndStartTestingMicrophone(){
+	Platform::PermissionStatus status=Platform::GetPermissionStatus(Platform::PermissionType::Microphone);
+	if (status==Platform::PermissionStatus::Granted) {
+		startTestingMicrophone();
+	} else if(status==Platform::PermissionStatus::CanRequest) {
+		Platform::RequestPermission(Platform::PermissionType::Microphone, crl::guard(this, [this](Platform::PermissionStatus status) {
+			if (status==Platform::PermissionStatus::Granted) {
+				crl::on_main(crl::guard(this, [this]{
+					startTestingMicrophone();
+				}));
+			}
+		}));
+	} else {
+		Ui::show(Box<ConfirmBox>(lang(lng_no_mic_permission), lang(lng_menu_settings), crl::guard(this, [] {
+			Platform::OpenSystemSettingsForPermission(Platform::PermissionType::Microphone);
+			Ui::hideLayer();
+		})));
+	}
+}
+
+void Calls::startTestingMicrophone(){
+	micTestTextStream.fire(lang(lng_settings_call_stop_mic_test));
+	levelUpdateTimer.callEach(50);
+	micTester=std::make_unique<tgvoip::AudioInputTester>(Global::CallInputDeviceID().toStdString());
+	if(micTester->Failed()){
+		Ui::show(Box<InformBox>(lang(lng_call_error_audio_io)));
+		stopTestingMicrophone();
+	}
+}
+
+void Calls::stopTestingMicrophone(){
+	micTestTextStream.fire(lang(lng_settings_call_test_mic));
+	levelUpdateTimer.cancel();
+	micTester.reset();
+	micTestLevel->setValue(0.0f);
+}
+
+} // namespace Settings

--- a/Telegram/SourceFiles/settings/settings_calls.cpp
+++ b/Telegram/SourceFiles/settings/settings_calls.cpp
@@ -44,13 +44,13 @@ Calls::Calls(QWidget *parent, UserData *self)
 }
 	
 Calls::~Calls(){
-	if(needWriteSettings){
+	if (needWriteSettings) {
     	Local::writeUserSettings();
 	}
 }
 
 void Calls::sectionSaveChanges(FnMut<void()> done){
-	if(micTester){
+	if (micTester) {
 		micTester.reset();
 	}
 	done();
@@ -60,28 +60,28 @@ void Calls::setupContent() {
 	const auto content = Ui::CreateChild<Ui::VerticalLayout>(this);
 
 	QString currentOutputName;
-	if(Global::CallOutputDeviceID()==qsl("default")){
-		currentOutputName=lang(lng_settings_call_device_default);
-	}else{
-    	std::vector<tgvoip::AudioOutputDevice> outputDevices=tgvoip::VoIPController::EnumerateAudioOutputs();
+	if (Global::CallOutputDeviceID() == qsl("default")) {
+		currentOutputName = lang(lng_settings_call_device_default);
+	} else {
+		std::vector<tgvoip::AudioOutputDevice> outputDevices = tgvoip::VoIPController::EnumerateAudioOutputs();
 		currentOutputName=Global::CallOutputDeviceID();
-    	for(tgvoip::AudioOutputDevice& dev:outputDevices){
-    		if(QString::fromUtf8(dev.id.c_str())==Global::CallOutputDeviceID()){
-    			currentOutputName=QString::fromUtf8(dev.displayName.c_str());
-    			break;
-    		}
-    	}
+		for (auto &dev : outputDevices) {
+			if (QString::fromUtf8(dev.id.c_str()) == Global::CallOutputDeviceID()) {
+				currentOutputName = QString::fromUtf8(dev.displayName.c_str());
+				break;
+			}
+		}
 	}
 	
 	QString currentInputName;
-	if(Global::CallInputDeviceID()==qsl("default")){
-		currentInputName=lang(lng_settings_call_device_default);
-	}else{
-		std::vector<tgvoip::AudioInputDevice> inputDevices=tgvoip::VoIPController::EnumerateAudioInputs();
-		currentInputName=Global::CallInputDeviceID();
-		for(tgvoip::AudioInputDevice& dev:inputDevices){
-			if(QString::fromUtf8(dev.id.c_str())==Global::CallInputDeviceID()){
-				currentInputName=QString::fromUtf8(dev.displayName.c_str());
+	if (Global::CallInputDeviceID() == qsl("default")) {
+		currentInputName = lang(lng_settings_call_device_default);
+	} else {
+		std::vector<tgvoip::AudioInputDevice> inputDevices = tgvoip::VoIPController::EnumerateAudioInputs();
+		currentInputName = Global::CallInputDeviceID();
+		for (auto &dev : inputDevices) {
+			if (QString::fromUtf8(dev.id.c_str()) == Global::CallInputDeviceID()) {
+				currentInputName = QString::fromUtf8(dev.displayName.c_str());
 				break;
 			}
 		}
@@ -90,66 +90,65 @@ void Calls::setupContent() {
 	AddSkip(content);
 	AddSubsectionTitle(content, lng_settings_call_section_output);
 	const auto outputButton = AddButtonWithLabel(
-		   content,
-		   lng_settings_call_output_device,
-		   rpl::single(currentOutputName) | rpl::then(outputNameStream.events()),
-		   st::settingsButton);
+		content,
+		lng_settings_call_output_device,
+		rpl::single(currentOutputName) | rpl::then(outputNameStream.events()),
+		st::settingsButton);
 	outputButton->addClickHandler([this] {
-		int selectedOption=0;
-		std::vector<tgvoip::AudioOutputDevice> devices=tgvoip::VoIPController::EnumerateAudioOutputs();
+		int selectedOption = 0;
+		std::vector<tgvoip::AudioOutputDevice> devices = tgvoip::VoIPController::EnumerateAudioOutputs();
 		std::vector<QString> options;
 		options.push_back(lang(lng_settings_call_device_default));
-		int i=1;
-		for(tgvoip::AudioOutputDevice& device:devices){
-			QString displayName=QString::fromUtf8(device.displayName.c_str());
+		int i = 1;
+		for (auto &device:devices) {
+			QString displayName = QString::fromUtf8(device.displayName.c_str());
 			options.push_back(displayName);
-			if(QString::fromUtf8(device.id.c_str())==Global::CallOutputDeviceID())
-				selectedOption=i;
+			if (QString::fromUtf8(device.id.c_str()) == Global::CallOutputDeviceID()) {
+				selectedOption = i;
+			}
 			i++;
 		}
 		Ui::show(Box<SingleChoiceBox>(lng_settings_call_output_device, options, selectedOption, [options, devices, this](int selectedOption){
-			QString name=options[selectedOption];
+			QString name = options[selectedOption];
 			outputNameStream.fire(std::move(name));
 			std::string selectedDeviceID;
-			if(selectedOption==0){
-				selectedDeviceID="default";
-			}else{
-				selectedDeviceID=devices[selectedOption-1].id;
+			if (selectedOption == 0) {
+				selectedDeviceID = "default";
+			} else {
+				selectedDeviceID = devices[selectedOption-1].id;
 			}
 			Global::SetCallOutputDeviceID(QString::fromStdString(selectedDeviceID));
 			Local::writeUserSettings();
 			
-			::Calls::Call* currentCall=::Calls::Current().currentCall();
-			if(currentCall){
+			::Calls::Call* currentCall = ::Calls::Current().currentCall();
+			if (currentCall) {
 				currentCall->setCurrentAudioDevice(false, selectedDeviceID);
 			}
 		}));
 	});
 
-	const auto outputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel),
-									  st::settingsAudioVolumeLabelPadding);
-	const auto outputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider),
-									   st::settingsAudioVolumeSliderPadding);
-	auto updateOutputLabel=[outputLabel](int value){
-		QString percent=QString::number(value);
+	const auto outputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel), st::settingsAudioVolumeLabelPadding);
+	const auto outputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider), st::settingsAudioVolumeSliderPadding);
+	auto updateOutputLabel = [outputLabel](int value){
+		QString percent = QString::number(value);
 		outputLabel->setText(lng_settings_call_output_volume(lt_percent, percent));
 	};
 	outputSlider->resize(st::settingsAudioVolumeSlider.seekSize);
 	outputSlider->setPseudoDiscrete(
-							  201,
-							  [](int val){
-								  return val;
-							  },
-    							Global::CallOutputVolume(),
-							  [updateOutputLabel, this](int value) {
-								  needWriteSettings=true;
-								  updateOutputLabel(value);
-								  Global::SetCallOutputVolume(value);
-			::Calls::Call* currentCall=::Calls::Current().currentCall();
-			if(currentCall){
+		201,
+		[](int val){
+			return val;
+		},
+		Global::CallOutputVolume(),
+		[updateOutputLabel, this](int value) {
+			needWriteSettings = true;
+			updateOutputLabel(value);
+			Global::SetCallOutputVolume(value);
+			::Calls::Call* currentCall = ::Calls::Current().currentCall();
+			if (currentCall) {
 				currentCall->setAudioVolume(false, value/100.0f);
 			}
-							  });
+	});
 	updateOutputLabel(Global::CallOutputVolume());
 
 	AddSkip(content);
@@ -157,50 +156,48 @@ void Calls::setupContent() {
 	AddSkip(content);
 	AddSubsectionTitle(content, lng_settings_call_section_input);
 	const auto inputButton = AddButtonWithLabel(
-		   content,
-		   lng_settings_call_input_device,
-			rpl::single(currentInputName) | rpl::then(inputNameStream.events()),
-    	   st::settingsButton);
+		content,
+		lng_settings_call_input_device,
+		rpl::single(currentInputName) | rpl::then(inputNameStream.events()),
+		st::settingsButton);
 	inputButton->addClickHandler([this] {
-		int selectedOption=0;
-		std::vector<tgvoip::AudioInputDevice> devices=tgvoip::VoIPController::EnumerateAudioInputs();
+		int selectedOption = 0;
+		std::vector<tgvoip::AudioInputDevice> devices = tgvoip::VoIPController::EnumerateAudioInputs();
 		std::vector<QString> options;
 		options.push_back(lang(lng_settings_call_device_default));
-		int i=1;
-		for(tgvoip::AudioInputDevice& device:devices){
-			QString displayName=QString::fromUtf8(device.displayName.c_str());
+		int i = 1;
+		for (auto &device : devices) {
+			QString displayName = QString::fromUtf8(device.displayName.c_str());
 			options.push_back(displayName);
-			if(QString::fromUtf8(device.id.c_str())==Global::CallInputDeviceID())
-				selectedOption=i;
+			if(QString::fromUtf8(device.id.c_str()) == Global::CallInputDeviceID())
+				selectedOption = i;
 			i++;
 		}
 		Ui::show(Box<SingleChoiceBox>(lng_settings_call_input_device, options, selectedOption, [options, devices, this](int selectedOption){
 			QString name=options[selectedOption];
 			inputNameStream.fire(std::move(name));
 			std::string selectedDeviceID;
-			if(selectedOption==0){
-				selectedDeviceID="default";
-			}else{
-				selectedDeviceID=devices[selectedOption-1].id;
+			if (selectedOption == 0) {
+				selectedDeviceID = "default";
+			} else {
+				selectedDeviceID = devices[selectedOption - 1].id;
 			}
 			Global::SetCallInputDeviceID(QString::fromUtf8(selectedDeviceID.c_str()));
 			Local::writeUserSettings();
-			if(micTester){
+			if (micTester) {
 				stopTestingMicrophone();
 			}
-			::Calls::Call* currentCall=::Calls::Current().currentCall();
+			::Calls::Call* currentCall = ::Calls::Current().currentCall();
 			if(currentCall){
 				currentCall->setCurrentAudioDevice(true, selectedDeviceID);
 			}
 		}));
 	});
 	
-	const auto inputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel),
-										  st::settingsAudioVolumeLabelPadding);
-	const auto inputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider),
-										   st::settingsAudioVolumeSliderPadding);
-	auto updateInputLabel=[inputLabel](int value){
-		QString percent=QString::number(value);
+	const auto inputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel), st::settingsAudioVolumeLabelPadding);
+	const auto inputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider), st::settingsAudioVolumeSliderPadding);
+	auto updateInputLabel = [inputLabel](int value){
+		QString percent = QString::number(value);
 		inputLabel->setText(lng_settings_call_input_volume(lt_percent, percent));
 	};
 	inputSlider->resize(st::settingsAudioVolumeSlider.seekSize);
@@ -208,27 +205,27 @@ void Calls::setupContent() {
 		[](int val){
 			return val;
 		},
-    	Global::CallInputVolume(),
+		Global::CallInputVolume(),
 		[updateInputLabel, this](int value) {
-		  needWriteSettings=true;
+		  needWriteSettings = true;
 			updateInputLabel(value);
 			Global::SetCallInputVolume(value);
-			::Calls::Call* currentCall=::Calls::Current().currentCall();
-			if(currentCall){
-				currentCall->setAudioVolume(true, value/100.0f);
+			::Calls::Call *currentCall = ::Calls::Current().currentCall();
+			if (currentCall) {
+				currentCall->setAudioVolume(true, value / 100.0f);
 			}
 		});
-    updateInputLabel(Global::CallInputVolume());
+	updateInputLabel(Global::CallInputVolume());
 
-    micTestButton=AddButton(content, rpl::single(lang(lng_settings_call_test_mic)) | rpl::then(micTestTextStream.events()), st::settingsButton);
+	micTestButton=AddButton(content, rpl::single(lang(lng_settings_call_test_mic)) | rpl::then(micTestTextStream.events()), st::settingsButton);
 
-    micTestLevel=content->add(object_ptr<Ui::LevelMeter>(content, st::defaultLevelMeter), st::settingsLevelMeterPadding);
-    micTestLevel->resize(QSize(0, st::defaultLevelMeter.height));
+	micTestLevel=content->add(object_ptr<Ui::LevelMeter>(content, st::defaultLevelMeter), st::settingsLevelMeterPadding);
+	micTestLevel->resize(QSize(0, st::defaultLevelMeter.height));
 
 	micTestButton->addClickHandler([this]{
-		if(!micTester){
+		if (!micTester) {
 			requestPermissionAndStartTestingMicrophone();
-		}else{
+		} else {
 			stopTestingMicrophone();
 		}
 	});
@@ -243,27 +240,28 @@ void Calls::setupContent() {
 	
 #ifdef Q_OS_MAC
 	AddButton(
-			  content,
-			  lng_settings_call_audio_ducking,
-			  st::settingsButton
-			  )->toggleOn(
-						  rpl::single(Global::CallAudioDuckingEnabled())
-						  )->toggledValue(
-	) | rpl::filter([](bool enabled) {
+		content,
+		lng_settings_call_audio_ducking,
+		st::settingsButton
+	)->toggleOn(
+		rpl::single(Global::CallAudioDuckingEnabled())
+	)->toggledValue() | rpl::filter([](bool enabled) {
 		return (enabled != Global::CallAudioDuckingEnabled());
 	}) | rpl::start_with_next([](bool enabled) {
 		Global::SetCallAudioDuckingEnabled(enabled);
 		Local::writeUserSettings();
-			::Calls::Call* currentCall=::Calls::Current().currentCall();
-			if(currentCall){
-				currentCall->setAudioDuckingEnabled(enabled);
-			}
+		::Calls::Call *currentCall = ::Calls::Current().currentCall();
+		if (currentCall) {
+			currentCall->setAudioDuckingEnabled(enabled);
+		}
 	}, content->lifetime());
 #endif // Q_OS_MAC
 	
 	const auto systemSettingsButton=AddButton(content, lng_settings_call_open_system_prefs, st::settingsButton);
 	systemSettingsButton->addClickHandler([]{
-		Platform::OpenSystemSettings(Platform::SystemSettingsType::Audio);
+		if (!Platform::OpenSystemSettings(Platform::SystemSettingsType::Audio)) {
+			Ui::show(Box<InformBox>(lang(lng_linux_no_audio_prefs)));
+		}
 	});
 	AddSkip(content);
 
@@ -271,12 +269,12 @@ void Calls::setupContent() {
 }
 
 void Calls::requestPermissionAndStartTestingMicrophone(){
-	Platform::PermissionStatus status=Platform::GetPermissionStatus(Platform::PermissionType::Microphone);
-	if (status==Platform::PermissionStatus::Granted) {
+	Platform::PermissionStatus status = Platform::GetPermissionStatus(Platform::PermissionType::Microphone);
+	if (status == Platform::PermissionStatus::Granted) {
 		startTestingMicrophone();
-	} else if(status==Platform::PermissionStatus::CanRequest) {
+	} else if (status == Platform::PermissionStatus::CanRequest) {
 		Platform::RequestPermission(Platform::PermissionType::Microphone, crl::guard(this, [this](Platform::PermissionStatus status) {
-			if (status==Platform::PermissionStatus::Granted) {
+			if (status == Platform::PermissionStatus::Granted) {
 				crl::on_main(crl::guard(this, [this]{
 					startTestingMicrophone();
 				}));
@@ -293,8 +291,8 @@ void Calls::requestPermissionAndStartTestingMicrophone(){
 void Calls::startTestingMicrophone(){
 	micTestTextStream.fire(lang(lng_settings_call_stop_mic_test));
 	levelUpdateTimer.callEach(50);
-	micTester=std::make_unique<tgvoip::AudioInputTester>(Global::CallInputDeviceID().toStdString());
-	if(micTester->Failed()){
+	micTester = std::make_unique<tgvoip::AudioInputTester>(Global::CallInputDeviceID().toStdString());
+	if (micTester->Failed()) {
 		Ui::show(Box<InformBox>(lang(lng_call_error_audio_io)));
 		stopTestingMicrophone();
 	}

--- a/Telegram/SourceFiles/settings/settings_calls.cpp
+++ b/Telegram/SourceFiles/settings/settings_calls.cpp
@@ -42,10 +42,10 @@ Calls::Calls(QWidget *parent, UserData *self)
 : Section(parent) {
 	setupContent();
 }
-	
+
 Calls::~Calls(){
 	if (needWriteSettings) {
-    	Local::writeUserSettings();
+		Local::writeUserSettings();
 	}
 }
 
@@ -72,7 +72,7 @@ void Calls::setupContent() {
 			}
 		}
 	}
-	
+
 	QString currentInputName;
 	if (Global::CallInputDeviceID() == qsl("default")) {
 		currentInputName = lang(lng_settings_call_device_default);
@@ -86,7 +86,7 @@ void Calls::setupContent() {
 			}
 		}
 	}
-	
+
 	AddSkip(content);
 	AddSubsectionTitle(content, lng_settings_call_section_output);
 	const auto outputButton = AddButtonWithLabel(
@@ -119,7 +119,7 @@ void Calls::setupContent() {
 			}
 			Global::SetCallOutputDeviceID(QString::fromStdString(selectedDeviceID));
 			Local::writeUserSettings();
-			
+
 			::Calls::Call* currentCall = ::Calls::Current().currentCall();
 			if (currentCall) {
 				currentCall->setCurrentAudioDevice(false, selectedDeviceID);
@@ -193,7 +193,7 @@ void Calls::setupContent() {
 			}
 		}));
 	});
-	
+
 	const auto inputLabel = content->add(object_ptr<Ui::LabelSimple>(content, st::settingsAudioVolumeLabel), st::settingsAudioVolumeLabelPadding);
 	const auto inputSlider = content->add(object_ptr<Ui::MediaSlider>(content, st::settingsAudioVolumeSlider), st::settingsAudioVolumeSliderPadding);
 	auto updateInputLabel = [inputLabel](int value){
@@ -207,7 +207,7 @@ void Calls::setupContent() {
 		},
 		Global::CallInputVolume(),
 		[updateInputLabel, this](int value) {
-		  needWriteSettings = true;
+			needWriteSettings = true;
 			updateInputLabel(value);
 			Global::SetCallInputVolume(value);
 			::Calls::Call *currentCall = ::Calls::Current().currentCall();
@@ -237,7 +237,7 @@ void Calls::setupContent() {
 	AddDivider(content);
 	AddSkip(content);
 	AddSubsectionTitle(content, lng_settings_call_section_other);
-	
+
 #ifdef Q_OS_MAC
 	AddButton(
 		content,
@@ -256,7 +256,7 @@ void Calls::setupContent() {
 		}
 	}, content->lifetime());
 #endif // Q_OS_MAC
-	
+
 	const auto systemSettingsButton=AddButton(content, lng_settings_call_open_system_prefs, st::settingsButton);
 	systemSettingsButton->addClickHandler([]{
 		if (!Platform::OpenSystemSettings(Platform::SystemSettingsType::Audio)) {
@@ -306,3 +306,4 @@ void Calls::stopTestingMicrophone(){
 }
 
 } // namespace Settings
+

--- a/Telegram/SourceFiles/settings/settings_calls.h
+++ b/Telegram/SourceFiles/settings/settings_calls.h
@@ -47,3 +47,4 @@ private:
 };
 
 } // namespace Settings
+

--- a/Telegram/SourceFiles/settings/settings_calls.h
+++ b/Telegram/SourceFiles/settings/settings_calls.h
@@ -1,0 +1,49 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include "settings/settings_common.h"
+#include "base/timer.h"
+
+namespace Calls{
+	class Call;
+} // namespace Calls
+
+namespace Ui{
+	class LevelMeter;
+}
+
+namespace tgvoip{
+	class AudioInputTester;
+}
+
+namespace Settings {
+
+class Calls : public Section {
+public:
+	explicit Calls(QWidget *parent, UserData *self = nullptr);
+	virtual ~Calls();
+	virtual void sectionSaveChanges(FnMut<void()> done) override;
+
+private:
+	void setupContent();
+	void requestPermissionAndStartTestingMicrophone();
+	void startTestingMicrophone();
+	void stopTestingMicrophone();
+
+	rpl::event_stream<QString> outputNameStream;
+	rpl::event_stream<QString> inputNameStream;
+	rpl::event_stream<QString> micTestTextStream;
+	bool needWriteSettings=false;
+	std::unique_ptr<tgvoip::AudioInputTester> micTester;
+	Button* micTestButton;
+	Ui::LevelMeter* micTestLevel;
+	base::Timer levelUpdateTimer;
+};
+
+} // namespace Settings

--- a/Telegram/SourceFiles/settings/settings_calls.h
+++ b/Telegram/SourceFiles/settings/settings_calls.h
@@ -10,15 +10,15 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "settings/settings_common.h"
 #include "base/timer.h"
 
-namespace Calls{
+namespace Calls {
 	class Call;
 } // namespace Calls
 
-namespace Ui{
+namespace Ui {
 	class LevelMeter;
 }
 
-namespace tgvoip{
+namespace tgvoip {
 	class AudioInputTester;
 }
 
@@ -36,14 +36,14 @@ private:
 	void startTestingMicrophone();
 	void stopTestingMicrophone();
 
-	rpl::event_stream<QString> outputNameStream;
-	rpl::event_stream<QString> inputNameStream;
-	rpl::event_stream<QString> micTestTextStream;
-	bool needWriteSettings=false;
-	std::unique_ptr<tgvoip::AudioInputTester> micTester;
-	Button* micTestButton;
-	Ui::LevelMeter* micTestLevel;
-	base::Timer levelUpdateTimer;
+	rpl::event_stream<QString> _outputNameStream;
+	rpl::event_stream<QString> _inputNameStream;
+	rpl::event_stream<QString> _micTestTextStream;
+	bool _needWriteSettings = false;
+	std::unique_ptr<tgvoip::AudioInputTester> _micTester;
+	Button *_micTestButton = nullptr;
+	Ui::LevelMeter *_micTestLevel = nullptr;
+	base::Timer _levelUpdateTimer;
 };
 
 } // namespace Settings

--- a/Telegram/SourceFiles/settings/settings_common.cpp
+++ b/Telegram/SourceFiles/settings/settings_common.cpp
@@ -13,6 +13,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "settings/settings_main.h"
 #include "settings/settings_notifications.h"
 #include "settings/settings_privacy_security.h"
+#include "settings/settings_calls.h"
 #include "ui/wrap/padding_wrap.h"
 #include "ui/wrap/vertical_layout.h"
 #include "ui/widgets/labels.h"
@@ -44,6 +45,8 @@ object_ptr<Section> CreateSection(
 		return object_ptr<Advanced>(parent, self);
 	case Type::Chat:
 		return object_ptr<Chat>(parent, self);
+	case Type::Calls:
+		return object_ptr<Calls>(parent, self);
 	}
 	Unexpected("Settings section type in Widget::createInnerWidget.");
 }

--- a/Telegram/SourceFiles/settings/settings_common.h
+++ b/Telegram/SourceFiles/settings/settings_common.h
@@ -38,6 +38,7 @@ enum class Type {
 	PrivacySecurity,
 	Advanced,
 	Chat,
+	Calls,
 };
 
 using Button = Info::Profile::Button;

--- a/Telegram/SourceFiles/settings/settings_main.cpp
+++ b/Telegram/SourceFiles/settings/settings_main.cpp
@@ -88,9 +88,9 @@ void SetupSections(
 		Type::Chat,
 		&st::settingsIconChat);
 	addSection(
-	   lng_settings_section_call_settings,
-	   Type::Calls,
-	   &st::settingsIconCalls);
+		lng_settings_section_call_settings,
+		Type::Calls,
+		&st::settingsIconCalls);
 	addSection(
 		lng_settings_advanced,
 		Type::Advanced,

--- a/Telegram/SourceFiles/settings/settings_main.cpp
+++ b/Telegram/SourceFiles/settings/settings_main.cpp
@@ -88,6 +88,10 @@ void SetupSections(
 		Type::Chat,
 		&st::settingsIconChat);
 	addSection(
+	   lng_settings_section_call_settings,
+	   Type::Calls,
+	   &st::settingsIconCalls);
+	addSection(
 		lng_settings_advanced,
 		Type::Advanced,
 		&st::settingsIconGeneral);

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -601,6 +601,7 @@ enum {
 	dbiScalePercent = 0x58,
 	dbiPlaybackSpeed = 0x59,
 	dbiLanguagesKey = 0x5a,
+	dbiCallSettings = 0x5b,
 
 	dbiEncryptedWithSalt = 333,
 	dbiEncrypted = 444,
@@ -1785,6 +1786,14 @@ bool _readSetting(quint32 blockId, QDataStream &stream, int version, ReadSetting
 
 		Global::SetVoiceMsgPlaybackDoubled(v == 2);
 	} break;
+			
+	case dbiCallSettings: {
+		QByteArray callSettings;
+		stream >> callSettings;
+		if(!_checkStreamStatus(stream)) return false;
+		
+		deserializeCallSettings(callSettings);
+	} break;
 
 	default:
 	LOG(("App Error: unknown blockId in _readSetting: %1").arg(blockId));
@@ -2002,6 +2011,7 @@ void _writeUserSettings() {
 	auto userData = userDataInstance
 		? userDataInstance->serialize()
 		: QByteArray();
+	auto callSettings = serializeCallSettings();
 
 	uint32 size = 23 * (sizeof(quint32) + sizeof(qint32));
 	size += sizeof(quint32) + Serialize::stringSize(Global::AskDownloadPath() ? QString() : Global::DownloadPath()) + Serialize::bytearraySize(Global::AskDownloadPath() ? QByteArray() : Global::DownloadPathBookmark());
@@ -2024,6 +2034,7 @@ void _writeUserSettings() {
 	if (!userData.isEmpty()) {
 		size += sizeof(quint32) + Serialize::bytearraySize(userData);
 	}
+	size += sizeof(quint32) + Serialize::bytearraySize(callSettings);
 
 	EncryptedDescriptor data(size);
 	data.stream
@@ -2073,6 +2084,7 @@ void _writeUserSettings() {
 	if (!Global::HiddenPinnedMessages().isEmpty()) {
 		data.stream << quint32(dbiHiddenPinnedMessages) << Global::HiddenPinnedMessages();
 	}
+	data.stream << qint32(dbiCallSettings) << callSettings;
 
 	FileWriteDescriptor file(_userSettingsKey);
 	file.writeEncrypted(data);
@@ -4800,6 +4812,43 @@ bool decrypt(const void *src, void *dst, uint32 len, const void *key128) {
 	}
 	MTP::aesDecryptLocal(src, dst, len, LocalKey, key128);
 	return true;
+}
+	
+QByteArray serializeCallSettings(){
+	QByteArray result=QByteArray();
+	uint32 size = 3*sizeof(qint32) + Serialize::stringSize(Global::CallOutputDeviceID()) + Serialize::stringSize(Global::CallInputDeviceID());
+	result.reserve(size);
+	QDataStream stream(&result, QIODevice::WriteOnly);
+	stream.setVersion(QDataStream::Qt_5_1);
+	stream << Global::CallOutputDeviceID();
+	stream << qint32(Global::CallOutputVolume());
+	stream << Global::CallInputDeviceID();
+	stream << qint32(Global::CallInputVolume());
+	stream << qint32(Global::CallAudioDuckingEnabled() ? 1 : 0);
+	return result;
+}
+
+void deserializeCallSettings(QByteArray& settings){
+	QDataStream stream(&settings, QIODevice::ReadOnly);
+	stream.setVersion(QDataStream::Qt_5_1);
+	QString outputDeviceID;
+	QString inputDeviceID;
+	qint32 outputVolume;
+	qint32 inputVolume;
+	qint32 duckingEnabled;
+	
+	stream >> outputDeviceID;
+	stream >> outputVolume;
+	stream >> inputDeviceID;
+	stream >> inputVolume;
+	stream >> duckingEnabled;
+	if(_checkStreamStatus(stream)){
+		Global::SetCallOutputDeviceID(outputDeviceID);
+		Global::SetCallOutputVolume(outputVolume);
+		Global::SetCallInputDeviceID(inputDeviceID);
+		Global::SetCallInputVolume(inputVolume);
+		Global::SetCallAudioDuckingEnabled(duckingEnabled);
+	}
 }
 
 struct ClearManagerData {

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -2512,6 +2512,9 @@ void _writeMap(WriteMapWhen when) {
 
 } // namespace
 
+QByteArray serializeCallSettings();
+void deserializeCallSettings(QByteArray& settings);
+
 void finish() {
 	if (_manager) {
 		_writeMap(WriteMapWhen::Now);

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -1786,12 +1786,12 @@ bool _readSetting(quint32 blockId, QDataStream &stream, int version, ReadSetting
 
 		Global::SetVoiceMsgPlaybackDoubled(v == 2);
 	} break;
-			
+
 	case dbiCallSettings: {
 		QByteArray callSettings;
 		stream >> callSettings;
 		if(!_checkStreamStatus(stream)) return false;
-		
+
 		deserializeCallSettings(callSettings);
 	} break;
 
@@ -4816,7 +4816,7 @@ bool decrypt(const void *src, void *dst, uint32 len, const void *key128) {
 	MTP::aesDecryptLocal(src, dst, len, LocalKey, key128);
 	return true;
 }
-	
+
 QByteArray serializeCallSettings(){
 	QByteArray result=QByteArray();
 	uint32 size = 3*sizeof(qint32) + Serialize::stringSize(Global::CallOutputDeviceID()) + Serialize::stringSize(Global::CallInputDeviceID());
@@ -4839,7 +4839,7 @@ void deserializeCallSettings(QByteArray& settings){
 	qint32 outputVolume;
 	qint32 inputVolume;
 	qint32 duckingEnabled;
-	
+
 	stream >> outputDeviceID;
 	stream >> outputVolume;
 	stream >> inputDeviceID;

--- a/Telegram/SourceFiles/storage/localstorage.h
+++ b/Telegram/SourceFiles/storage/localstorage.h
@@ -172,6 +172,9 @@ bool isBotTrusted(UserData *bot);
 
 bool encrypt(const void *src, void *dst, uint32 len, const void *key128);
 bool decrypt(const void *src, void *dst, uint32 len, const void *key128);
+	
+QByteArray serializeCallSettings();
+void deserializeCallSettings(QByteArray& settings);
 
 namespace internal {
 

--- a/Telegram/SourceFiles/storage/localstorage.h
+++ b/Telegram/SourceFiles/storage/localstorage.h
@@ -172,9 +172,6 @@ bool isBotTrusted(UserData *bot);
 
 bool encrypt(const void *src, void *dst, uint32 len, const void *key128);
 bool decrypt(const void *src, void *dst, uint32 len, const void *key128);
-	
-QByteArray serializeCallSettings();
-void deserializeCallSettings(QByteArray& settings);
 
 namespace internal {
 

--- a/Telegram/SourceFiles/ui/widgets/level_meter.cpp
+++ b/Telegram/SourceFiles/ui/widgets/level_meter.cpp
@@ -1,0 +1,42 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "ui/widgets/level_meter.h"
+
+namespace Ui {
+
+LevelMeter::LevelMeter(QWidget* parent, const style::LevelMeter& st) : RpWidget(parent), _st(st){
+
+}
+
+void LevelMeter::setValue(float value){
+	_value=value;
+	repaint();
+}
+
+void LevelMeter::paintEvent(QPaintEvent* event){
+	Painter p(this);
+	PainterHighQualityEnabler hq(p);
+	
+	p.setPen(Qt::NoPen);
+	
+	auto activeFg = _st.activeFg;
+	auto inactiveFg = _st.inactiveFg;
+	auto radius = _st.lineWidth/2;
+	QRect rect(0, 0, _st.lineWidth, height());
+	p.setBrush(activeFg);
+	for(int i=0;i<_st.lineCount;i++){
+		float valueAtLine=(float)(i+1)/_st.lineCount;
+		if(valueAtLine>_value){
+			p.setBrush(inactiveFg);
+		}
+		rect.moveLeft((_st.lineWidth+_st.lineSpacing)*i);
+    	p.drawRoundedRect(rect, radius, radius);
+	}
+}
+
+} // namespace Ui

--- a/Telegram/SourceFiles/ui/widgets/level_meter.cpp
+++ b/Telegram/SourceFiles/ui/widgets/level_meter.cpp
@@ -21,9 +21,9 @@ void LevelMeter::setValue(float value){
 void LevelMeter::paintEvent(QPaintEvent* event){
 	Painter p(this);
 	PainterHighQualityEnabler hq(p);
-	
+
 	p.setPen(Qt::NoPen);
-	
+
 	auto activeFg = _st.activeFg;
 	auto inactiveFg = _st.inactiveFg;
 	auto radius = _st.lineWidth / 2;

--- a/Telegram/SourceFiles/ui/widgets/level_meter.cpp
+++ b/Telegram/SourceFiles/ui/widgets/level_meter.cpp
@@ -9,12 +9,12 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace Ui {
 
-LevelMeter::LevelMeter(QWidget* parent, const style::LevelMeter& st) : RpWidget(parent), _st(st){
+LevelMeter::LevelMeter(QWidget *parent, const style::LevelMeter &st) : RpWidget(parent), _st(st){
 
 }
 
 void LevelMeter::setValue(float value){
-	_value=value;
+	_value = value;
 	repaint();
 }
 
@@ -26,16 +26,16 @@ void LevelMeter::paintEvent(QPaintEvent* event){
 	
 	auto activeFg = _st.activeFg;
 	auto inactiveFg = _st.inactiveFg;
-	auto radius = _st.lineWidth/2;
+	auto radius = _st.lineWidth / 2;
 	QRect rect(0, 0, _st.lineWidth, height());
 	p.setBrush(activeFg);
-	for(int i=0;i<_st.lineCount;i++){
-		float valueAtLine=(float)(i+1)/_st.lineCount;
-		if(valueAtLine>_value){
+	for (auto i = 0; i < _st.lineCount; ++i) {
+		float valueAtLine = (float)(i + 1) / _st.lineCount;
+		if (valueAtLine > _value) {
 			p.setBrush(inactiveFg);
 		}
-		rect.moveLeft((_st.lineWidth+_st.lineSpacing)*i);
-    	p.drawRoundedRect(rect, radius, radius);
+		rect.moveLeft((_st.lineWidth + _st.lineSpacing) * i);
+		p.drawRoundedRect(rect, radius, radius);
 	}
 }
 

--- a/Telegram/SourceFiles/ui/widgets/level_meter.h
+++ b/Telegram/SourceFiles/ui/widgets/level_meter.h
@@ -16,10 +16,10 @@ class LevelMeter : public RpWidget {
 public:
 	LevelMeter(QWidget *parent, const style::LevelMeter& st);
 	void setValue(float value);
-	
+
 protected:
 	void paintEvent(QPaintEvent *e) override;
-	
+
 private:
 	const style::LevelMeter &_st;
 	float _value=0.0f;

--- a/Telegram/SourceFiles/ui/widgets/level_meter.h
+++ b/Telegram/SourceFiles/ui/widgets/level_meter.h
@@ -24,4 +24,5 @@ private:
 	const style::LevelMeter &_st;
 	float _value=0.0f;
 };
+
 } // namespace Ui

--- a/Telegram/SourceFiles/ui/widgets/level_meter.h
+++ b/Telegram/SourceFiles/ui/widgets/level_meter.h
@@ -1,0 +1,27 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include "styles/style_widgets.h"
+#include "ui/rp_widget.h"
+
+namespace Ui {
+
+class LevelMeter : public RpWidget {
+public:
+	LevelMeter(QWidget *parent, const style::LevelMeter& st);
+	void setValue(float value);
+	
+protected:
+	void paintEvent(QPaintEvent *e) override;
+	
+private:
+	const style::LevelMeter &_st;
+	float _value=0.0f;
+};
+} // namespace Ui

--- a/Telegram/SourceFiles/ui/widgets/widgets.style
+++ b/Telegram/SourceFiles/ui/widgets/widgets.style
@@ -1197,3 +1197,21 @@ InfoTopBar {
 	highlightBg: color;
 	highlightDuration: int;
 }
+
+LevelMeter {
+    height: pixels;
+	lineWidth: pixels;
+	lineSpacing: pixels;
+	lineCount: int;
+	activeFg: color;
+	inactiveFg: color;
+}
+
+defaultLevelMeter: LevelMeter {
+    height: 18px;
+	lineWidth: 3px;
+	lineSpacing: 5px;
+	lineCount: 44;
+	activeFg: mediaPlayerActiveFg;
+	inactiveFg: mediaPlayerInactiveFg;
+}

--- a/Telegram/gyp/telegram_sources.txt
+++ b/Telegram/gyp/telegram_sources.txt
@@ -62,6 +62,8 @@
 <(src_loc)/boxes/sessions_box.h
 <(src_loc)/boxes/share_box.cpp
 <(src_loc)/boxes/share_box.h
+<(src_loc)/boxes/single_choice_box.cpp
+<(src_loc)/boxes/single_choice_box.h
 <(src_loc)/boxes/sticker_set_box.cpp
 <(src_loc)/boxes/sticker_set_box.h
 <(src_loc)/boxes/stickers_box.cpp
@@ -576,6 +578,8 @@
 <(src_loc)/settings/settings_advanced.h
 <(src_loc)/settings/settings_chat.cpp
 <(src_loc)/settings/settings_chat.h
+<(src_loc)/settings/settings_calls.cpp
+<(src_loc)/settings/settings_calls.h
 <(src_loc)/settings/settings_codes.cpp
 <(src_loc)/settings/settings_codes.h
 <(src_loc)/settings/settings_common.cpp
@@ -688,6 +692,8 @@
 <(src_loc)/ui/widgets/input_fields.h
 <(src_loc)/ui/widgets/labels.cpp
 <(src_loc)/ui/widgets/labels.h
+<(src_loc)/ui/widgets/level_meter.cpp
+<(src_loc)/ui/widgets/level_meter.h
 <(src_loc)/ui/widgets/menu.cpp
 <(src_loc)/ui/widgets/menu.h
 <(src_loc)/ui/widgets/multi_select.cpp


### PR DESCRIPTION
This PR adds a new section to settings, allowing users to choose audio devices for calls, adjust volume, and disable audio ducking (on OS X).

Also, happy new year to everyone  🎅🏻🌲🎉