### PR TITLE
Added Shortcut to jump to the Saved Messages.

### DIFF
--- a/Telegram/SourceFiles/core/shortcuts.cpp
+++ b/Telegram/SourceFiles/core/shortcuts.cpp
@@ -66,6 +66,7 @@ const auto CommandByName = base::flat_map<QString, Command>{
 	{ qsl("next_chat")        , Command::ChatNext },
 	{ qsl("first_chat")       , Command::ChatFirst },
 	{ qsl("last_chat")        , Command::ChatLast },
+	{ qsl("self_chat")        , Command::ChatSelf },
 };
 
 const auto CommandNames = base::flat_map<Command, QString>{
@@ -87,6 +88,7 @@ const auto CommandNames = base::flat_map<Command, QString>{
 	{ Command::ChatNext      , qsl("next_chat") },
 	{ Command::ChatFirst     , qsl("first_chat") },
 	{ Command::ChatLast      , qsl("last_chat") },
+	{ Command::ChatSelf      , qsl("self_chat") },
 };
 
 class Manager {
@@ -320,6 +322,8 @@ void Manager::fillDefaults() {
 	set(qsl("ctrl+3"), Command::ChatPinned3);
 	set(qsl("ctrl+4"), Command::ChatPinned4);
 	set(qsl("ctrl+5"), Command::ChatPinned5);
+
+	set(qsl("ctrl+0"), Command::ChatSelf);
 }
 
 void Manager::writeDefaultFile() {

--- a/Telegram/SourceFiles/core/shortcuts.h
+++ b/Telegram/SourceFiles/core/shortcuts.h
@@ -28,6 +28,7 @@ enum class Command {
 	ChatNext,
 	ChatFirst,
 	ChatLast,
+	ChatSelf,
 	ChatPinned1,
 	ChatPinned2,
 	ChatPinned3,

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -2915,6 +2915,10 @@ void DialogsInner::setupShortcuts() {
 		request->check(Command::ChatLast) && request->handle([=] {
 			return jumpToDialogRow(last);
 		});
+		request->check(Command::ChatSelf) && request->handle([] {
+			App::main()->choosePeer(Auth().userPeerId(), ShowAtUnreadMsgId);
+			return true;
+		});
 
 		static const auto kPinned = {
 			Command::ChatPinned1,


### PR DESCRIPTION
It is a little bit sad that we have `Ctrl+1-5` shortcuts for pinned dialogs, but still have no shortcut for the Saved Messages.
We just have to have it. =)
And of course it should be editable.