### PR TITLE
Fixed crash in window resizing when layer is opened.

### DIFF
--- a/Telegram/SourceFiles/info/info_section_widget.cpp
+++ b/Telegram/SourceFiles/info/info_section_widget.cpp
@@ -53,7 +53,7 @@ void SectionWidget::init() {
 	_content->contentChanged(
 	) | rpl::start_with_next([=] {
 		_connecting->raise();
-	}, _content->lifetime());
+	}, _connecting->lifetime());
 }
 
 Dialogs::RowDescriptor SectionWidget::activeChat() const {


### PR DESCRIPTION
#### Steps to reproduce:
1. Resize the window to minimum width.
2. Open `View profile`/`View channel info`/`Settings`.
3. Maximize the window.
4. Return size of the window.
5. Crash.

The crash is due to the connection icon that was optimized here 26f1ade5ba22b2b351b12e3ce8cc179f2e013758.

![image](https://user-images.githubusercontent.com/4051126/53702274-49362a80-3e16-11e9-8f1c-de3ee7abaaac.gif)
