### PR TITLE
Added scroll animation in dialogs list when it scrolls to top.

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -333,7 +333,25 @@ void DialogsWidget::dialogsToUp() {
 		return;
 	}
 	if (_filter->getLastText().trimmed().isEmpty() && !_searchInChat) {
-		_scroll->scrollToY(0);
+		_scrollToAnimation.finish();
+		auto scrollTop = _scroll->scrollTop();
+		const auto scrollTo = 0;
+		const auto maxAnimatedDelta = _scroll->height();
+		if (scrollTo + maxAnimatedDelta < scrollTop) {
+			scrollTop = scrollTo + maxAnimatedDelta;
+			_scroll->scrollToY(scrollTop);
+		}
+
+		const auto scroll = [&] {
+			_scroll->scrollToY(qRound(_scrollToAnimation.current()));
+		};
+
+		_scrollToAnimation.start(
+			scroll,
+			scrollTop,
+			scrollTo,
+			st::slideDuration,
+			anim::sineInOut);
 	}
 }
 

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.h
@@ -199,6 +199,7 @@ private:
 	object_ptr<BottomButton> _loadMoreChats = { nullptr };
 	std::unique_ptr<Window::ConnectionState> _connecting;
 
+	Animation _scrollToAnimation;
 	Animation _a_show;
 	Window::SlideDirection _showDirection;
 	QPixmap _cacheUnder, _cacheOver;


### PR DESCRIPTION
It's a bit sad that there is scroll animation in the dialogs, but not in the dialog list. =(
So I added an animation to the scroll when it goes to top (e.g. the user pins the dialog).
The animation of the scroll to top repeats patterns of the scroll animation's behavior in the dialogs.


![image](https://user-images.githubusercontent.com/4051126/53305531-9e60c200-3893-11e9-85cc-cb38a3fb3d44.gif)
