### PR TITLE
Add option to disable animated stickers

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -327,6 +327,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_suggest_emoji" = "Suggest emoji replacements";
 "lng_settings_suggest_by_emoji" = "Suggest popular stickers by emoji";
 "lng_settings_loop_stickers" = "Loop animated stickers";
+"lng_settings_disable_animated_stickers" = "Disable animated stickers";
 "lng_settings_large_emoji" = "Large emoji";
 "lng_settings_view_emojis" = "View list";
 "lng_settings_send_enter" = "Send by Enter";

--- a/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
@@ -109,6 +109,7 @@ void Sticker::paintLottie(Painter &p, const QRect &r, bool selected) {
 	const auto playOnce = isEmojiSticker()
 		|| !_document->session().settings().loopAnimatedStickers();
 	if (!paused
+		&& !_document->session().settings().disableAnimatedStickers();
 		&& (!playOnce || frame.index != 0 || !_lottieOncePlayed)
 		&& _lottie->markFrameShown()
 		&& playOnce

--- a/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
@@ -109,7 +109,7 @@ void Sticker::paintLottie(Painter &p, const QRect &r, bool selected) {
 	const auto playOnce = isEmojiSticker()
 		|| !_document->session().settings().loopAnimatedStickers();
 	if (!paused
-		&& !_document->session().settings().disableAnimatedStickers();
+		&& !_document->session().settings().disableAnimatedStickers()
 		&& (!playOnce || frame.index != 0 || !_lottieOncePlayed)
 		&& _lottie->markFrameShown()
 		&& playOnce

--- a/Telegram/SourceFiles/main/main_settings.cpp
+++ b/Telegram/SourceFiles/main/main_settings.cpp
@@ -85,6 +85,7 @@ QByteArray Settings::serialize() const {
 		stream << qint32(_variables.skipArchiveInSearch.current() ? 1 : 0);
 		stream << qint32(_variables.autoplayGifs ? 1 : 0);
 		stream << qint32(_variables.loopAnimatedStickers ? 1 : 0);
+		stream << qint32(_variables.disableAnimatedStickers ? 1 : 0);
 		stream << qint32(_variables.largeEmoji.current() ? 1 : 0);
 		stream << qint32(_variables.replaceEmoji.current() ? 1 : 0);
 		stream << qint32(_variables.suggestEmoji ? 1 : 0);
@@ -131,6 +132,7 @@ void Settings::constructFromSerialized(const QByteArray &serialized) {
 	qint32 skipArchiveInSearch = _variables.skipArchiveInSearch.current() ? 1 : 0;
 	qint32 autoplayGifs = _variables.autoplayGifs ? 1 : 0;
 	qint32 loopAnimatedStickers = _variables.loopAnimatedStickers ? 1 : 0;
+	qint32 disableAnimatedStickers = _variables.disableAnimatedStickers ? 1 : 0;
 	qint32 largeEmoji = _variables.largeEmoji.current() ? 1 : 0;
 	qint32 replaceEmoji = _variables.replaceEmoji.current() ? 1 : 0;
 	qint32 suggestEmoji = _variables.suggestEmoji ? 1 : 0;
@@ -229,6 +231,7 @@ void Settings::constructFromSerialized(const QByteArray &serialized) {
 	if (!stream.atEnd()) {
 		stream >> autoplayGifs;
 		stream >> loopAnimatedStickers;
+		stream >> disableAnimatedStickers;
 		stream >> largeEmoji;
 		stream >> replaceEmoji;
 		stream >> suggestEmoji;
@@ -309,6 +312,7 @@ void Settings::constructFromSerialized(const QByteArray &serialized) {
 	_variables.skipArchiveInSearch = (skipArchiveInSearch == 1);
 	_variables.autoplayGifs = (autoplayGifs == 1);
 	_variables.loopAnimatedStickers = (loopAnimatedStickers == 1);
+	_variables.disableAnimatedStickers = (disableAnimatedStickers == 1);
 	_variables.largeEmoji = (largeEmoji == 1);
 	_variables.replaceEmoji = (replaceEmoji == 1);
 	_variables.suggestEmoji = (suggestEmoji == 1);

--- a/Telegram/SourceFiles/main/main_settings.h
+++ b/Telegram/SourceFiles/main/main_settings.h
@@ -212,6 +212,12 @@ public:
 	void setLoopAnimatedStickers(bool value) {
 		_variables.loopAnimatedStickers = value;
 	}
+	[[nodiscard]] bool disableAnimatedStickers() const {
+		return _variables.disableAnimatedStickers;
+	}
+	void setDisableAnimatedStickers(bool value) {
+		_variables.disableAnimatedStickers = value;
+	}
 	void setLargeEmoji(bool value);
 	[[nodiscard]] bool largeEmoji() const;
 	[[nodiscard]] rpl::producer<bool> largeEmojiValue() const;
@@ -268,6 +274,7 @@ private:
 		rpl::variable<bool> skipArchiveInSearch = false;
 		bool autoplayGifs = true;
 		bool loopAnimatedStickers = true;
+		bool disableAnimatedStickers = false;
 		rpl::variable<bool> largeEmoji = true;
 		rpl::variable<bool> replaceEmoji = true;
 		bool suggestEmoji = true;

--- a/Telegram/SourceFiles/settings/settings_chat.cpp
+++ b/Telegram/SourceFiles/settings/settings_chat.cpp
@@ -720,6 +720,14 @@ void SetupStickersEmoji(
 			session->saveSettingsDelayed();
 		});
 
+	add(
+		tr::lng_settings_disable_animated_stickers(tr::now),
+		session->settings().disableAnimatedStickers(),
+		[=](bool checked) {
+			session->settings().setDisableAnimatedStickers(checked);
+			session->saveSettingsDelayed();
+		});
+
 	AddButton(
 		container,
 		tr::lng_stickers_you_have(),


### PR DESCRIPTION
This PR adds a checkbox in the sticker options to disable animated stickers from playing entirely. Instead, it will halt on the first frame.

Fixes #6234 