### PR TITLE
fixing mediaview fullscreen on X11

### DIFF
--- a/Telegram/SourceFiles/mediaview.cpp
+++ b/Telegram/SourceFiles/mediaview.cpp
@@ -138,7 +138,7 @@ MediaView::MediaView()
 	});
 	handleAuthSessionChange();
 
-	setWindowFlags(Qt::FramelessWindowHint);
+	setWindowFlags(Qt::FramelessWindowHint | Qt::MaximizeUsingFullscreenGeometryHint);
 	moveToScreen();
 	setAttribute(Qt::WA_NoSystemBackground, true);
 	setAttribute(Qt::WA_TranslucentBackground, true);
@@ -1774,7 +1774,7 @@ void MediaView::displayFinished() {
 	updateControls();
 	if (isHidden()) {
 		psUpdateOverlayed(this);
-		show();
+		showFullScreen();
 		psShowOverAll(this);
 		activateWindow();
 		Core::App().setActiveWindow(this);


### PR DESCRIPTION
Trying again to fix fullscreen of mediaview on X11, related to #5607 , #5075 and #5048.

Tested it fixed mediaview in Arch Linux under:
* KDE Plasma (kwin 5.14.90)
* i3wm (4.16)

But strangely AwesomeWM 4.2 still misplaced the fullscreen window. But previous version of awesome (3.4 tested) was able to show the fullscreen window correctly so I suspect there are some bugs with  awesomewm 4.2 's end.