### PR TITLE
Linux: manually set desktop file name

### DIFF
--- a/Telegram/SourceFiles/core/launcher.cpp
+++ b/Telegram/SourceFiles/core/launcher.cpp
@@ -208,6 +208,9 @@ void Launcher::init() {
 
 	QApplication::setApplicationName(qsl("TelegramDesktop"));
 
+#if defined(Q_OS_LINUX) && QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+	QApplication::setDesktopFileName(qsl("telegramdesktop.desktop"));
+#endif
 #ifndef OS_MAC_OLD
 	QApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
 #endif // OS_MAC_OLD


### PR DESCRIPTION
the binary name deviates from the default .desktop name, setting it manually fixes the not displayed icon on Wayland mentioned in #5180

https://github.com/qt/qtwayland/blob/5.12/src/client/qwaylandwindow.cpp#L149