### PR TITLE
Added "Beginning" button to calendar

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -76,6 +76,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_month_day_year" = "{month} {day}, {year}";
 "lng_month_year" = "{month} {year}";
 
+"lng_calendar_beginning" = "Beginning";
+
 "lng_box_ok" = "OK";
 "lng_box_done" = "Done";
 

--- a/Telegram/SourceFiles/boxes/calendar_box.cpp
+++ b/Telegram/SourceFiles/boxes/calendar_box.cpp
@@ -27,6 +27,11 @@ public:
 		_month.setForced(_month.value(), true);
 	}
 
+	void setBeginningButton(bool enabled);
+	bool hasBeginningButton() const {
+		return _beginningButton;
+	}
+
 	void setMinDate(QDate date);
 	void setMaxDate(QDate date);
 
@@ -55,6 +60,9 @@ public:
 	bool isEnabled(int index) const {
 		return (index >= _minDayIndex) && (index <= _maxDayIndex);
 	}
+	bool atBeginning() const {
+		return _highlighted == _min;
+	}
 
 	const base::Variable<QDate> &month() {
 		return _month;
@@ -68,6 +76,8 @@ private:
 
 	static int daysShiftForMonth(QDate month);
 	static int rowsCountForMonth(QDate month);
+
+	bool _beginningButton = false;
 
 	base::Variable<QDate> _month;
 	QDate _min, _max;
@@ -84,6 +94,10 @@ private:
 
 CalendarBox::Context::Context(QDate month, QDate highlighted) : _highlighted(highlighted) {
 	showMonth(month);
+}
+
+void CalendarBox::Context::setBeginningButton(bool enabled) {
+	_beginningButton = enabled;
 }
 
 void CalendarBox::Context::setMinDate(QDate date) {
@@ -502,6 +516,14 @@ void CalendarBox::setMaxDate(QDate date) {
 	_context->setMaxDate(date);
 }
 
+bool CalendarBox::hasBeginningButton() const {
+	return _context->hasBeginningButton();
+}
+
+void CalendarBox::setBeginningButton(bool enabled) {
+	_context->setBeginningButton(enabled);
+}
+
 void CalendarBox::prepare() {
 	_previous->setClickedCallback([this] { goPreviousMonth(); });
 	_next->setClickedCallback([this] { goNextMonth(); });
@@ -509,7 +531,6 @@ void CalendarBox::prepare() {
 //	_inner = setInnerWidget(object_ptr<Inner>(this, _context.get()), st::calendarScroll, st::calendarTitleHeight);
 	_inner->setDateChosenCallback(std::move(_callback));
 
-	addLeftButton(tr::lng_calendar_beginning(), [this] { _inner->selectBeginning(); });
 	addButton(tr::lng_close(), [this] { closeBox(); });
 
 	subscribe(_context->month(), [this](QDate month) { monthChanged(month); });
@@ -518,6 +539,9 @@ void CalendarBox::prepare() {
 
 	if (_finalize) {
 		_finalize(this);
+	}
+	if (!_context->atBeginning() && hasBeginningButton()) {
+		addLeftButton(tr::lng_calendar_beginning(), [this] { _inner->selectBeginning(); });
 	}
 }
 

--- a/Telegram/SourceFiles/boxes/calendar_box.cpp
+++ b/Telegram/SourceFiles/boxes/calendar_box.cpp
@@ -192,6 +192,7 @@ public:
 
 	int countHeight();
 	void setDateChosenCallback(Fn<void(QDate)> callback);
+	void selectBeginning();
 
 	~Inner();
 
@@ -420,6 +421,10 @@ void CalendarBox::Inner::setDateChosenCallback(Fn<void(QDate)> callback) {
 	_dateChosenCallback = std::move(callback);
 }
 
+void CalendarBox::Inner::selectBeginning() {
+	_dateChosenCallback(_context->dateFromIndex(_context->minDayIndex()));
+}
+
 CalendarBox::Inner::~Inner() = default;
 
 class CalendarBox::Title : public TWidget, private base::Subscriber {
@@ -504,6 +509,7 @@ void CalendarBox::prepare() {
 //	_inner = setInnerWidget(object_ptr<Inner>(this, _context.get()), st::calendarScroll, st::calendarTitleHeight);
 	_inner->setDateChosenCallback(std::move(_callback));
 
+	addLeftButton(tr::lng_calendar_beginning(), [this] { _inner->selectBeginning(); });
 	addButton(tr::lng_close(), [this] { closeBox(); });
 
 	subscribe(_context->month(), [this](QDate month) { monthChanged(month); });
@@ -558,6 +564,8 @@ void CalendarBox::resizeEvent(QResizeEvent *e) {
 void CalendarBox::keyPressEvent(QKeyEvent *e) {
 	if (e->key() == Qt::Key_Escape) {
 		e->ignore();
+	} else if (e->key() == Qt::Key_Home) {
+		_inner->selectBeginning();
 	} else if (e->key() == Qt::Key_Left) {
 		goPreviousMonth();
 	} else if (e->key() == Qt::Key_Right) {

--- a/Telegram/SourceFiles/boxes/calendar_box.h
+++ b/Telegram/SourceFiles/boxes/calendar_box.h
@@ -33,6 +33,8 @@ public:
 		FnMut<void(not_null<CalendarBox*>)> finalize,
 		const style::CalendarSizes &st);
 
+	void setBeginningButton(bool enabled);
+	bool hasBeginningButton() const;
 
 	void setMinDate(QDate date);
 	void setMaxDate(QDate date);

--- a/Telegram/SourceFiles/window/window_session_controller.cpp
+++ b/Telegram/SourceFiles/window/window_session_controller.cpp
@@ -587,6 +587,7 @@ void SessionController::showJumpToDate(Dialogs::Key chat, QDate requestedDate) {
 		std::move(callback));
 	box->setMinDate(minPeerDate(chat));
 	box->setMaxDate(maxPeerDate(chat));
+	box->setBeginningButton(true);
 	Ui::show(std::move(box));
 }
 


### PR DESCRIPTION
This pull request adds functionality to jump to first message by pressing "Beginning" button when selecting date.

![Calendar with "Beginning" button](https://user-images.githubusercontent.com/2903496/63943301-05944480-ca78-11e9-878b-250ef77aa617.png)

Additionaly, you can press **Home** button on keyboard while calendar is open.