### PR TITLE
Support Key_End in Chat history

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -5251,6 +5251,11 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 		_scroll->keyPressEvent(e);
 	} else if (e->key() == Qt::Key_PageUp) {
 		_scroll->keyPressEvent(e);
+	// This is not recommended at this step, may be increased crash in the program.
+	// } else if (e->key() == Qt::Key_Home) { //0x01000010
+	// 	_scroll->keyPressEvent(e);
+	} else if (e->key() == Qt::Key_End) { //0x01000011
+		_scroll->keyPressEvent(e);
 	} else if (e->key() == Qt::Key_Down) {
 		if (!(e->modifiers() & (Qt::ShiftModifier | Qt::MetaModifier | Qt::ControlModifier))) {
 			_scroll->keyPressEvent(e);


### PR DESCRIPTION
Hello,

I'm Max. (https://t.me/MAX_BASE)
This is a suggestion to telegram team, to support `End key` in the chat history.
> Note: Because we need to press multi-time PageDown key when we need to go down.

It requires to handle the `End` event in there. (Not complete yet)
Thank you for your attention.

Best,
Max Base