### PR TITLE
Fix rlottie caching

### DIFF
--- a/Telegram/SourceFiles/lottie/lottie_animation.cpp
+++ b/Telegram/SourceFiles/lottie/lottie_animation.cpp
@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "lottie/lottie_cache.h"
 #include "lottie/lottie_player.h"
 #include "base/algorithm.h"
+#include "core/utils.h"
 #include "zlib.h"
 #include "logs.h"
 
@@ -128,7 +129,13 @@ std::unique_ptr<rlottie::Animation> CreateFromContent(
 	const auto string = UnpackGzip(content);
 	Assert(string.size() <= kMaxFileSize);
 
-	auto result = rlottie::Animation::loadFromData(string, std::string());
+	auto cacheKey = std::string();
+#ifndef TDESKTOP_OFFICIAL_TARGET
+	cacheKey.resize(20);
+	hashSha1(string.data(), string.size(), cacheKey.data());
+#endif // TDESKTOP_OFFICIAL_TARGET
+	auto result = rlottie::Animation::loadFromData(string, cacheKey);
+
 	if (!result) {
 		LOG(("Lottie Error: Parse failed."));
 	}


### PR DESCRIPTION
This change fixes animated stickers caching by using sticker's SHA1 hash
as cache key (instead of using empty string as key for all the stickers,
that leads to situation where all stickers become looking same).

// it adds zero impact for "default" static build (as "official target"
does), but helps with "unbundled" builds, when maintainers build all the
deps as shared libraries and in case when rlottie built with enabled
cache support (the default on it's buildsystem).