### PR TITLE
 Added grouping of album files into a single notification.

### DIFF
--- a/Telegram/SourceFiles/data/data_media_types.cpp
+++ b/Telegram/SourceFiles/data/data_media_types.cpp
@@ -301,14 +301,12 @@ QString MediaPhoto::notificationText() const {
 	return WithCaptionNotificationText(
 		lang(lng_in_dlg_photo),
 		parent()->originalText().text);
-	//return WithCaptionNotificationText(lang(lng_in_dlg_album), _caption);
 }
 
 QString MediaPhoto::chatListText() const {
 	return WithCaptionDialogsText(
 		lang(lng_in_dlg_photo),
 		parent()->originalText().text);
-	//return WithCaptionDialogsText(lang(lng_in_dlg_album), _caption);
 }
 
 QString MediaPhoto::pinnedTextSubstring() const {

--- a/Telegram/SourceFiles/history/history_item.cpp
+++ b/Telegram/SourceFiles/history/history_item.cpp
@@ -706,6 +706,9 @@ QString HistoryItem::notificationText() const {
 QString HistoryItem::inDialogsText(DrawInDialog way) const {
 	auto getText = [this]() {
 		if (_media) {
+			if (_groupId) {
+				return textcmdLink(1, TextUtilities::Clean(lang(lng_in_dlg_album)));
+			}
 			return _media->chatListText();
 		} else if (!emptyText()) {
 			return TextUtilities::Clean(_text.originalText());

--- a/Telegram/SourceFiles/window/notifications_manager.h
+++ b/Telegram/SourceFiles/window/notifications_manager.h
@@ -79,6 +79,7 @@ public:
 
 private:
 	void showNext();
+	void showGrouped();
 	void ensureSoundCreated();
 
 	AuthSession *_authSession = nullptr;
@@ -99,6 +100,7 @@ private:
 	Waiters _waiters;
 	Waiters _settingWaiters;
 	base::Timer _waitTimer;
+	base::Timer _waitForAllGroupedTimer;
 
 	QMap<History*, QMap<crl::time, PeerData*>> _whenAlerts;
 
@@ -108,6 +110,9 @@ private:
 
 	std::unique_ptr<Media::Audio::Track> _soundTrack;
 
+	int _lastForwardedCount = 0;
+	FullMsgId _lastHistoryItemId;
+	
 };
 
 class Manager {


### PR DESCRIPTION
It is pretty annoying when someone sends you an album and you get several notifications of the same message.
So this PR combines the album messages in the single notification.
### The first commit.
![image](https://user-images.githubusercontent.com/4051126/53694700-9dfc8580-3dc3-11e9-9ac2-6acf0e601f74.gif)

![image](https://user-images.githubusercontent.com/4051126/53694727-0186b300-3dc4-11e9-8479-c5999d4fe264.gif)

In the code.
I have noticed that the album grouping algorithm is very similar to the forwarded messages grouping algorithm. So I crossed them. A process is almost the same. In addition to checking the author of forwarded messages, I added checking the `groupId()`.

Also.
The `forwardedItem` was renamed to `forwardedOrGroupedItem`.

Removed unused `lng_in_dlg_album` keys in `MediaPhoto`, seems like it will never be used.
https://github.com/telegramdesktop/tdesktop/blob/e70465c633e03bbda2847f6cc42f892e1674c17a/Telegram/SourceFiles/data/data_media_types.cpp#L300-L312

Removed unused `ms` in `System::showNext()`.
https://github.com/telegramdesktop/tdesktop/blob/e70465c633e03bbda2847f6cc42f892e1674c17a/Telegram/SourceFiles/window/notifications_manager.cpp#L313

Refactored a multiple `nextNotify = nullptr;` with the `continue;`. It allows not to use several `} else {` with the same single line.
https://github.com/telegramdesktop/tdesktop/blob/e70465c633e03bbda2847f6cc42f892e1674c17a/Telegram/SourceFiles/window/notifications_manager.cpp#L344-L352

### The second commit.
The second commit is pretty related to grouping of notifications.
If the user receives a lot of forwarded messages, notifications will be divided into random parts.
The second commit adds a small delay so that the Telegram has time to load all the forwarded messages and show the single notification. The album grouping is also subject to this issue, so I put fix to this PR too. I tried to cover the code with comments, because it is easy to get confused by timers.

![image](https://user-images.githubusercontent.com/4051126/53694945-490e3e80-3dc6-11e9-9a45-68c0e90af66c.gif)
![image](https://user-images.githubusercontent.com/4051126/53694957-5297a680-3dc6-11e9-81b5-adfa3f55403a.gif)