### PR TITLE
Improved "Create link" box title display.

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1409,7 +1409,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_menu_formatting_link_edit" = "Edit link";
 "lng_menu_formatting_clear" = "Plain text";
 "lng_formatting_link_create_title" = "Create link";
-"lng_formatting_link_edit_title" = "Create link";
+"lng_formatting_link_edit_title" = "Edit link";
 "lng_formatting_link_text" = "Text";
 "lng_formatting_link_url" = "URL";
 "lng_formatting_link_create" = "Create";

--- a/Telegram/SourceFiles/chat_helpers/message_field.cpp
+++ b/Telegram/SourceFiles/chat_helpers/message_field.cpp
@@ -155,7 +155,10 @@ void EditLinkBox::prepare() {
 		}
 	});
 
-	setTitle(langFactory(lng_formatting_link_create_title));
+	const auto title = url->getLastText().isEmpty()
+			? lng_formatting_link_create_title
+			: lng_formatting_link_edit_title;
+	setTitle(langFactory(title));
 
 	addButton(langFactory(lng_formatting_link_create), submit);
 	addButton(langFactory(lng_cancel), [=] { closeBox(); });


### PR DESCRIPTION
This PR slightly improves the display of the "Create link" box title.
When url in box already exists title changes to "Edit link".
Seems like the `lng_formatting_link_edit_title` key was created for this, but it was forgotten to insert in the code.

![image](https://user-images.githubusercontent.com/4051126/52668151-c95a2600-2f23-11e9-84e4-d86e20d240fd.png)  ![image](https://user-images.githubusercontent.com/4051126/52668114-b2b3cf00-2f23-11e9-8397-6c21da577b55.png)
