### PR TITLE
Removed unnecessary calling of saveDraftToCloud() method when quit.

### DIFF
--- a/Telegram/SourceFiles/app.cpp
+++ b/Telegram/SourceFiles/app.cpp
@@ -757,9 +757,6 @@ namespace App {
 				window->hide();
 			}
 		}
-		if (auto mainwidget = App::main()) {
-			mainwidget->saveDraftToCloud();
-		}
 		Core::Application::QuitAttempt();
 	}
 


### PR DESCRIPTION
Sorry for PR spamming. =) This one is pretty small.
As I said [here](https://github.com/telegramdesktop/tdesktop/pull/5618#issuecomment-458731027) before, after the fix of the online status while user quits, calling of `saveDraftToCloud()` became useless.

If user quits with offline status, his draft is already synced with the cloud.
If user quits with online status, his draft will be synced from `MainWidget::isQuitPrevent()`.