### PR TITLE
Fixed sending polls as reply to other messages.

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -5437,6 +5437,11 @@ void ApiWrap::createPoll(
 	if (options.replyTo) {
 		sendFlags |= MTPmessages_SendMedia::Flag::f_reply_to_msg_id;
 	}
+	if (options.clearDraft) {
+		sendFlags |= MTPmessages_SendMedia::Flag::f_clear_draft;
+		history->clearLocalDraft();
+		history->clearCloudDraft();
+	}
 	const auto channelPost = peer->isChannel() && !peer->isMegagroup();
 	const auto silentPost = channelPost
 		&& _session->data().notifySilentPosts(peer);

--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -1118,6 +1118,15 @@ bool MainWidget::historyInSelectionMode() const {
 	return _history->inSelectionMode();
 }
 
+MsgId MainWidget::currentReplyToIdFor(not_null<History*> history) const {
+	if (_history->history() == history) {
+		return _history->replyToId();
+	} else if (const auto localDraft = history->localDraft()) {
+		return localDraft->msgId;
+	}
+	return 0;
+}
+
 void MainWidget::sendBotCommand(PeerData *peer, UserData *bot, const QString &cmd, MsgId replyTo) {
 	_history->sendBotCommand(peer, bot, cmd, replyTo);
 }

--- a/Telegram/SourceFiles/mainwidget.h
+++ b/Telegram/SourceFiles/mainwidget.h
@@ -217,6 +217,8 @@ public:
 	TimeMs highlightStartTime(not_null<const HistoryItem*> item) const;
 	bool historyInSelectionMode() const;
 
+	MsgId currentReplyToIdFor(not_null<History*> history) const;
+
 	void sendBotCommand(PeerData *peer, UserData *bot, const QString &cmd, MsgId replyTo);
 	void hideSingleUseKeyboard(PeerData *peer, MsgId replyTo);
 	bool insertBotCommand(const QString &cmd);

--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
@@ -35,6 +35,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "data/data_poll.h"
 #include "data/data_channel.h"
 #include "data/data_chat.h"
+#include "data/data_drafts.h"
 #include "data/data_user.h"
 #include "dialogs/dialogs_key.h"
 
@@ -636,7 +637,14 @@ void PeerMenuCreatePoll(not_null<PeerData*> peer) {
 		if (std::exchange(*lock, true)) {
 			return;
 		}
-		const auto options = ApiWrap::SendOptions(peer->owner().history(peer));
+		auto options = ApiWrap::SendOptions(peer->owner().history(peer));
+		if (const auto id = App::main()->currentReplyToIdFor(options.history)) {
+			options.replyTo = id;
+		}
+		if (const auto localDraft = options.history->localDraft()) {
+			options.clearDraft = localDraft->textWithTags.text.isEmpty();
+		}
+
 		Auth().api().createPoll(result, options, crl::guard(box, [=] {
 			box->closeBox();
 		}), crl::guard(box, [=](const RPCError &error) {


### PR DESCRIPTION
This PR fixes [this one](https://github.com/telegramdesktop/tdesktop/issues/5550).
But I'm not completely sure about the way of my solution.
Particularly not sure about using of the `MainWidget` singleton method to pass the `replyToId` value, but it is easier than passing the value through 2 child classes.
Reading of the local draft is needed when a user is in `Channel/Group info` and wants to create the poll from there. 
Generally it works and repeats patterns of the Android client's behavior.