### PR TITLE
Make theme preview fully translatable

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1570,6 +1570,30 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_theme_preview_users#one" = "{count} person is using this theme";
 "lng_theme_preview_users#other" = "{count} people are using this theme";
 
+"lng_theme_preview_dialog_name1" = "Eva Summer";
+"lng_theme_preview_dialog_text1" = "Reminds me of a Chinese proverb: the best time to plant a tree was 20 years ago.";
+"lng_theme_preview_dialog_name2" = "Alexandra Smith";
+"lng_theme_preview_dialog_text2" = "This is amazing!";
+"lng_theme_preview_dialog_name3" = "Mike Apple";
+"lng_theme_preview_dialog_name4" = "Evening Club";
+"lng_theme_preview_dialog_author4" = "Eva";
+"lng_theme_preview_dialog_name5" = "Old Pirates";
+"lng_theme_preview_dialog_author5" = "Max";
+"lng_theme_preview_dialog_text5" = "Yo-ho-ho!";
+"lng_theme_preview_dialog_name6" = "Max Bright";
+"lng_theme_preview_dialog_text6" = "How about some coffee?";
+"lng_theme_preview_dialog_name7" = "Natalie Parker";
+"lng_theme_preview_dialog_text7" = "OK, great)";
+"lng_theme_preview_dialog_name8" = "Davy Jones";
+"lng_theme_preview_dialog_file8" = "Keynote.pdf";
+
+"lng_theme_preview_your_name" = "Alex Cassio";
+"lng_theme_preview_chat_title" = "Eva Summer";
+"lng_theme_preview_message1" = "Nearly missed this sunrise";
+"lng_theme_preview_message2" = "Twenty years from now you will be more disappointed by the things that you didn't do than by the ones you did do, so throw off the bowlines, sail away from safe harbor, catch the trade winds in your sails.";
+"lng_theme_preview_message3" = "Mark Twain said that ☝🏻";
+"lng_theme_preview_message4" = "Reminds me of a Chinese proverb: the best time to plant a tree was 20 years ago. The second best time is now.";
+
 "lng_new_authorization" = "{name},\nWe detected a login into your account from a new device on {day}, {date} at {time}\n\nDevice: {device}\nLocation: {location}\n\nIf this wasn't you, you can go to Settings — Show all sessions and terminate that session.\n\nIf you think that somebody logged in to your account against your will, you can enable two-step verification in Settings.\n\nSincerely,\nThe Telegram Team";
 
 "lng_new_version_wrap" = "Telegram Desktop was updated to version {version}\n\n{changes}\n\nFull version history is available here:\n{link}";

