### PR TITLE
Added handler for "MESSAGE_EMPTY" error to delete a local message.

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -4628,7 +4628,11 @@ void ApiWrap::sendMessage(MessageToSend &&message) {
 			applyUpdates(result, randomId);
 			history->clearSentDraftText(QString());
 		}).fail([=](const RPCError &error) {
-			sendMessageFail(error);
+			if (error.type() == qstr("MESSAGE_EMPTY")) {
+				lastMessage->destroy();
+			} else {
+				sendMessageFail(error);
+			}
 			history->clearSentDraftText(QString());
 		}).afterRequest(history->sendRequestId
 		).send();

--- a/Telegram/SourceFiles/ui/text/text.h
+++ b/Telegram/SourceFiles/ui/text/text.h
@@ -261,7 +261,7 @@ QString textcmdStopSemibold();
 const QChar *textSkipCommand(const QChar *from, const QChar *end, bool canLink = true);
 
 inline bool chIsSpace(QChar ch, bool rich = false) {
-	return ch.isSpace() || (ch < 32 && !(rich && ch == TextCommand)) || (ch == QChar::ParagraphSeparator) || (ch == QChar::LineSeparator) || (ch == QChar::ObjectReplacementCharacter) || (ch == QChar::CarriageReturn) || (ch == QChar::Tabulation);
+	return ch.isSpace() || (ch < 32 && !(rich && ch == TextCommand)) || (ch == QChar::ParagraphSeparator) || (ch == QChar::LineSeparator) || (ch == QChar::ObjectReplacementCharacter) || (ch == QChar::CarriageReturn) || (ch == QChar::Tabulation) || (ch == QChar(8203)/*Zero width space.*/);
 }
 inline bool chIsDiac(QChar ch) { // diac and variation selectors
 	return (ch.category() == QChar::Mark_NonSpacing) || (ch == 1652) || (ch >= 64606 && ch <= 64611);


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/telegramdesktop/tdesktop/issues/3145).
In another sending methods the zero width space is handled fine.
Perhaps the message box is unnecessary.


![image](https://user-images.githubusercontent.com/4051126/53299765-11484980-3850-11e9-941d-b41cb5fa0053.gif)
