### PR TITLE
Updated libvdpau to 1.2.

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -314,6 +314,7 @@ buildVdpau() {
   git clone git://anongit.freedesktop.org/vdpau/libvdpau
 
   cd "$EXTERNAL/libvdpau"
+  git checkout libvdpau-1.2
   ./autogen.sh --prefix=$VDPAU_PATH --enable-static
   make $MAKE_ARGS
   sudo make install

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -64,6 +64,7 @@ Go to ***BuildPath*** and run
 
     git clone git://anongit.freedesktop.org/vdpau/libvdpau
     cd libvdpau
+    git checkout libvdpau-1.2
     ./autogen.sh --enable-static
     make $MAKE_THREADS_CNT
     sudo make install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -176,6 +176,7 @@ parts:
   libvdpau:
     source: git://anongit.freedesktop.org/vdpau/libvdpau
     source-depth: 1
+    source-branch: libvdpau-1.2
     plugin: autotools
     build-packages:
       - libx11-dev


### PR DESCRIPTION
Unfortunately, a few days ago the `libvdpau` repository switched to the Meson Build System and removed the `autogen.sh` shell file.
But before doing that, devs kindly created the `libvdpau-1.2` tag.
TDesktop doesn't use the Meson system anywhere, so we'll probably have to stay on that version for now.

<details><summary>Git Log</summary><blockquote>

![image](https://user-images.githubusercontent.com/4051126/53829122-7b6b9780-3f90-11e9-83a4-0b8631d9ffa1.png)

</blockquote></details>