### PR TITLE
Do not show edit timer for supergroup admins

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -6677,6 +6677,12 @@ void HistoryWidget::paintEditHeader(Painter &p, const QRect &rect, int left, int
 
 	if (!_replyEditMsg || _replyEditMsg->history()->peer->isSelf()) return;
 
+	if (const auto megagroup = _replyEditMsg->history()->peer->asMegagroup()) {
+		if (megagroup->amCreator() || megagroup->hasAdminRights()) {
+			return;
+		}
+	}
+
 	QString editTimeLeftText;
 	int updateIn = -1;
 	auto timeSinceMessage = ItemDateTime(_replyEditMsg).msecsTo(QDateTime::currentDateTime());


### PR DESCRIPTION
Since supergroup admins can edit their messages without limit, timer is not needed there.