### PR TITLE
Fixed extra space in a name of the post author after forwarding message.

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -4242,7 +4242,7 @@ void ApiWrap::forwardMessages(
 					? UserId(0)
 					: peerToUser(self->id);
 				const auto messagePostAuthor = channelPost
-					? (self->firstName + ' ' + self->lastName)
+					? App::peerName(self)
 					: QString();
 				history->addNewForwarded(
 					newId.msg,
@@ -4323,7 +4323,7 @@ void ApiWrap::sendSharedContact(
 	}
 	const auto messageFromId = channelPost ? 0 : _session->userId();
 	const auto messagePostAuthor = channelPost
-		? (_session->user()->firstName + ' ' + _session->user()->lastName)
+		? App::peerName(_session->user())
 		: QString();
 	const auto vcard = QString();
 	const auto views = 1;


### PR DESCRIPTION
This PR fixes a pretty rare improper display of the post author.
If user has no the last name, his forwarded messages locally will be display with extra space in the author section.
So I unified the creation of the `messagePostAuthor` string in the `ApiWrap` class.

![image](https://user-images.githubusercontent.com/4051126/53290532-5ae45600-37b6-11e9-92f2-65aa6b97f6b4.png)