### PR TITLE
Fix library: libxkbcommon

### DIFF
--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -209,6 +209,7 @@ Go to ***BuildPath*** and run
 
     git clone https://github.com/xkbcommon/libxkbcommon.git
     cd libxkbcommon
+    git checkout e7bb704
     ./autogen.sh --disable-x11
     make $MAKE_THREADS_CNT
     sudo make install


### PR DESCRIPTION
Since [25cd67d@xkbcommon/libxkbcommon](https://github.com/xkbcommon/libxkbcommon/commit/25cd67daf7ef7a4bfe49a2b91b2fe085e36ae786),
autogen.sh tool has been removed