### PR TITLE
Fixed inline message restriction width

### DIFF
--- a/Telegram/SourceFiles/inline_bots/inline_results_widget.cpp
+++ b/Telegram/SourceFiles/inline_bots/inline_results_widget.cpp
@@ -97,6 +97,7 @@ void Inner::checkRestrictedPeer() {
 				_restrictedLabel.create(this, *error, st::stickersRestrictedLabel);
 				_restrictedLabel->show();
 				_restrictedLabel->move(st::inlineResultsLeft - st::buttonRadius, st::stickerPanPadding);
+				_restrictedLabel->resizeToNaturalWidth(width() - (st::inlineResultsLeft - st::buttonRadius) * 2);
 				if (_switchPmButton) {
 					_switchPmButton->hide();
 				}


### PR DESCRIPTION
Before:
![](https://user-images.githubusercontent.com/2903496/66312419-42761580-e919-11e9-9169-c765fd79f81b.png)
After:
![](https://user-images.githubusercontent.com/2903496/66327819-20d65780-e934-11e9-86be-9c49963653fc.png)
