### PR TITLE
Fixed a keeping online status after application quit.

### DIFF
--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -1039,6 +1039,11 @@ void Application::preventWindowActivation() {
 void Application::QuitAttempt() {
 	auto prevents = false;
 	if (AuthSession::Exists() && !Sandbox::Instance().isSavingSession()) {
+		if (auto mainwidget = App::main()) {
+			if (mainwidget->isQuitPrevent()) {
+				prevents = true;
+			}
+		}
 		if (Auth().api().isQuitPrevent()) {
 			prevents = true;
 		}

--- a/Telegram/SourceFiles/mainwidget.h
+++ b/Telegram/SourceFiles/mainwidget.h
@@ -300,6 +300,8 @@ public:
 	void notify_userIsBotChanged(UserData *bot);
 	void notify_historyMuteUpdated(History *history);
 
+	bool isQuitPrevent();
+
 	~MainWidget();
 
 signals:
@@ -444,6 +446,9 @@ private:
 
 	void viewsIncrementDone(QVector<MTPint> ids, const MTPVector<MTPint> &result, mtpRequestId req);
 	bool viewsIncrementFail(const RPCError &error, mtpRequestId req);
+
+	void updateStatusDone(const MTPBool &result);
+	bool updateStatusFail(const RPCError &error);
 
 	void refreshResizeAreas();
 	template <typename MoveCallback, typename FinishCallback>


### PR DESCRIPTION
[This issue](https://github.com/telegramdesktop/tdesktop/issues/5528) occurs because the application does not send the offline status when it quits.

Use case 1:
- User wants to quit the application.
- User opens a tray context menu by right click. — In this moment the main window loses focus and the application makes the status offline.
- User clicks "Quit Telegram". 
- Everything is okay.

Use case 2:
- User wants to quit the application.
- User presses `Ctrl + Q`.
- The application closes without changes of the online status.
- User is still online for awhile.

After this patch, user after pressing `Ctrl + Q` will have the offline status immediately.

