### PR TITLE
Added forwarded info in tooltip of sticker.

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -3054,6 +3054,13 @@ QString HistoryInner::tooltipText() const {
 					ParseDateTime(forwarded->originalDate).toString(
 						QLocale::system().dateTimeFormat(
 							QLocale::LongFormat)));
+				if (const auto media = view->media()) {
+					if (media->hidesForwardedInfo()) {
+						dateText += "\n" + lng_forwarded(
+							lt_user, 
+							forwarded->originalSender->shortName());
+					}
+				}
 			}
 			return dateText;
 		}

--- a/Telegram/SourceFiles/history/media/history_media.h
+++ b/Telegram/SourceFiles/history/media/history_media.h
@@ -201,6 +201,10 @@ public:
 		return false;
 	}
 
+	[[nodiscard]] virtual bool hidesForwardedInfo() const {
+		return false;
+	}
+
 	// Sometimes webpages can force the bubble to fit their size instead of
 	// allowing message text to be as wide as possible (like wallpapers).
 	[[nodiscard]] virtual bool enforceBubbleWidth() const {

--- a/Telegram/SourceFiles/history/media/history_media_sticker.h
+++ b/Telegram/SourceFiles/history/media/history_media_sticker.h
@@ -45,6 +45,9 @@ public:
 	QString emoji() const {
 		return _emoji;
 	}
+	bool hidesForwardedInfo() const override {
+		return true;
+	}
 
 private:
 	QSize countOptimalSize() override;


### PR DESCRIPTION
Unfortunately, it is almost impossible to get the information from whom the sticker was forwarded.
The only way to see that is to start forwarding this forwarded sticker to someone, then it will be seen who the original author.
![image](https://user-images.githubusercontent.com/4051126/53679105-09b5f400-3cd9-11e9-9605-0a58ee87de4c.png)


So this PR added a little more information in the tooltip of forwarded stickers.
![image](https://user-images.githubusercontent.com/4051126/53679118-4d106280-3cd9-11e9-8436-3df38ab18110.png)
