### PR TITLE
fixing mediaview fullscreen on X11

### DIFF
--- a/Telegram/SourceFiles/mediaview.cpp
+++ b/Telegram/SourceFiles/mediaview.cpp
@@ -138,10 +138,11 @@ MediaView::MediaView()
 	});
 	handleAuthSessionChange();
 
-	setWindowFlags(Qt::FramelessWindowHint);
+	setWindowFlags(Qt::FramelessWindowHint | Qt::MaximizeUsingFullscreenGeometryHint | Qt::WindowStaysOnTopHint);
 	moveToScreen();
 	setAttribute(Qt::WA_NoSystemBackground, true);
 	setAttribute(Qt::WA_TranslucentBackground, true);
+	setAttribute(Qt::WA_X11NetWmWindowTypeDock, true);
 	setMouseTracking(true);
 
 	hide();


### PR DESCRIPTION
This should fix #5607 , #5075 and #5048 
Tested in Arch Linux under KDE(kwin 5.14.90), i3wm (4.16) and AwesomeWM(4.2)