### PR TITLE
Resize message with photo when bubbled

### DIFF
--- a/Telegram/SourceFiles/history/history.style
+++ b/Telegram/SourceFiles/history/history.style
@@ -371,6 +371,7 @@ botKbScroll: defaultSolidScroll;
 historyDateFadeDuration: 200;
 
 historyPhotoLeft: 14px;
+historyPhotoBubbleMinWidth: 200px;
 historyMessageRadius: roundRadiusLarge;
 historyBubbleTailInLeft: icon {{ "bubble_tail", msgInBg }};
 historyBubbleTailInLeftSelected: icon {{ "bubble_tail", msgInBgSelected }};

--- a/Telegram/SourceFiles/history/view/media/history_view_photo.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_photo.cpp
@@ -87,7 +87,7 @@ QSize Photo::countOptimalSize() {
 	if (_serviceWidth > 0) {
 		return { _serviceWidth, _serviceWidth };
 	}
-	const auto minWidth = qMax(st::minPhotoSize, _parent->infoWidth() + 2 * (st::msgDateImgDelta + st::msgDateImgPadding.x()));
+	const auto minWidth = qMax((_parent->hasBubble() ? st::historyPhotoBubbleMinWidth : st::minPhotoSize), _parent->infoWidth() + 2 * (st::msgDateImgDelta + st::msgDateImgPadding.x()));
 	const auto maxActualWidth = qMax(tw, minWidth);
 	maxWidth = qMax(maxActualWidth, th);
 	minHeight = qMax(th, st::minPhotoSize);
@@ -127,7 +127,7 @@ QSize Photo::countCurrentSize(int newWidth) {
 	if (_pixw < 1) _pixw = 1;
 	if (_pixh < 1) _pixh = 1;
 
-	auto minWidth = qMax(st::minPhotoSize, _parent->infoWidth() + 2 * (st::msgDateImgDelta + st::msgDateImgPadding.x()));
+	auto minWidth = qMax((_parent->hasBubble() ? st::historyPhotoBubbleMinWidth : st::minPhotoSize), _parent->infoWidth() + 2 * (st::msgDateImgDelta + st::msgDateImgPadding.x()));
 	newWidth = qMax(_pixw, minWidth);
 	auto newHeight = qMax(_pixh, st::minPhotoSize);
 	if (_parent->hasBubble() && !_caption.isEmpty()) {


### PR DESCRIPTION
This PR solves two problems by resizing message with photo when it's bubbled (i.e. have additional text like caption or author name).

## Problem 1: barely readable caption
![](https://user-images.githubusercontent.com/2903496/65863742-6665b400-e379-11e9-8ea7-cf2871b06a42.png)
It takes too many lines and it's hard to read this.

### After patch
![](https://user-images.githubusercontent.com/2903496/65864250-3bc82b00-e37a-11e9-9a55-1eeadcfa5fb8.png)


## Problem 2: too little space for user name and admin title
![](https://user-images.githubusercontent.com/2903496/65864026-e25ffc00-e379-11e9-86cb-86df0644ce61.png)
![](https://user-images.githubusercontent.com/2903496/65864080-fa378000-e379-11e9-85a4-a77b46cf7e06.png)

### After patch
![](https://user-images.githubusercontent.com/2903496/65864366-6dd98d00-e37a-11e9-88c1-688bf1d784ce.png)
![](https://user-images.githubusercontent.com/2903496/65864442-8e094c00-e37a-11e9-8336-d972fb7e495d.png)

