### PR TITLE
Fixed checking of media editing in FileLoadTask.

### DIFF
--- a/Telegram/SourceFiles/boxes/edit_caption_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_caption_box.cpp
@@ -726,7 +726,9 @@ void EditCaptionBox::paintEvent(QPaintEvent *e) {
 			nameright = 0;
 			statustop = st::msgFileStatusTop - st::msgFilePadding.top();
 		}
-		const auto editButton = _editMedia->width() + st::editMediaButtonSkip;
+		const auto editButton = _isAllowedEditMedia
+			? _editMedia->width() + st::editMediaButtonSkip
+			: 0;
 		const auto namewidth = w - nameleft - editButton;
 		const auto x = (width() - w) / 2, y = st::boxPhotoPadding.top();
 

--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -539,6 +539,7 @@ FileLoadTask::FileLoadTask(
 , _type(type)
 , _caption(caption)
 , _msgIdToEdit(msgIdToEdit) {
+	Expects(_msgIdToEdit == 0 || IsServerMsgId(_msgIdToEdit));
 }
 
 FileLoadTask::FileLoadTask(

--- a/Telegram/SourceFiles/storage/localimageloader.h
+++ b/Telegram/SourceFiles/storage/localimageloader.h
@@ -323,7 +323,7 @@ private:
 	VoiceWaveform _waveform;
 	SendMediaType _type;
 	TextWithTags _caption;
-	MsgId _msgIdToEdit;
+	MsgId _msgIdToEdit = 0;
 
 	std::shared_ptr<FileLoadResult> _result;
 


### PR DESCRIPTION
In the code.

`editButton` should be calculated only if editing of media is allowed.
https://github.com/telegramdesktop/tdesktop/blob/14de1fe4858107bf8719191893e144681e09418f/Telegram/SourceFiles/boxes/edit_caption_box.cpp#L727-L731

