### PR TITLE
Fixed AppData validation error

### DIFF
--- a/lib/xdg/telegramdesktop.appdata.xml
+++ b/lib/xdg/telegramdesktop.appdata.xml
@@ -26,15 +26,13 @@
     <keywords>
         <keyword>tg</keyword>
         <keyword>telegram</keyword>
-        <keyword>tdesktoo</keyword>
+        <keyword>tdesktop</keyword>
         <keyword>messaging</keyword>
         <keyword>messenger</keyword>
         <keyword>chat</keyword>
         <keyword>sms</keyword>
         <keyword>im</keyword>
     </keywords>
-    <releases>
-    </releases>
     <content_rating type="oars-1.1">
         <content_attribute id="violence-cartoon">none</content_attribute>
         <content_attribute id="violence-fantasy">none</content_attribute>


### PR DESCRIPTION
Fixed AppData validation error: tags cannot be empty.

Before:
```
$ appstream-util validate-relax --nonet telegramdesktop.appdata.xml
telegramdesktop.appdata.xml: FAILED:
• tag-invalid           : Expected children for tag
Validation of files failed
```

After:
```
$ appstream-util validate-relax --nonet telegramdesktop.appdata.xml
telegramdesktop.appdata.xml: OK
```