### PR TITLE
Disable auto download for Files in default setting

### DIFF
--- a/Telegram/SourceFiles/data/data_auto_download.cpp
+++ b/Telegram/SourceFiles/data/data_auto_download.cpp
@@ -41,7 +41,7 @@ void SetDefaultsForSource(Full &data, Source source) {
 	const auto channelsFileLimit = (source == Source::Channel)
 		? 0
 		: kDefaultMaxSize;
-	data.setBytesLimit(source, Type::File, channelsFileLimit);
+	data.setBytesLimit(source, Type::File, 0);
 	data.setBytesLimit(source, Type::Video, channelsFileLimit);
 	data.setBytesLimit(source, Type::Music, channelsFileLimit);
 }


### PR DESCRIPTION
I work for a company that uses Telegram on many computers. Multiple files are uploaded to the group chat room, and all of the files, including those I don't need personally, are automatically downloaded, making  uncomfortable. Therefore, it would be better for job to not automatically download the files in default settings.

In addition, it would be more appropriate to disable auto-downloading, considering files such as unidentified executables.