### PR TITLE
Allow searching for messages by a user who has left a chat, fixes #5667

### DIFF
--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -281,6 +281,8 @@ void AddSpecialBoxController::prepare() {
 	delegate()->peerListSetSearchMode(PeerListSearchMode::Enabled);
 	const auto title = [&] {
 		switch (_role) {
+		case Role::Members:
+			return langFactory(lng_profile_participants_section);
 		case Role::Admins:
 			return langFactory(lng_channel_add_admin);
 		case Role::Restricted:
@@ -412,6 +414,7 @@ void AddSpecialBoxController::loadMoreRows() {
 void AddSpecialBoxController::rowClicked(not_null<PeerListRow*> row) {
 	auto user = row->peer()->asUser();
 	switch (_role) {
+	case Role::Members: return;
 	case Role::Admins: return showAdmin(user);
 	case Role::Restricted: return showRestricted(user);
 	case Role::Kicked: return kickUser(user);

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
@@ -19,18 +19,15 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Dialogs {
 
 void ShowSearchFromBox(
-		not_null<Window::Navigation*> navigation,
 		not_null<PeerData*> peer,
 		Fn<void(not_null<UserData*>)> callback,
 		Fn<void()> closedCallback) {
 	auto createController = [
-		navigation,
 		peer,
 		callback = std::move(callback)
 	]() -> std::unique_ptr<PeerListController> {
 		if (peer && (peer->isChat() || peer->isMegagroup())) {
 			return std::make_unique<Dialogs::SearchFromController>(
-				navigation,
 				peer,
 				std::move(callback));
 		}
@@ -50,7 +47,6 @@ void ShowSearchFromBox(
 }
 
 SearchFromController::SearchFromController(
-	not_null<Window::Navigation*> navigation,
 	not_null<PeerData*> peer,
 	Fn<void(not_null<UserData*>)> callback)
 : AddSpecialBoxController(

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
@@ -53,15 +53,16 @@ SearchFromController::SearchFromController(
 	not_null<Window::Navigation*> navigation,
 	not_null<PeerData*> peer,
 	Fn<void(not_null<UserData*>)> callback)
-: ParticipantsBoxController(
-	navigation,
+: AddSpecialBoxController(
 	peer,
-	ParticipantsBoxController::Role::Members)
+	ParticipantsBoxController::Role::Members,
+	AdminDoneCallback(),
+	BannedDoneCallback())
 , _callback(std::move(callback)) {
 }
 
 void SearchFromController::prepare() {
-	ParticipantsBoxController::prepare();
+	AddSpecialBoxController::prepare();
 	delegate()->peerListSetTitle(langFactory(lng_search_messages_from));
 }
 

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
@@ -14,7 +14,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Dialogs {
 
 void ShowSearchFromBox(
-	not_null<Window::Navigation*> navigation,
 	not_null<PeerData*> peer,
 	Fn<void(not_null<UserData*>)> callback,
 	Fn<void()> closedCallback);
@@ -22,7 +21,6 @@ void ShowSearchFromBox(
 class SearchFromController : public AddSpecialBoxController {
 public:
 	SearchFromController(
-		not_null<Window::Navigation*> navigation,
 		not_null<PeerData*> peer,
 		Fn<void(not_null<UserData*>)> callback);
 

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "boxes/peer_list_box.h"
 #include "boxes/peers/edit_participants_box.h"
+#include "boxes/peers/add_participants_box.h"
 
 namespace Dialogs {
 
@@ -18,7 +19,7 @@ void ShowSearchFromBox(
 	Fn<void(not_null<UserData*>)> callback,
 	Fn<void()> closedCallback);
 
-class SearchFromController : public ParticipantsBoxController {
+class SearchFromController : public AddSpecialBoxController {
 public:
 	SearchFromController(
 		not_null<Window::Navigation*> navigation,
@@ -29,7 +30,7 @@ public:
 	void rowClicked(not_null<PeerListRow*> row) override;
 
 protected:
-	std::unique_ptr<PeerListRow> createRow(not_null<UserData*> user) const override;
+	std::unique_ptr<PeerListRow> createRow(not_null<UserData*> user) const;
 
 private:
 	Fn<void(not_null<UserData*>)> _callback;

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -1229,7 +1229,6 @@ void DialogsWidget::showSearchFrom() {
 	if (const auto peer = _searchInChat.peer()) {
 		const auto chat = _searchInChat;
 		Dialogs::ShowSearchFromBox(
-			controller(),
 			peer,
 			crl::guard(this, [=](not_null<UserData*> user) {
 				Ui::hideLayer();


### PR DESCRIPTION
fixes #5667 

Change `Dialog::SearchFromController` to inherit not from`ParticipantsBoxController`, which only shows the users in the group, but instead from`AddSpecialBoxController` which shows the group's users but falls back on global search as well.

I know you don't generally accept pull requests for features and calling this a bug is very borderline but I figured I'd post it anyway.