--- a/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
+++ b/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
@@ -316,12 +316,22 @@ void Generator::generateData() {
 	_rows.back().pinned = true;
 	addRow("Alexandra Smith", 7, "10:00", "This is amazing!");
 	_rows.back().unreadCounter = 2;
-	addRow("Mike Apple", 2, "9:00", textcmdLink(1, QChar(55357) + QString() + QChar(56836) + " Sticker"));
+	addRow("Mike Apple", 2, "9:00", textcmdLink(1, tr::lng_in_dlg_sticker_emoji(tr::now, lt_emoji, QChar(55357) + QString() + QChar(56836))));
 	_rows.back().unreadCounter = 2;
 	_rows.back().muted = true;
-	addRow("Evening Club", 1, "8:00", textcmdLink(1, "Eva: Photo"));
+	addRow("Evening Club", 1, "8:00", textcmdLink(1, tr::lng_dialogs_text_with_from(
+		tr::now,
+		lt_from_part,
+		tr::lng_dialogs_text_from_wrapped(tr::now, lt_from, "Eva"),
+		lt_message,
+		tr::lng_in_dlg_photo(tr::now))));
 	_rows.back().type = Row::Type::Group;
-	addRow("Old Pirates", 6, "7:00", textcmdLink(1, "Max:") + " Yo-ho-ho!");
+	addRow("Old Pirates", 6, "7:00", tr::lng_dialogs_text_with_from(
+		tr::now,
+		lt_from_part,
+		textcmdLink(1, tr::lng_dialogs_text_from_wrapped(tr::now, lt_from, "Max")),
+		lt_message,
+		"Yo-ho-ho!"));
 	_rows.back().type = Row::Type::Group;
 	addRow("Max Bright", 3, "6:00", "How about some coffee?");
 	_rows.back().status = Status::Received;
@@ -330,7 +340,7 @@ void Generator::generateData() {
 	addRow("Davy Jones", 5, "4:00", textcmdLink(1, "Keynote.pdf"));
 
 	_topBarName.setText(st::msgNameStyle, "Eva Summer", Ui::NameTextOptions());
-	_topBarStatus = "online";
+	_topBarStatus = tr::lng_status_online(tr::now);
 	_topBarStatusActive = true;
 
 	addPhotoBubble(":/gui/art/sunrise.jpg", "Nearly missed this sunrise", "7:00", Status::None);
@@ -340,7 +350,7 @@ void Generator::generateData() {
 	addAudioBubble(waveform, 33, "0:07", "8:00", Status::None);
 	_bubbles.back().outbg = true;
 	_bubbles.back().status = Status::Received;
-	addDateBubble("December 26");
+	addDateBubble(langDayOfMonthFull(QDate(QDate::currentDate().year(), 12, 26)));
 	addTextBubble("Twenty years from now you will be more disappointed by the things that you didn't do than by the ones you did do, so throw off the bowlines, sail away from safe harbor, catch the trade winds in your sails.", "10:00", Status::Received);
 	_bubbles.back().tail = false;
 	_bubbles.back().outbg = true;

--- a/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
+++ b/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
@@ -311,39 +311,39 @@ void Generator::addPhotoBubble(QString image, QString caption, QString date, Sta
 
 void Generator::generateData() {
 	_rows.reserve(9);
-	addRow("Eva Summer", 0, "11:00", "Reminds me of a Chinese proverb: the best time to plant a tree was 20 years ago.");
+	addRow(tr::lng_theme_preview_dialog_name1(tr::now), 0, "11:00", tr::lng_theme_preview_dialog_text1(tr::now));
 	_rows.back().active = true;
 	_rows.back().pinned = true;
-	addRow("Alexandra Smith", 7, "10:00", "This is amazing!");
+	addRow(tr::lng_theme_preview_dialog_name2(tr::now), 7, "10:00", tr::lng_theme_preview_dialog_text2(tr::now));
 	_rows.back().unreadCounter = 2;
-	addRow("Mike Apple", 2, "9:00", textcmdLink(1, tr::lng_in_dlg_sticker_emoji(tr::now, lt_emoji, QChar(55357) + QString() + QChar(56836))));
+	addRow(tr::lng_theme_preview_dialog_name3(tr::now), 2, "9:00", textcmdLink(1, tr::lng_in_dlg_sticker_emoji(tr::now, lt_emoji, QChar(55357) + QString() + QChar(56836))));
 	_rows.back().unreadCounter = 2;
 	_rows.back().muted = true;
-	addRow("Evening Club", 1, "8:00", textcmdLink(1, tr::lng_dialogs_text_with_from(
+	addRow(tr::lng_theme_preview_dialog_name4(tr::now), 1, "8:00", textcmdLink(1, tr::lng_dialogs_text_with_from(
 		tr::now,
 		lt_from_part,
-		tr::lng_dialogs_text_from_wrapped(tr::now, lt_from, "Eva"),
+		tr::lng_dialogs_text_from_wrapped(tr::now, lt_from, tr::lng_theme_preview_dialog_author4(tr::now)),
 		lt_message,
 		tr::lng_in_dlg_photo(tr::now))));
 	_rows.back().type = Row::Type::Group;
-	addRow("Old Pirates", 6, "7:00", tr::lng_dialogs_text_with_from(
+	addRow(tr::lng_theme_preview_dialog_name5(tr::now), 6, "7:00", tr::lng_dialogs_text_with_from(
 		tr::now,
 		lt_from_part,
-		textcmdLink(1, tr::lng_dialogs_text_from_wrapped(tr::now, lt_from, "Max")),
+		textcmdLink(1, tr::lng_dialogs_text_from_wrapped(tr::now, lt_from, tr::lng_theme_preview_dialog_author5(tr::now))),
 		lt_message,
-		"Yo-ho-ho!"));
+		tr::lng_theme_preview_dialog_text5(tr::now)));
 	_rows.back().type = Row::Type::Group;
-	addRow("Max Bright", 3, "6:00", "How about some coffee?");
+	addRow(tr::lng_theme_preview_dialog_name6(tr::now), 3, "6:00", tr::lng_theme_preview_dialog_text6(tr::now));
 	_rows.back().status = Status::Received;
-	addRow("Natalie Parker", 4, "5:00", "OK, great)");
+	addRow(tr::lng_theme_preview_dialog_name7(tr::now), 4, "5:00",tr::lng_theme_preview_dialog_text7(tr::now));
 	_rows.back().status = Status::Received;
-	addRow("Davy Jones", 5, "4:00", textcmdLink(1, "Keynote.pdf"));
+	addRow(tr::lng_theme_preview_dialog_name8(tr::now), 5, "4:00", textcmdLink(1, tr::lng_theme_preview_dialog_file8(tr::now)));
 
-	_topBarName.setText(st::msgNameStyle, "Eva Summer", Ui::NameTextOptions());
+	_topBarName.setText(st::msgNameStyle, tr::lng_theme_preview_chat_title(tr::now), Ui::NameTextOptions());
 	_topBarStatus = tr::lng_status_online(tr::now);
 	_topBarStatusActive = true;
 
-	addPhotoBubble(":/gui/art/sunrise.jpg", "Nearly missed this sunrise", "7:00", Status::None);
+	addPhotoBubble(":/gui/art/sunrise.jpg", tr::lng_theme_preview_message1(tr::now), "7:00", Status::None);
 	int wavedata[] = { 0, 0, 0, 0, 27, 31, 4, 1, 0, 0, 23, 30, 18, 9, 7, 19, 4, 2, 2, 2, 0, 0, 15, 15, 15, 15, 3, 15, 19, 3, 2, 0, 0, 0, 0, 0, 3, 12, 16, 6, 4, 6, 14, 12, 2, 12, 12, 11, 3, 0, 7, 5, 7, 4, 7, 5, 2, 4, 0, 9, 5, 7, 6, 2, 2, 0, 0 };
 	auto waveform = QVector<int>(base::array_size(wavedata));
 	memcpy(waveform.data(), wavedata, sizeof(wavedata));
@@ -351,16 +351,16 @@ void Generator::generateData() {
 	_bubbles.back().outbg = true;
 	_bubbles.back().status = Status::Received;
 	addDateBubble(langDayOfMonthFull(QDate(QDate::currentDate().year(), 12, 26)));
-	addTextBubble("Twenty years from now you will be more disappointed by the things that you didn't do than by the ones you did do, so throw off the bowlines, sail away from safe harbor, catch the trade winds in your sails.", "10:00", Status::Received);
+	addTextBubble(tr::lng_theme_preview_message2(tr::now), "10:00", Status::Received);
 	_bubbles.back().tail = false;
 	_bubbles.back().outbg = true;
-	addTextBubble("Mark Twain said that " + QString() + QChar(9757) + QChar(55356) + QChar(57339), "10:00", Status::Received);
+	addTextBubble(tr::lng_theme_preview_message3(tr::now), "10:00", Status::Received);
 	_bubbles.back().outbg = true;
 	_bubbles.back().attached = true;
 	_bubbles.back().tail = true;
-	addTextBubble("Reminds me of a Chinese proverb: the best time to plant a tree was 20 years ago. The second best time is now.", "11:00", Status::None);
-	_bubbles.back().replyName.setText(st::msgNameStyle, "Alex Cassio", Ui::NameTextOptions());
-	_bubbles.back().replyText.setText(st::messageTextStyle, "Mark Twain said that " + QString() + QChar(9757) + QChar(55356) + QChar(57339), Ui::DialogTextOptions());
+	addTextBubble(tr::lng_theme_preview_message4(tr::now), "11:00", Status::None);
+	_bubbles.back().replyName.setText(st::msgNameStyle, tr::lng_theme_preview_your_name(tr::now), Ui::NameTextOptions());
+	_bubbles.back().replyText.setText(st::messageTextStyle, tr::lng_theme_preview_message3(tr::now), Ui::DialogTextOptions());
 }
 
 Generator::Generator(


### PR DESCRIPTION
This PR makes theme preview fully translatable, like in other official clients.

## Tests

Custom Russian-based locale (all new keys translated):
![](https://user-images.githubusercontent.com/2903496/65372014-eb164b00-dc72-11e9-90ea-520ce6f4901f.png)

Official Russian-based locale (no new keys):
![](https://user-images.githubusercontent.com/2903496/65372053-7ee81700-dc73-11e9-815e-eb857a586b71.png)

English:
![](https://user-images.githubusercontent.com/2903496/65372043-5233ff80-dc73-11e9-847b-5592740f11b9.png)
