### PR TITLE
Fix last message tail drawing in theme preview

### DIFF
--- a/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
+++ b/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
@@ -398,6 +398,7 @@ void Generator::paintHistoryList() {
 
 	_historyBottom = _history.y() + _history.height();
 	_historyBottom -= st::historyPaddingBottom;
+	_p->setClipping(true);
 	for (auto i = _bubbles.size(); i != 0;) {
 		auto &bubble = _bubbles[--i];
 		if (bubble.width > 0) {


### PR DESCRIPTION
If you set `msgInBg` color to semi-transparent, you'll see that tail of last message in theme preview will overlay message bubble. The problem is: if `QPainter->setClipping(false)` was called, then first clip instruction (in this case `setClipRegion` for cutting bubble corner) will be skipped.

Current state (1.8.7 beta):
![](https://user-images.githubusercontent.com/2903496/64581052-5ddd1780-d391-11e9-83a9-3f46601e3a68.png)

After fix (this pull):
![](https://user-images.githubusercontent.com/2903496/64581100-86fda800-d391-11e9-8c1d-3205316d9cc1.png)

