### PR TITLE
be compatible with range-v3 0.9.x/1.0 branch

### DIFF
--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -28,7 +28,10 @@ GOTO:EOF
     git clone -q --depth 1 --branch master https://github.com/telegramdesktop/dependencies_windows.git %LIB_DIR%
     cd %LIB_DIR%
 
-    git clone --depth 1 --branch 0.5.0 https://github.com/ericniebler/range-v3
+    git clone https://github.com/ericniebler/range-v3
+    cd range-v3
+    git checkout 0.5.0
+    cd ..
 
     if exist prepare.bat (
         call prepare.bat

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -29,9 +29,6 @@ GOTO:EOF
     cd %LIB_DIR%
 
     git clone https://github.com/ericniebler/range-v3
-    cd range-v3
-    git checkout 0.5.0
-    cd ..
 
     if exist prepare.bat (
         call prepare.bat

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -28,7 +28,7 @@ GOTO:EOF
     git clone -q --depth 1 --branch master https://github.com/telegramdesktop/dependencies_windows.git %LIB_DIR%
     cd %LIB_DIR%
 
-    git clone https://github.com/ericniebler/range-v3
+    git clone --depth 1 --branch 0.9.1 https://github.com/ericniebler/range-v3
 
     if exist prepare.bat (
         call prepare.bat

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -217,7 +217,7 @@ buildRange() {
   rm -rf *
 
   cd "$EXTERNAL"
-  git clone --depth=1 https://github.com/ericniebler/range-v3
+  git clone --depth 1 --branch 0.9.1 https://github.com/ericniebler/range-v3
 
   cd "$EXTERNAL/range-v3"
   cp -r * "$RANGE_PATH/"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -28,7 +28,7 @@ GYP_CACHE_VERSION="3"
 GYP_PATCH="$UPSTREAM/Telegram/Patches/gyp.diff"
 
 RANGE_PATH="$BUILD/range-v3"
-RANGE_CACHE_VERSION="4"
+RANGE_CACHE_VERSION="3"
 
 VA_PATH="$BUILD/libva"
 VA_CACHE_VERSION="3"
@@ -217,7 +217,7 @@ buildRange() {
   rm -rf *
 
   cd "$EXTERNAL"
-  git clone --depth 1 --branch 0.5.0 https://github.com/ericniebler/range-v3
+  git clone --depth=1 https://github.com/ericniebler/range-v3
 
   cd "$EXTERNAL/range-v3"
   cp -r * "$RANGE_PATH/"

--- a/Telegram/SourceFiles/boxes/single_choice_box.cpp
+++ b/Telegram/SourceFiles/boxes/single_choice_box.cpp
@@ -38,7 +38,7 @@ void SingleChoiceBox::prepare() {
 	content->add(object_ptr<Ui::FixedHeightWidget>(
 		content,
 		st::boxOptionListPadding.top() + st::autolockButton.margin.top()));
-	auto &&ints = ranges::view::ints(0);
+	auto &&ints = ranges::view::ints(0, ranges::unreachable);
 	for (const auto &[i, text] : ranges::view::zip(ints, _optionTexts)) {
 		content->add(
 			object_ptr<Ui::Radiobutton>(

--- a/Telegram/SourceFiles/chat_helpers/emoji_keywords.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_keywords.cpp
@@ -449,7 +449,7 @@ std::vector<Result> EmojiKeywords::LangPack::query(
 	}
 
 	const auto from = _data.emoji.lower_bound(normalized);
-	auto &&chosen = ranges::make_iterator_range(
+	auto &&chosen = ranges::subrange(
 		from,
 		end(_data.emoji)
 	) | ranges::view::take_while([&](const auto &pair) {

--- a/Telegram/SourceFiles/chat_helpers/emoji_sets_manager.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_sets_manager.cpp
@@ -367,7 +367,7 @@ void Row::paintPreview(Painter &p) const {
 	const auto y = st::manageEmojiPreviewPadding.top();
 	const auto width = st::manageEmojiPreviewWidth;
 	const auto height = st::manageEmojiPreviewWidth;
-	auto &&preview = ranges::view::zip(_preview, ranges::view::ints(0));
+	auto &&preview = ranges::view::zip(_preview, ranges::view::ints(0, int(_preview.size())));
 	for (const auto &[pixmap, index] : preview) {
 		const auto row = (index / 2);
 		const auto column = (index % 2);
@@ -570,7 +570,7 @@ void Row::setupPreview(const Set &set) {
 	const auto size = st::manageEmojiPreview * cIntRetinaFactor();
 	const auto original = QImage(set.previewPath);
 	const auto full = original.height();
-	auto &&preview = ranges::view::zip(_preview, ranges::view::ints(0));
+	auto &&preview = ranges::view::zip(_preview, ranges::view::ints(0, int(_preview.size())));
 	for (auto &&[pixmap, index] : preview) {
 		pixmap = App::pixmapFromImageInPlace(original.copy(
 			{ full * index, 0, full, full }

--- a/Telegram/SourceFiles/data/data_channel.cpp
+++ b/Telegram/SourceFiles/data/data_channel.cpp
@@ -764,7 +764,7 @@ void ApplyMegagroupAdmins(
 	}
 
 	auto adding = base::flat_map<UserId, QString>();
-	auto admins = ranges::make_iterator_range(
+	auto admins = ranges::subrange(
 		list.begin(), list.end()
 	) | ranges::view::transform([](const MTPChannelParticipant &p) {
 		const auto userId = p.match([](const auto &data) {

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -2962,7 +2962,7 @@ void InnerWidget::setupShortcuts() {
 			Command::ChatPinned4,
 			Command::ChatPinned5,
 		};
-		auto &&pinned = ranges::view::zip(kPinned, ranges::view::ints(0));
+		auto &&pinned = ranges::view::zip(kPinned, ranges::view::ints(0, ranges::unreachable));
 		for (const auto [command, index] : pinned) {
 			request->check(command) && request->handle([=, index = index] {
 				const auto list = session().data().chatsList()->indexed();

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -17,7 +17,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <range/v3/algorithm/max_element.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/transform.hpp>
-#include <range/v3/to_container.hpp>
+#include <range/v3/range/conversion.hpp>
 
 namespace App { // Hackish..
 QString formatPhone(QString phone);

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -2444,7 +2444,7 @@ MessageIdsList HistoryInner::getSelectedItems() const {
 		return {};
 	}
 
-	auto result = make_iterator_range(
+	auto result = ranges::subrange(
 		_selected.begin(),
 		_selected.end()
 	) | view::filter([](const auto &selected) {

--- a/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
@@ -34,6 +34,10 @@ struct PercentCounterItem {
 	int percent = 0;
 	int remainder = 0;
 
+	inline bool operator==(const PercentCounterItem &o) const {
+		return remainder == o.remainder && percent == o.percent;
+	}
+
 	inline bool operator<(const PercentCounterItem &other) const {
 		if (remainder > other.remainder) {
 			return true;

--- a/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
@@ -91,7 +91,7 @@ void CountNicePercent(
 	auto &&zipped = ranges::view::zip(
 		votes,
 		items,
-		ranges::view::ints(0));
+		ranges::view::ints(0, int(items.size())));
 	for (auto &&[votes, item, index] : zipped) {
 		item.index = index;
 		item.percent = (votes * 100) / total;

--- a/Telegram/SourceFiles/media/streaming/media_streaming_reader.cpp
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_reader.cpp
@@ -291,7 +291,7 @@ auto Reader::Slice::prepareFill(int from, int till) -> PrepareFillResult {
 		ranges::less(),
 		&PartsMap::value_type::first);
 	const auto haveTill = FindNotLoadedStart(
-		ranges::make_iterator_range(start, finish),
+		ranges::subrange(start, finish),
 		fromOffset);
 	if (haveTill < till) {
 		result.offsetsFromLoader = offsetsFromLoader(
@@ -607,14 +607,14 @@ auto Reader::Slices::fill(int offset, bytes::span buffer) -> FillResult {
 		markSliceUsed(fromSlice);
 		CopyLoaded(
 			buffer,
-			ranges::make_iterator_range(first.start, first.finish),
+			ranges::subrange(first.start, first.finish),
 			firstFrom,
 			firstTill);
 		if (fromSlice + 1 < tillSlice) {
 			markSliceUsed(fromSlice + 1);
 			CopyLoaded(
 				buffer.subspan(firstTill - firstFrom),
-				ranges::make_iterator_range(second.start, second.finish),
+				ranges::subrange(second.start, second.finish),
 				secondFrom,
 				secondTill);
 		}
@@ -644,7 +644,7 @@ auto Reader::Slices::fillFromHeader(int offset, bytes::span buffer)
 	if (prepared.ready) {
 		CopyLoaded(
 			buffer,
-			ranges::make_iterator_range(prepared.start, prepared.finish),
+			ranges::subrange(prepared.start, prepared.finish),
 			from,
 			till);
 		result.filled = true;

--- a/Telegram/SourceFiles/ui/grouped_layout.cpp
+++ b/Telegram/SourceFiles/ui/grouped_layout.cpp
@@ -117,7 +117,7 @@ std::string Layouter::CountProportions(const std::vector<float64> &ratios) {
 		ratios
 	) | ranges::view::transform([](float64 ratio) {
 		return (ratio > 1.2) ? 'w' : (ratio < 0.8) ? 'n' : 'q';
-	}) | ranges::to_<std::string>();
+	}) | ranges::to<std::string>();
 }
 
 std::vector<GroupMediaLayout> Layouter::layout() const {

--- a/Telegram/SourceFiles/ui/image/image_prepare.cpp
+++ b/Telegram/SourceFiles/ui/image/image_prepare.cpp
@@ -262,7 +262,7 @@ QImage BlurLargeImage(QImage image, int radius) {
 	const auto dvs = take(dvcount);
 
 	auto &&ints = ranges::view::ints;
-	for (auto &&[value, index] : ranges::view::zip(dvs, ints(0))) {
+	for (auto &&[value, index] : ranges::view::zip(dvs, ints(0, ranges::unreachable))) {
 		value = (index / divsum);
 	}
 	const auto dv = dvs.data();

--- a/Telegram/SourceFiles/ui/text/text_entity.cpp
+++ b/Telegram/SourceFiles/ui/text/text_entity.cpp
@@ -1141,7 +1141,7 @@ const QRegularExpression &RegExpWordSplit() {
 
 [[nodiscard]] QString ExpandCustomLinks(const TextWithTags &text) {
 	const auto entities = ConvertTextTagsToEntities(text.tags);
-	auto &&urls = ranges::make_iterator_range(
+	auto &&urls = ranges::subrange(
 		entities.begin(),
 		entities.end()
 	) | ranges::view::filter([](const EntityInText &entity) {
@@ -2098,7 +2098,7 @@ EntityInText::EntityInText(
 int EntityInText::FirstMonospaceOffset(
 		const EntitiesInText &entities,
 		int textLength) {
-	auto &&monospace = ranges::make_iterator_range(
+	auto &&monospace = ranges::subrange(
 		entities.begin(),
 		entities.end()
 	) | ranges::view::filter([](const EntityInText & entity) {

--- a/Telegram/gyp/common/win.gypi
+++ b/Telegram/gyp/common/win.gypi
@@ -33,6 +33,8 @@
             '/w14834', # [[nodiscard]]
             '/w15038', # wrong initialization order
             '/w14265', # class has virtual functions, but destructor is not virtual
+            '/experimental:preprocessor', # need for range-v3 see https://github.com/ericniebler/range-v3#supported-compilers
+            '/wd5105', # needed for `/experimental:preprocessor`, suppressing C5105 "macro expansion producing 'defined' has undefined behavior"
           ],
           'TreatWChar_tAsBuiltInType': 'false',
         },

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -38,7 +38,7 @@ Go to ***BuildPath*** and run
     mkdir Libraries
     cd Libraries
 
-    git clone --branch 0.5.0 https://github.com/ericniebler/range-v3
+    git clone --branch 0.9.1 https://github.com/ericniebler/range-v3
 
     git clone https://github.com/telegramdesktop/zlib.git
     cd zlib

--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -55,7 +55,7 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
     mkdir Libraries
     cd Libraries
 
-    git clone --branch 0.5.0 https://github.com/ericniebler/range-v3 range-v3
+    git clone --branch 0.9.1 https://github.com/ericniebler/range-v3 range-v3
 
     git clone https://github.com/telegramdesktop/lzma.git
     cd lzma\C\Util\LzmaLib

--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -30,7 +30,7 @@ Go to ***BuildPath*** and run
 
     cd Libraries
 
-    git clone --branch 0.5.0 https://github.com/ericniebler/range-v3
+    git clone --branch 0.9.1 https://github.com/ericniebler/range-v3
 
     cd xz-5.0.5
     CFLAGS="-mmacosx-version-min=10.8" LDFLAGS="-mmacosx-version-min=10.8" ./configure

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -393,7 +393,6 @@ parts:
   range-v3:
     source: https://github.com/ericniebler/range-v3.git
     source-depth: 1
-    source-tag: 0.5.0
     plugin: nil
     override-build: |
       set -x

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -393,6 +393,7 @@ parts:
   range-v3:
     source: https://github.com/ericniebler/range-v3.git
     source-depth: 1
+    source-tag: 0.9.1
     plugin: nil
     override-build: |
       set -x


### PR DESCRIPTION
This made 5 changes to the current code base to be compatible with higher versions of range-v3 library.
1. ranges::iterator_range was renamed to subrange, see https://github.com/ericniebler/range-v3/issues/766
2. PercentCounterItem need an operator== for ranges::sort for some reason
3. include <range/v3/to_container.hpp> changed to include <range/v3/range/conversion.hpp>
4. explicitly specify the upper bound in ranges::view::ints
5. change the deprecated ranges::to_ (with underscore) to ranges::to (without underscore)