### PR TITLE
Added author of channel post in tooltip.

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1000,6 +1000,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_forwarded_via" = "Forwarded from {user} via {inline_bot}";
 "lng_forwarded_channel_via" = "Forwarded from {channel} via {inline_bot}";
 "lng_forwarded_signed" = "{channel} ({user})";
+"lng_signed_author" = "Author: {user}";
 "lng_in_reply_to" = "In reply to";
 "lng_edited" = "edited";
 "lng_edited_date" = "Edited: {date}";

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -3055,6 +3055,11 @@ QString HistoryInner::tooltipText() const {
 						QLocale::system().dateTimeFormat(
 							QLocale::LongFormat)));
 			}
+			if (const auto msgsigned = view->data()->Get<HistoryMessageSigned>()) {
+				if (msgsigned->isElided) {
+					dateText += '\n' + lng_signed_author(lt_user, msgsigned->author);
+				}
+			}
 			return dateText;
 		}
 	} else if (_mouseCursorState == CursorState::Forwarded

--- a/Telegram/SourceFiles/history/history_item_components.cpp
+++ b/Telegram/SourceFiles/history/history_item_components.cpp
@@ -50,11 +50,12 @@ void HistoryMessageVia::resize(int32 availw) const {
 }
 
 void HistoryMessageSigned::refresh(const QString &date) {
-	auto time = qsl(", ") + date;
 	auto name = author;
-	auto timew = st::msgDateFont->width(time);
-	auto namew = st::msgDateFont->width(name);
-	if (timew + namew > st::maxSignatureSize) {
+	const auto time = qsl(", ") + date;
+	const auto timew = st::msgDateFont->width(time);
+	const auto namew = st::msgDateFont->width(name);
+	isElided = (timew + namew > st::maxSignatureSize);
+	if (isElided) {
 		name = st::msgDateFont->elided(author, st::maxSignatureSize - timew);
 	}
 	signature.setText(

--- a/Telegram/SourceFiles/history/history_item_components.h
+++ b/Telegram/SourceFiles/history/history_item_components.h
@@ -37,6 +37,7 @@ struct HistoryMessageSigned : public RuntimeComponent<HistoryMessageSigned, Hist
 	void refresh(const QString &date);
 	int maxWidth() const;
 
+	bool isElided = false;
 	QString author;
 	Text signature;
 };


### PR DESCRIPTION
When the author name of the channel post is too long, it is possible to see the author from the message header only when you forward this post to another chat.
So PR adds the author of the channel post in the tooltip when it is cut off.
Also this PR closes [this one](https://github.com/telegramdesktop/tdesktop/issues/5510).

![image](https://user-images.githubusercontent.com/4051126/53297705-51e59a00-3833-11e9-800e-ea2c59611c12.png)

![image](https://user-images.githubusercontent.com/4051126/53297761-316a0f80-3834-11e9-8283-3a9c89b9f0c1.png)

