### PR TITLE
Fix stickers sending as photos in certain situations

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -3088,7 +3088,7 @@ void HistoryWidget::chooseAttach() {
 			if (list.allFilesForCompress || list.albumIsPossible) {
 				confirmSendingFiles(std::move(list), CompressConfirm::Auto);
 			} else if (!showSendingFilesError(list)) {
-				uploadFiles(std::move(list), SendMediaType::File);
+				confirmSendingFiles(std::move(list), CompressConfirm::No);
 			}
 		}
 	}));

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -3085,7 +3085,11 @@ void HistoryWidget::chooseAttach() {
 			auto list = Storage::PrepareMediaList(
 				result.paths,
 				st::sendMediaPreviewSize);
-			confirmSendingFiles(std::move(list), CompressConfirm::Auto);
+			if (list.allFilesForCompress || list.albumIsPossible) {
+				confirmSendingFiles(std::move(list), CompressConfirm::Auto);
+			} else if (!showSendingFilesError(list)) {
+				uploadFiles(std::move(list), SendMediaType::File);
+			}
 		}
 	}));
 }


### PR DESCRIPTION
The commit in https://github.com/telegramdesktop/tdesktop/pull/5478 doesn't behave the same as dragging:

When selecting any file to send via the `historyAttach` button, the compressed parameter of `HistoryWidget::confirmSendingFiles` is always set to `CompressConfirm::Auto`:

https://github.com/telegramdesktop/tdesktop/blob/48cee21b9f5f372dab64e9baf829b425e71e3c45/Telegram/SourceFiles/history/history_widget.cpp#L3088

This causes the `SendFilesBox` to infer the type of the file as whatever it was set to last:

https://github.com/telegramdesktop/tdesktop/blob/48cee21b9f5f372dab64e9baf829b425e71e3c45/Telegram/SourceFiles/boxes/send_files_box.cpp#L1456-L1468

Which means if photo was selected last, then the sticker is sent as a photo (though it still initially displays as a sticker on the client side, and restarting the client or viewing the message from another client shows that it was actually sent as a photo).

The drag and drop method explicitly sets `CompressConfirm::No` for documents:
https://github.com/telegramdesktop/tdesktop/blob/0f67f75bed0cc12f354450ffd032e8bdeaa4f15a/Telegram/SourceFiles/history/history_widget.cpp#L351-L358

This PR does the same by bringing back the condition that the commit at https://github.com/telegramdesktop/tdesktop/pull/5478 removed, but replacing the `uploadFiles` call with one to `confirmSendingFiles`.