### PR TITLE
Added Search Shortcut in Shared Media.

### DIFF
--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
+++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
@@ -328,7 +328,7 @@ void Widget::setupShortcuts() {
 		return isActiveWindow() && !Ui::isLayerShown() && inFocusChain();
 	}) | rpl::start_with_next([=](not_null<Shortcuts::Request*> request) {
 		using Command = Shortcuts::Command;
-		request->check(Command::Search, 1) && request->handle([=] {
+		request->check(Command::Search, 2) && request->handle([=] {
 			_fixedBar->showSearch();
 			return true;
 		});

--- a/Telegram/SourceFiles/history/feed/history_feed_section.cpp
+++ b/Telegram/SourceFiles/history/feed/history_feed_section.cpp
@@ -303,7 +303,7 @@ void Widget::setupShortcuts() {
 		return isActiveWindow() && !Ui::isLayerShown() && inFocusChain();
 	}) | rpl::start_with_next([=](not_null<Shortcuts::Request*> request) {
 		using Command = Shortcuts::Command;
-		request->check(Command::Search, 1) && request->handle([=] {
+		request->check(Command::Search, 2) && request->handle([=] {
 			App::main()->searchInChat(_feed);
 			return true;
 		});

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -1321,7 +1321,7 @@ void HistoryWidget::setupShortcuts() {
 	}) | rpl::start_with_next([=](not_null<Shortcuts::Request*> request) {
 		using Command = Shortcuts::Command;
 		if (_history) {
-			request->check(Command::Search) && request->handle([=] {
+			request->check(Command::Search, 1) && request->handle([=] {
 				App::main()->searchInChat(_history);
 				return true;
 			});

--- a/Telegram/SourceFiles/info/info_top_bar.cpp
+++ b/Telegram/SourceFiles/info/info_top_bar.cpp
@@ -213,10 +213,7 @@ void TopBar::createSearchView(
 
 	auto button = base::make_unique_q<Ui::IconButton>(this, _st.search);
 	auto search = button.get();
-	search->addClickHandler([=] {
-		_searchModeEnabled = true;
-		updateControlsVisibility(anim::type::normal);
-	});
+	search->addClickHandler([=] { showSearch(); });
 	auto searchWrap = pushButton(std::move(button));
 	registerToggleControlCallback(searchWrap, [=] {
 		return !selectionMode()
@@ -284,6 +281,11 @@ void TopBar::createSearchView(
 		_searchModeAvailable = visible || alreadyInSearch;
 		updateControlsVisibility(anim::type::instant);
 	}, wrap->lifetime());
+}
+
+void TopBar::showSearch() {
+	_searchModeEnabled = true;
+	updateControlsVisibility(anim::type::normal);
 }
 
 void TopBar::removeButton(not_null<Ui::RpWidget*> button) {

--- a/Telegram/SourceFiles/info/info_top_bar.h
+++ b/Telegram/SourceFiles/info/info_top_bar.h
@@ -82,6 +82,8 @@ public:
 		updateControlsVisibility(anim::type::instant);
 	}
 
+	void showSearch();
+
 protected:
 	int resizeGetHeight(int newWidth) override;
 	void paintEvent(QPaintEvent *e) override;

--- a/Telegram/SourceFiles/info/info_wrap_widget.cpp
+++ b/Telegram/SourceFiles/info/info_wrap_widget.cpp
@@ -21,6 +21,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/wrap/fade_wrap.h"
 #include "ui/search_field_controller.h"
 #include "calls/calls_instance.h"
+#include "core/shortcuts.h"
 #include "window/window_controller.h"
 #include "window/window_slide_animation.h"
 #include "window/window_peer_menu.h"
@@ -76,6 +77,19 @@ WrapWidget::WrapWidget(
 		});
 	}, lifetime());
 	restoreHistoryStack(memento->takeStack());
+}
+
+void WrapWidget::setupShortcuts() {
+	Shortcuts::Requests(
+	) | rpl::filter([=] {
+		return requireTopBarSearch();
+	}) | rpl::start_with_next([=](not_null<Shortcuts::Request*> request) {
+		using Command = Shortcuts::Command;
+		request->check(Command::Search) && request->handle([=] {
+			_topBar->showSearch();
+			return true;
+		});
+	}, lifetime());
 }
 
 void WrapWidget::restoreHistoryStack(
@@ -377,6 +391,7 @@ void WrapWidget::createTopBar() {
 	} else if (requireTopBarSearch()) {
 		auto search = _controller->searchFieldController();
 		Assert(search != nullptr);
+		setupShortcuts();
 		_topBar->createSearchView(
 			search,
 			_controller->searchEnabledByContent(),

--- a/Telegram/SourceFiles/info/info_wrap_widget.h
+++ b/Telegram/SourceFiles/info/info_wrap_widget.h
@@ -171,6 +171,7 @@ private:
 	//void createTabs();
 	void createTopBar();
 	void highlightTopBar();
+	void setupShortcuts();
 
 	not_null<RpWidget*> topWidget() const;
 


### PR DESCRIPTION
This PR closes #5756.

In the code.
I moved a lambda of the search button into a separated method to avoid repeating parts of the code and to make it possible to call this method from the parent class.
Also I added shortcut as `Command::Search` instead of `Ctrl + F` to reach more flexibility.
