### PR TITLE
Show restricted date to user

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1768,6 +1768,13 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_restricted_send_inline" = "The admins of this group restricted you from posting inline content here.";
 "lng_restricted_send_polls" = "The admins of this group restricted you from posting polls here.";
 
+"lng_restricted_send_message_until" = "The admins of this group restricted you from writing here until {date}, {time}.";
+"lng_restricted_send_media_until" = "The admins of this group restricted you from posting media content here until {date}, {time}.";
+"lng_restricted_send_stickers_until" = "The admins of this group restricted you from posting stickers here until {date}, {time}.";
+"lng_restricted_send_gifs_until" = "The admins of this group restricted you from posting GIFs here until {date}, {time}.";
+"lng_restricted_send_inline_until" = "The admins of this group restricted you from posting inline content here until {date}, {time}.";
+"lng_restricted_send_polls_until" = "The admins of this group restricted you from posting polls here until {date}, {time}.";
+
 "lng_restricted_send_message_all" = "Writing messages isn't allowed in this group.";
 "lng_restricted_send_media_all" = "Posting media content isn't allowed in this group.";
 "lng_restricted_send_stickers_all" = "Posting stickers isn't allowed in this group.";

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -3219,7 +3219,7 @@ void HistoryWidget::chooseAttach() {
 	} else if (const auto error = Data::RestrictionError(
 			_peer,
 			ChatRestriction::f_send_media)) {
-		Ui::Toast::Show(*error);
+		ShowErrorToast(*error);
 		return;
 	} else if (showSlowmodeError()) {
 		return;

--- a/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
@@ -170,7 +170,7 @@ void ScheduledWidget::chooseAttach() {
 	if (const auto error = Data::RestrictionError(
 		_history->peer,
 		ChatRestriction::f_send_media)) {
-		Ui::Toast::Show(*error);
+		ShowErrorToast(*error);
 		return;
 	}
 


### PR DESCRIPTION
With this PR users can see their restriction date in blocked message field/inline bot suggestions/sticker box/GIF box.

Currently text tells only "You have been restricted" without date.