### PR TITLE
Allow searching for messages by a user who has left a chat, fixes #5667

### DIFF
--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -445,7 +445,6 @@ void AddSpecialBoxController::loadMoreRows() {
 void AddSpecialBoxController::rowClicked(not_null<PeerListRow*> row) {
 	auto user = row->peer()->asUser();
 	switch (_role) {
-	case Role::Members: return;
 	case Role::Admins: return showAdmin(user);
 	case Role::Restricted: return showRestricted(user);
 	case Role::Kicked: return kickUser(user);

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -312,6 +312,8 @@ void AddSpecialBoxController::prepare() {
 	delegate()->peerListSetSearchMode(PeerListSearchMode::Enabled);
 	auto title = [&] {
 		switch (_role) {
+		case Role::Members:
+			return tr::lng_profile_participants_section();
 		case Role::Admins:
 			return tr::lng_channel_add_admin();
 		case Role::Restricted:
@@ -443,6 +445,7 @@ void AddSpecialBoxController::loadMoreRows() {
 void AddSpecialBoxController::rowClicked(not_null<PeerListRow*> row) {
 	auto user = row->peer()->asUser();
 	switch (_role) {
+	case Role::Members: return;
 	case Role::Admins: return showAdmin(user);
 	case Role::Restricted: return showRestricted(user);
 	case Role::Kicked: return kickUser(user);

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -299,7 +299,7 @@ void AddSpecialBoxController::migrate(not_null<ChannelData*> channel) {
 
 std::unique_ptr<PeerListRow> AddSpecialBoxController::createSearchRow(
 		not_null<PeerData*> peer) {
-	if (peer->isSelf()) {
+	if (_excludeSelf && peer->isSelf()) {
 		return nullptr;
 	}
 	if (const auto user = peer->asUser()) {
@@ -802,7 +802,8 @@ void AddSpecialBoxController::kickUser(
 }
 
 bool AddSpecialBoxController::appendRow(not_null<UserData*> user) {
-	if (delegate()->peerListFindRow(user->id) || user->isSelf()) {
+	if (delegate()->peerListFindRow(user->id)
+		|| (_excludeSelf && user->isSelf())) {
 		return false;
 	}
 	delegate()->peerListAppendRow(createRow(user));

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.h
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.h
@@ -131,6 +131,9 @@ private:
 	AdminDoneCallback _adminDoneCallback;
 	BannedDoneCallback _bannedDoneCallback;
 
+protected:
+	bool _excludeSelf = true;
+
 };
 
 // Finds chat/channel members, then contacts, then global search results.

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
@@ -54,7 +54,9 @@ SearchFromController::SearchFromController(
 	ParticipantsBoxController::Role::Members,
 	AdminDoneCallback(),
 	BannedDoneCallback())
-, _callback(std::move(callback)) {
+, _callback(std::move(callback))
+{
+	_excludeSelf = false;
 }
 
 void SearchFromController::prepare() {

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
@@ -19,18 +19,15 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Dialogs {
 
 void ShowSearchFromBox(
-		not_null<Window::SessionNavigation*> navigation,
 		not_null<PeerData*> peer,
 		Fn<void(not_null<UserData*>)> callback,
 		Fn<void()> closedCallback) {
 	auto createController = [
-		navigation,
 		peer,
 		callback = std::move(callback)
 	]() -> std::unique_ptr<PeerListController> {
 		if (peer && (peer->isChat() || peer->isMegagroup())) {
 			return std::make_unique<Dialogs::SearchFromController>(
-				navigation,
 				peer,
 				std::move(callback));
 		}
@@ -50,7 +47,6 @@ void ShowSearchFromBox(
 }
 
 SearchFromController::SearchFromController(
-	not_null<Window::SessionNavigation*> navigation,
 	not_null<PeerData*> peer,
 	Fn<void(not_null<UserData*>)> callback)
 : AddSpecialBoxController(

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
@@ -53,15 +53,16 @@ SearchFromController::SearchFromController(
 	not_null<Window::SessionNavigation*> navigation,
 	not_null<PeerData*> peer,
 	Fn<void(not_null<UserData*>)> callback)
-: ParticipantsBoxController(
-	navigation,
+: AddSpecialBoxController(
 	peer,
-	ParticipantsBoxController::Role::Members)
+	ParticipantsBoxController::Role::Members,
+	AdminDoneCallback(),
+	BannedDoneCallback())
 , _callback(std::move(callback)) {
 }
 
 void SearchFromController::prepare() {
-	ParticipantsBoxController::prepare();
+	AddSpecialBoxController::prepare();
 	delegate()->peerListSetTitle(tr::lng_search_messages_from());
 }
 

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
@@ -14,7 +14,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Dialogs {
 
 void ShowSearchFromBox(
-	not_null<Window::SessionNavigation*> navigation,
 	not_null<PeerData*> peer,
 	Fn<void(not_null<UserData*>)> callback,
 	Fn<void()> closedCallback);
@@ -22,7 +21,6 @@ void ShowSearchFromBox(
 class SearchFromController : public AddSpecialBoxController {
 public:
 	SearchFromController(
-		not_null<Window::SessionNavigation*> navigation,
 		not_null<PeerData*> peer,
 		Fn<void(not_null<UserData*>)> callback);
 

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "boxes/peer_list_box.h"
 #include "boxes/peers/edit_participants_box.h"
+#include "boxes/peers/add_participants_box.h"
 
 namespace Dialogs {
 
@@ -18,7 +19,7 @@ void ShowSearchFromBox(
 	Fn<void(not_null<UserData*>)> callback,
 	Fn<void()> closedCallback);
 
-class SearchFromController : public ParticipantsBoxController {
+class SearchFromController : public AddSpecialBoxController {
 public:
 	SearchFromController(
 		not_null<Window::SessionNavigation*> navigation,
@@ -29,7 +30,7 @@ public:
 	void rowClicked(not_null<PeerListRow*> row) override;
 
 protected:
-	std::unique_ptr<PeerListRow> createRow(not_null<UserData*> user) const override;
+	std::unique_ptr<PeerListRow> createRow(not_null<UserData*> user) const;
 
 private:
 	Fn<void(not_null<UserData*>)> _callback;

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.h
@@ -8,7 +8,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "boxes/peer_list_box.h"
-#include "boxes/peers/edit_participants_box.h"
 #include "boxes/peers/add_participants_box.h"
 
 namespace Dialogs {

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -1322,7 +1322,6 @@ void Widget::showSearchFrom() {
 	if (const auto peer = _searchInChat.peer()) {
 		const auto chat = _searchInChat;
 		ShowSearchFromBox(
-			controller(),
 			peer,
 			crl::guard(this, [=](not_null<UserData*> user) {
 				Ui::hideLayer();


### PR DESCRIPTION
This is PR #5728 but with a fix that allows searching for your own messages. Also [this request](https://github.com/telegramdesktop/tdesktop/pull/5728#pullrequestreview-212555077) has been done.


The original PR message from @TheWug follows:

-----

fixes #5667

Change `Dialog::SearchFromController` to inherit not from `ParticipantsBoxController`, which only shows the users in the group, but instead from `AddSpecialBoxController` which shows the group's users but falls back on global search as well.

I know you don't generally accept pull requests for features and calling this a bug is very borderline but I figured I'd post it anyway.