### PR TITLE
Do not upload wallpaper after updating

### DIFF
--- a/Telegram/SourceFiles/window/themes/window_theme.cpp
+++ b/Telegram/SourceFiles/window/themes/window_theme.cpp
@@ -389,11 +389,7 @@ void ChatBackground::start() {
 }
 
 void ChatBackground::refreshSession() {
-	const auto session = AuthSession::Exists() ? &Auth() : nullptr;
-	if (_session != session) {
-		_session = session;
-		checkUploadWallPaper();
-	}
+	_session = AuthSession::Exists() ? &Auth() : nullptr;
 }
 
 void ChatBackground::checkUploadWallPaper() {


### PR DESCRIPTION
 * This behaviour may be unexpected for a user and cause to leak private pictures to the remote server.
 * The patch prevents the checkUploadWallPaper() method from being called during startup initialization. The user still has an opportunity to send his subsequent wallpapers to Telegram Cloud. To do this, he can click on the link "Choose from file".