### PR TITLE
Enable to handle .pptx .xlsx .docx extensions

### DIFF
--- a/Telegram/SourceFiles/layout.cpp
+++ b/Telegram/SourceFiles/layout.cpp
@@ -95,17 +95,20 @@ int32 documentColorIndex(DocumentData *document, QString &ext) {
 		? document->mimeString().toLower()
 		: QString();
 	if (name.endsWith(qstr(".doc")) ||
+	    	name.endsWith(qstr(".docx")) ||
 		name.endsWith(qstr(".txt")) ||
 		name.endsWith(qstr(".psd")) ||
 		mime.startsWith(qstr("text/"))) {
 		colorIndex = 0;
 	} else if (
 		name.endsWith(qstr(".xls")) ||
+		name.endsWith(qstr(".xlsx")) ||
 		name.endsWith(qstr(".csv"))) {
 		colorIndex = 1;
 	} else if (
 		name.endsWith(qstr(".pdf")) ||
 		name.endsWith(qstr(".ppt")) ||
+		name.endsWith(qstr(".pptx")) ||
 		name.endsWith(qstr(".key"))) {
 		colorIndex = 2;
 	} else if (


### PR DESCRIPTION
Minor improvements: 
I realized that Office 2013+ extensions(.pptx, .xlsx, .docx) didn't have layout colors.