### PR TITLE
Removed "Export history" from context menu for empty chats.

### DIFF
--- a/Telegram/SourceFiles/data/data_peer.cpp
+++ b/Telegram/SourceFiles/data/data_peer.cpp
@@ -7,8 +7,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "data/data_peer.h"
 
-#include <rpl/filter.h>
-#include <rpl/map.h>
 #include "data/data_user.h"
 #include "data/data_chat.h"
 #include "data/data_channel.h"
@@ -26,6 +24,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/image/image.h"
 #include "ui/empty_userpic.h"
 #include "ui/text_options.h"
+#include "history/history.h"
+#include "history/view/history_view_element.h"
+#include "history/history_item.h"
 
 namespace {
 
@@ -374,6 +375,17 @@ void PeerData::setPinnedMessageId(MsgId messageId) {
 			this,
 			Notify::PeerUpdate::Flag::PinnedMessageChanged);
 	}
+}
+
+bool PeerData::canExportChatHistory() const {
+	for (const auto &block : _owner->history(id)->blocks) {
+		for (const auto &message : block->messages) {
+			if (!message->data()->serviceMsg()) {
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 bool PeerData::setAbout(const QString &newAbout) {

--- a/Telegram/SourceFiles/data/data_peer.h
+++ b/Telegram/SourceFiles/data/data_peer.h
@@ -274,6 +274,8 @@ public:
 		setPinnedMessageId(0);
 	}
 
+	[[nodiscard]] bool canExportChatHistory() const;
+
 	// Returns true if about text was changed.
 	bool setAbout(const QString &newAbout);
 	const QString &about() const {

--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
@@ -336,9 +336,11 @@ void Filler::addUserActions(not_null<UserData*> user) {
 				lang(lng_profile_invite_to_group),
 				[user] { AddBotToGroupBoxController::Start(user); });
 		}
-		_addAction(
-			lang(lng_profile_export_chat),
-			[=] { PeerMenuExportChat(user); });
+		if (user->canExportChatHistory()) {
+			_addAction(
+				lang(lng_profile_export_chat),
+				[=] { PeerMenuExportChat(user); });
+		}
 	}
 	_addAction(
 		lang(lng_profile_delete_conversation),
@@ -369,9 +371,11 @@ void Filler::addChatActions(not_null<ChatData*> chat) {
 				lang(lng_polls_create),
 				[=] { PeerMenuCreatePoll(chat); });
 		}
-		_addAction(
-			lang(lng_profile_export_chat),
-			[=] { PeerMenuExportChat(chat); });
+		if (chat->canExportChatHistory()) {
+			_addAction(
+				lang(lng_profile_export_chat),
+				[=] { PeerMenuExportChat(chat); });
+		}
 	}
 	_addAction(
 		lang(lng_profile_clear_and_exit),
@@ -411,11 +415,13 @@ void Filler::addChannelActions(not_null<ChannelData*> channel) {
 				lang(lng_polls_create),
 				[=] { PeerMenuCreatePoll(channel); });
 		}
-		_addAction(
-			lang(isGroup
-				? lng_profile_export_chat
-				: lng_profile_export_channel),
-			[=] { PeerMenuExportChat(channel); });
+		if (channel->canExportChatHistory()) {
+			_addAction(
+				lang(isGroup
+					? lng_profile_export_chat
+					: lng_profile_export_channel),
+				[=] { PeerMenuExportChat(channel); });
+		}
 	}
 	if (channel->amIn()) {
 		if (isGroup && !channel->isPublic()) {


### PR DESCRIPTION
There's nothing to export, so we don't need this option when chat is empty.

![image](https://user-images.githubusercontent.com/4051126/54740070-4fc0f200-4bcb-11e9-8921-d51b339013d3.png)
