### PR TITLE
Make build scripts a bit more configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
    - BUILD_VERSION="disable_network_proxy"
    - BUILD_VERSION="disable_desktop_file_generation"
    - BUILD_VERSION="disable_gtk_integration"
+   - BUILD_VERSION="use_packed_resources"
 
 matrix:
   fast_finish: true

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -43,6 +43,7 @@ OPENAL_PATH="$BUILD/openal-soft"
 OPENAL_CACHE_VERSION="4"
 
 GYP_DEFINES=""
+GYP_PACKED_RESOURCES="0"
 
 [[ ! $MAKE_ARGS ]] && MAKE_ARGS="--silent -j4"
 
@@ -120,7 +121,11 @@ build() {
     GYP_DEFINES+=",TDESKTOP_DISABLE_GTK_INTEGRATION"
   fi
 
-  info_msg "Build defines: ${GYP_DEFINES}"
+  if [[ $BUILD_VERSION == *"use_packed_resources"* ]]; then
+    GYP_PACKED_RESOURCES="1"
+  fi
+
+  info_msg "Build defines: $GYP_DEFINES, packed resources: $GYP_PACKED_RESOURCES"
 
   buildTelegram
 
@@ -677,6 +682,7 @@ buildTelegram() {
       -Dapi_id=17349 \
       -Dapi_hash=344583e45741c457fe1862106095a5eb \
       -Dbuild_defines=${GYP_DEFINES:1} \
+      -Duse_packed_resources=$GYP_PACKED_RESOURCES \
       -Dlinux_path_xkbcommon=$XKB_PATH \
       -Dlinux_path_va=$VA_PATH \
       -Dlinux_path_vdpau=$VDPAU_PATH \
@@ -700,16 +706,22 @@ buildTelegram() {
 }
 
 check() {
-  local filePath="$UPSTREAM/out/Debug/Telegram"
+  local filePath size
+  filePath="$UPSTREAM/out/Debug/Telegram"
+  resourcesPath="$UPSTREAM/out/Debug/tresources.rcc"
+
   if test -f "$filePath"; then
     success_msg "Build successfully done! :)"
 
-    local size;
     size=$(stat -c %s "$filePath")
     success_msg "File size of ${filePath}: ${size} Bytes"
   else
     error_msg "Build error, output file does not exist"
     exit 1
+  fi
+  if test -f "$resourcesPath"; then
+    size=$(stat -c %s "$resourcesPath")
+    success_msg "File size of ${resourcesPath}: ${size} Bytes"
   fi
 }
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -49,9 +49,9 @@ GYP_DEFINES=""
 run() {
   # Move files to subdir
   cd ..
-  mv tdesktop tdesktop2
-  mkdir tdesktop
-  mv tdesktop2 "$UPSTREAM"
+  mv "$REPO" "${REPO}_2"
+  mkdir "$REPO"
+  mv "${REPO}_2" "$UPSTREAM"
 
   mkdir "$BUILD"
 

--- a/Telegram/SourceFiles/base/build_config.h
+++ b/Telegram/SourceFiles/base/build_config.h
@@ -47,12 +47,11 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #define ARCH_CPU_X86_FAMILY 1
 #define ARCH_CPU_X86 1
 #define ARCH_CPU_32_BITS 1
-#elif defined(__aarch64__)
+#elif defined _LP64 || defined _M_X64 || defined _M_ARM64 || defined _M_ALPHA
+// _LP64 is defined by GCC, others by MSVC
 #define ARCH_CPU_64_BITS 1
-#elif defined(_M_ARM) || defined(__arm__)
-#define ARCH_CPU_32_BITS 1
 #else
-#error Please add support for your architecture in base/build_config.h
+#define ARCH_CPU_32_BITS 1
 #endif
 
 #if defined(__GNUC__)

--- a/Telegram/SourceFiles/base/tests_main.cpp
+++ b/Telegram/SourceFiles/base/tests_main.cpp
@@ -7,7 +7,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
-#include "reporters/catch_reporter_compact.hpp"
+#if __has_include("reporters/catch_reporter_compact.hpp")
+# include "reporters/catch_reporter_compact.hpp"
+#endif  // __has_include
 #include <QFile>
 
 int (*TestForkedMethod)()/* = nullptr*/;

--- a/Telegram/SourceFiles/core/file_utilities.cpp
+++ b/Telegram/SourceFiles/core/file_utilities.cpp
@@ -16,6 +16,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include <QtWidgets/QFileDialog>
 #include <QtCore/QCoreApplication>
+#include <QtCore/QResource>
 #include <QtCore/QStandardPaths>
 #include <QtGui/QDesktopServices>
 
@@ -402,3 +403,20 @@ bool GetDefault(
 
 } // namespace internal
 } // namespace FileDialog
+
+void Resources::LoadAllData() {
+#ifdef TDESKTOP_USE_PACKED_RESOURCES
+	// Load resources packed into a separated file
+	QStringList paths;
+#ifdef _DEBUG
+	paths += cExeDir();
+#endif
+	paths += QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
+	for (QString directory : paths) {
+		if (QResource::registerResource(directory + qsl("/tresources.rcc"))) {
+			return;  // found
+		}
+	}
+	qFatal("Packed resources not found");
+#endif
+}

--- a/Telegram/SourceFiles/core/file_utilities.h
+++ b/Telegram/SourceFiles/core/file_utilities.h
@@ -107,3 +107,9 @@ bool GetDefault(
 
 } // namespace internal
 } // namespace FileDialog
+
+namespace Resources {
+
+void LoadAllData();
+
+} // namespace Resources

--- a/Telegram/SourceFiles/core/launcher.cpp
+++ b/Telegram/SourceFiles/core/launcher.cpp
@@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "platform/platform_info.h"
 #include "ui/main_queue_processor.h"
 #include "core/crash_reports.h"
+#include "core/file_utilities.h"
 #include "core/update_checker.h"
 #include "core/sandbox.h"
 #include "base/concurrent_timer.h"
@@ -244,6 +245,7 @@ void Launcher::init() {
 	prepareSettings();
 
 	QApplication::setApplicationName(qsl("TelegramDesktop"));
+	Resources::LoadAllData(); // should be called after setting an application name
 
 #ifdef TDESKTOP_LAUNCHER_FILENAME
 #define TDESKTOP_LAUNCHER_FILENAME_TO_STRING_HELPER(V) #V

--- a/Telegram/gyp/PrecompiledHeader.cmake
+++ b/Telegram/gyp/PrecompiledHeader.cmake
@@ -77,6 +77,8 @@ function(export_all_flags _filename _source_name_for_flags)
   set(_compile_file_flags "$<$<BOOL:${_compile_file_flags}>:$<JOIN:${_compile_file_flags},\n>\n>")
   set(_compile_flags "$<$<BOOL:${_compile_flags}>:$<JOIN:${_compile_flags},\n>\n>")
   set(_compile_options "$<$<BOOL:${_compile_options}>:$<JOIN:${_compile_options},\n>\n>")
+  get_source_file_property(_file_lang "${_source_name_for_flags}" LANGUAGE)
+  set(_compile_file_flags "${CMAKE_${_file_lang}_FLAGS}\n${_compile_file_flags}")
   file(GENERATE OUTPUT "${_filename}" CONTENT "${_compile_definitions}${_include_directories}${_compile_file_flags}${_compile_flags}${_compile_options}\n")
 endfunction()
 

--- a/Telegram/gyp/common/linux.gypi
+++ b/Telegram/gyp/common/linux.gypi
@@ -8,6 +8,20 @@
   'conditions': [
     [ 'build_linux', {
       'variables': {
+        'variables': {
+          'cpu_type%': '<!(uname -m)',
+        },
+        'cpu_type%': '<(cpu_type)',
+        'conditions': [
+          [ 'cpu_type == "x86_64"',
+            { 'disable_lto%': 0 },
+            { 'disable_lto%': 1 },
+          ],
+          [ '"64" in cpu_type',
+            { 'bitness%': 64 },
+            { 'bitness%': 32 },
+          ],
+        ],
         'linux_common_flags': [
           '-pipe',
           '-Wall',
@@ -51,7 +65,7 @@
         '<(linux_path_breakpad)/lib',
       ],
       'conditions': [
-        [ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "aarch64"', {
+        [ 'bitness == 64', {
           'defines': [
             'Q_OS_LINUX64',
           ],
@@ -69,7 +83,7 @@
               'sources': [ '__Wrong_Official_Build_Target_<(official_build_target)_' ],
             }],
           ],
-        }], [ '"<!(uname -p)" == "x86_64"', {
+        }], [ 'not disable_lto', {
           # 32 bit version can't be linked with debug info or LTO,
           # virtual memory exhausted :(
           'cflags_c': [ '-g' ],

--- a/Telegram/gyp/lib_base.gyp
+++ b/Telegram/gyp/lib_base.gyp
@@ -23,9 +23,16 @@
       'submodules_loc': '../ThirdParty',
       'pch_source': '<(src_loc)/base/base_pch.cpp',
       'pch_header': '<(src_loc)/base/base_pch.h',
+      'use_common_xxhash%': 0,
     },
-    'defines': [
-      'XXH_INLINE_ALL',
+    'conditions': [
+      [ 'use_common_xxhash', {
+        'link_settings': {
+          'libraries': [ '-lxxhash' ],
+        },
+      }, {
+        'defines': [ 'XXH_INLINE_ALL' ],
+      }],
     ],
     'dependencies': [
       'crl.gyp:crl',

--- a/Telegram/gyp/lib_lottie.gyp
+++ b/Telegram/gyp/lib_lottie.gyp
@@ -22,23 +22,18 @@
       'submodules_loc': '../ThirdParty',
       'rlottie_loc': '<(submodules_loc)/rlottie/inc',
       'lz4_loc': '<(submodules_loc)/lz4/lib',
+      'use_common_rlottie%': 0,
+      'use_common_lz4%': 0,
     },
     'dependencies': [
       'crl.gyp:crl',
       'lib_base.gyp:lib_base',
-      'lib_rlottie.gyp:lib_rlottie',
       'lib_ffmpeg.gyp:lib_ffmpeg',
-      'lib_lz4.gyp:lib_lz4',
     ],
     'export_dependent_settings': [
       'crl.gyp:crl',
       'lib_base.gyp:lib_base',
-      'lib_rlottie.gyp:lib_rlottie',
       'lib_ffmpeg.gyp:lib_ffmpeg',
-      'lib_lz4.gyp:lib_lz4',
-    ],
-    'defines': [
-      'LOT_BUILD',
     ],
     'include_dirs': [
       '<(src_loc)',
@@ -74,6 +69,17 @@
       'include_dirs': [
         '/usr/local/macold/include/c++/v1',
       ],
+    }], [ 'use_common_rlottie', {
+      'link_settings': { 'libraries': [ 'rlottie' ] },
+    }, {
+      'dependencies': [ 'lib_rlottie.gyp:lib_rlottie' ],
+      'export_dependent_settings': [ 'lib_rlottie.gyp:lib_rlottie' ],
+      'defines': [ 'LOT_BUILD' ],
+    }], [ 'use_common_lz4', {
+      'link_settings': { 'libraries': [ 'lz4' ] },
+    }, {
+      'dependencies': [ 'lib_lz4.gyp:lib_lz4' ],
+      'export_dependent_settings': [ 'lib_lz4.gyp:lib_lz4' ],
     }]],
   }],
 }

--- a/Telegram/gyp/lib_scheme.gyp
+++ b/Telegram/gyp/lib_scheme.gyp
@@ -30,7 +30,7 @@
       'include_dirs': [
         '/usr/local/macold/include/c++/v1',
       ],
-    }], [ 'cpu_type.startswith("mips64")', {
+    }], [ 'build_linux and cpu_type.startswith("mips64")', {
       'cflags_cc': [ '-mxgot' ],
     }]],
     'include_dirs': [

--- a/Telegram/gyp/lib_scheme.gyp
+++ b/Telegram/gyp/lib_scheme.gyp
@@ -30,6 +30,8 @@
       'include_dirs': [
         '/usr/local/macold/include/c++/v1',
       ],
+    }], [ 'cpu_type.startswith("mips64")', {
+      'cflags_cc': [ '-mxgot' ],
     }]],
     'include_dirs': [
       '<(src_loc)',

--- a/Telegram/gyp/lib_storage.gyp
+++ b/Telegram/gyp/lib_storage.gyp
@@ -23,10 +23,8 @@
       'submodules_loc': '../ThirdParty',
       'pch_source': '<(src_loc)/storage/storage_pch.cpp',
       'pch_header': '<(src_loc)/storage/storage_pch.h',
+      'use_common_xxhash%': 0,
     },
-    'defines': [
-      'XXH_INLINE_ALL',
-    ],
     'dependencies': [
       'crl.gyp:crl',
       'lib_base.gyp:lib_base',
@@ -88,6 +86,12 @@
         '<(src_loc)/storage/storage_clear_legacy_win.cpp',
         '<(src_loc)/storage/storage_file_lock_win.cpp',
       ],
+    }], [ 'use_common_xxhash', {
+      'link_settings': {
+        'libraries': [ '-lxxhash' ],
+      },
+    }, {
+      'defines': [ 'XXH_INLINE_ALL' ],
     }]],
   }],
 }

--- a/Telegram/gyp/linux_glibc_wraps.gyp
+++ b/Telegram/gyp/linux_glibc_wraps.gyp
@@ -14,7 +14,7 @@
     'sources': [
       '../SourceFiles/platform/linux/linux_glibc_wraps.c',
     ],
-    'conditions': [[ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "aarch64"', {
+    'conditions': [[ 'bitness == 64', {
       'sources': [
         '../SourceFiles/platform/linux/linux_glibc_wraps_64.c',
       ],

--- a/Telegram/gyp/modules/qt.gypi
+++ b/Telegram/gyp/modules/qt.gypi
@@ -93,6 +93,7 @@
             ],
           }],
         ],
+        'linux_path_qt%': '',
       },
       'qt_version%': '<(qt_version)',
       'qt_version_loc': '<!(python -c "print(\'<(qt_version)\'.replace(\'.\', \'_\'))")',
@@ -109,8 +110,13 @@
         }],
         [ 'build_macold', {
           'qt_loc%': '/usr/local/macold/Qt-<(qt_version)',
-        }, {
+        }],
+        [ 'build_linux', {
           'qt_loc%': '/usr/local/tdesktop/Qt-<(qt_version)',
+        }],
+        [ 'linux_path_qt', {
+          # Permit old-style path overriding.
+          'qt_loc%': '<(linux_path_qt)',
         }]
       ],
     },

--- a/Telegram/gyp/modules/qt.gypi
+++ b/Telegram/gyp/modules/qt.gypi
@@ -102,6 +102,7 @@
       'qt_libs_release': [
         '<!@(python -c "for s in \'<@(qt_libs)\'.split(\' \'): print(\'<(qt_lib_prefix)\' + s + \'<(qt_lib_release_postfix)\')")',
       ],
+      'linux_path_xkbcommon%': '',
       'conditions': [
         [ 'build_win', {
           'qt_loc%': '<(DEPTH)/../../../Libraries/qt<(qt_version_loc)/qtbase',
@@ -132,6 +133,11 @@
     'linux_lib_ssl%': '/usr/local/ssl/lib/libssl.a',
     'linux_lib_crypto%': '/usr/local/ssl/lib/libcrypto.a',
     'linux_lib_icu%': 'libicutu.a libicui18n.a libicuuc.a libicudata.a',
+    'conditions': [
+      [ 'linux_path_xkbcommon', {
+        'linux_lib_xkbcommon': '<(linux_path_xkbcommon)/lib/libxkbcommon.a',
+      }],
+    ],
   },
 
   'configurations': {

--- a/Telegram/gyp/modules/qt.gypi
+++ b/Telegram/gyp/modules/qt.gypi
@@ -28,16 +28,8 @@
             'qtharfbuzzng',
           ],
           'qt_version%': '<(qt_version)',
-          'conditions': [
-            [ 'build_macold', {
-              'linux_path_qt%': '/usr/local/macold/Qt-<(qt_version)',
-            }, {
-              'linux_path_qt%': '/usr/local/tdesktop/Qt-<(qt_version)',
-            }]
-          ]
         },
         'qt_version%': '<(qt_version)',
-        'qt_loc_unix': '<(linux_path_qt)',
         'conditions': [
           [ 'build_win', {
             'qt_lib_prefix': '<(ld_lib_prefix)',
@@ -103,7 +95,6 @@
         ],
       },
       'qt_version%': '<(qt_version)',
-      'qt_loc_unix': '<(qt_loc_unix)',
       'qt_version_loc': '<!(python -c "print(\'<(qt_version)\'.replace(\'.\', \'_\'))")',
       'qt_libs_debug': [
         '<!@(python -c "for s in \'<@(qt_libs)\'.split(\' \'): print(\'<(qt_lib_prefix)\' + s + \'<(qt_lib_debug_postfix)\')")',
@@ -111,24 +102,33 @@
       'qt_libs_release': [
         '<!@(python -c "for s in \'<@(qt_libs)\'.split(\' \'): print(\'<(qt_lib_prefix)\' + s + \'<(qt_lib_release_postfix)\')")',
       ],
+      'conditions': [
+        [ 'build_win', {
+          'qt_loc%': '<(DEPTH)/../../../Libraries/qt<(qt_version_loc)/qtbase',
+        }],
+        [ 'build_macold', {
+          'qt_loc%': '/usr/local/macold/Qt-<(qt_version)',
+        }, {
+          'qt_loc%': '/usr/local/tdesktop/Qt-<(qt_version)',
+        }]
+      ],
     },
     'qt_libs_debug': [ '<@(qt_libs_debug)' ],
     'qt_libs_release': [ '<@(qt_libs_release)' ],
     'qt_version%': '<(qt_version)',
-    'conditions': [
-      [ 'build_win', {
-        'qt_loc': '<(DEPTH)/../../../Libraries/qt<(qt_version_loc)/qtbase',
-      }, {
-        'qt_loc': '<(qt_loc_unix)',
-      }],
-    ],
+
+    'qt_incdir%': '<(qt_loc)/include',
+    'qt_libdir%': '<(qt_loc)/lib',
+    'qt_bindir%': '<(qt_loc)/bin',
+    'qt_plugins%': '<(qt_loc)/plugins',
+    'qt_specs%': '<(qt_loc)/mkspecs',
 
     # If you need moc sources include a line in your 'sources':
     # '<!@(python <(DEPTH)/list_sources.py [sources] <(qt_moc_list_sources_arg))'
     # where [sources] contains all your source files
     'qt_moc_list_sources_arg': '--moc-prefix SHARED_INTERMEDIATE_DIR/<(_target_name)/moc/moc_',
 
-    'linux_path_xkbcommon%': '/usr/local',
+    'linux_lib_xkbcommon%': '/usr/local/lib/libxkbcommon.a',
     'linux_lib_ssl%': '/usr/local/ssl/lib/libssl.a',
     'linux_lib_crypto%': '/usr/local/ssl/lib/libcrypto.a',
     'linux_lib_icu%': 'libicutu.a libicui18n.a libicuuc.a libicudata.a',
@@ -180,21 +180,20 @@
   },
 
   'include_dirs': [
-    '<(qt_loc)/include',
-    '<(qt_loc)/include/QtCore',
-    '<(qt_loc)/include/QtGui',
-    '<(qt_loc)/include/QtDBus',
-    '<(qt_loc)/include/QtCore/<(qt_version)',
-    '<(qt_loc)/include/QtGui/<(qt_version)',
-    '<(qt_loc)/include/QtCore/<(qt_version)/QtCore',
-    '<(qt_loc)/include/QtGui/<(qt_version)/QtGui',
+    '<(qt_incdir)',
+    '<(qt_incdir)/QtCore',
+    '<(qt_incdir)/QtGui',
+    '<(qt_incdir)/QtDBus',
+    '<(qt_incdir)/QtCore/<(qt_version)',
+    '<(qt_incdir)/QtGui/<(qt_version)',
+    '<(qt_incdir)/QtCore/<(qt_version)/QtCore',
+    '<(qt_incdir)/QtGui/<(qt_version)/QtGui',
   ],
   'library_dirs': [
-    '<(qt_loc)/lib',
-    '<(qt_loc)/plugins',
-    '<(qt_loc)/plugins/bearer',
-    '<(qt_loc)/plugins/platforms',
-    '<(qt_loc)/plugins/imageformats',
+    '<(qt_libdir)',
+    '<(qt_plugins)/bearer',
+    '<(qt_plugins)/platforms',
+    '<(qt_plugins)/imageformats',
   ],
   'defines': [
     'QT_WIDGETS_LIB',
@@ -208,11 +207,11 @@
         '<(DEPTH)/linux_glibc_wraps.gyp:linux_glibc_wraps',
       ],
       'library_dirs': [
-        '<(qt_loc)/plugins/platforminputcontexts',
+        '<(qt_plugins)/platforminputcontexts',
       ],
       'libraries': [
         '<(PRODUCT_DIR)/obj.target/liblinux_glibc_wraps.a',
-        '<(linux_path_xkbcommon)/lib/libxkbcommon.a',
+        '<(linux_lib_xkbcommon)',
         '<@(qt_libs_release)',
         '<(linux_lib_ssl)',
         '<(linux_lib_crypto)',
@@ -227,7 +226,7 @@
         '-lpthread',
       ],
       'include_dirs': [
-        '<(qt_loc)/mkspecs/linux-g++',
+        '<(qt_specs)/linux-g++',
       ],
       'ldflags': [
         '-static-libstdc++',

--- a/Telegram/gyp/modules/qt_moc.gypi
+++ b/Telegram/gyp/modules/qt_moc.gypi
@@ -15,7 +15,7 @@
       '<(SHARED_INTERMEDIATE_DIR)/<(_target_name)/moc/moc_<(RULE_INPUT_ROOT).cpp',
     ],
     'action': [
-      '<(qt_loc)/bin/moc<(exe_ext)',
+      '<(qt_bindir)/moc<(exe_ext)',
 
       # Silence "Note: No relevant classes found. No output generated."
       '--no-notes',

--- a/Telegram/gyp/modules/qt_rcc.gypi
+++ b/Telegram/gyp/modules/qt_rcc.gypi
@@ -15,7 +15,7 @@
       '<(SHARED_INTERMEDIATE_DIR)/<(_target_name)/qrc/qrc_<(RULE_INPUT_ROOT).cpp',
     ],
     'action': [
-      '<(qt_loc)/bin/rcc<(exe_ext)',
+      '<(qt_bindir)/rcc<(exe_ext)',
       '-name', '<(RULE_INPUT_ROOT)',
       '-no-compress',
       '<(RULE_INPUT_PATH)',

--- a/Telegram/gyp/telegram/linux.gypi
+++ b/Telegram/gyp/telegram/linux.gypi
@@ -10,6 +10,7 @@
       'variables': {
         'build_defines%': '',
       },
+      'cpu_type%': '<!(uname -m)',
       'not_need_gtk%': '<!(python -c "print(\'TDESKTOP_DISABLE_GTK_INTEGRATION\' in \'<(build_defines)\')")',
       'pkgconfig_libs': [
 # In order to work libxkbcommon must be linked statically,
@@ -69,15 +70,14 @@
       },
     },
     'conditions': [
-      [ '"<!(uname -p)" != "x86_64"', {
+      [ 'cpu_type != "x86_64"', {
         'ldflags': [
           '-Wl,-wrap,__divmoddi4',
         ],
       }], ['not_need_gtk!="True"', {
         'cflags_cc': [
-          '<!(pkg-config 2> /dev/null --cflags gtk+-2.0)',
-          '<!(pkg-config 2> /dev/null --cflags glib-2.0)',
-          '<!(pkg-config 2> /dev/null --cflags dee-1.0)',
+          '<!(pkg-config --cflags gtk+-2.0)',
+          '<!(pkg-config --cflags glib-2.0)',
         ],
       }], ['<!(pkg-config ayatana-appindicator3-0.1; echo $?) == 0', {
         'cflags_cc': [ '<!(pkg-config --cflags ayatana-appindicator3-0.1)' ],

--- a/Telegram/gyp/telegram/telegram.gypi
+++ b/Telegram/gyp/telegram/telegram.gypi
@@ -47,6 +47,7 @@
         'pt-BR',
       ],
       'build_defines%': '',
+      'use_common_xxhash%': 0,
       'list_sources_command': 'python <(DEPTH)/list_sources.py --input <(DEPTH)/telegram/sources.txt --replace src_loc=<(src_loc)',
       'pch_source': '<(src_loc)/stdafx.cpp',
       'pch_header': '<(src_loc)/stdafx.h',
@@ -72,7 +73,6 @@
       'codegen.gyp:codegen_numbers',
       'codegen.gyp:codegen_style',
       'tests/tests.gyp:tests',
-      'utils.gyp:Updater',
       '../ThirdParty/libtgvoip/libtgvoip.gyp:libtgvoip',
       'crl.gyp:crl',
       'lib_base.gyp:lib_base',
@@ -88,7 +88,6 @@
       'AL_LIBTYPE_STATIC',
       'AL_ALEXT_PROTOTYPES',
       'TGVOIP_USE_CXX11_LIB',
-      'XXH_INLINE_ALL',
       'TDESKTOP_API_ID=<(api_id)',
       'TDESKTOP_API_HASH=<(api_hash)',
       '<!@(python -c "for s in \'<(build_defines)\'.split(\',\'): print(s)")',
@@ -134,6 +133,7 @@
         ],
         'dependencies': [
           'utils.gyp:Packer',
+          'utils.gyp:Updater',
         ],
       }], [ 'build_mac', {
         'mac_hardened_runtime': 1,
@@ -155,6 +155,10 @@
         'sources': [
           '../../Telegram/Telegram Desktop.entitlements',
         ],
+      }], [ 'use_common_xxhash', {
+        'libraries': [ '-lxxhash' ],
+      }, {
+        'defines': [ 'XXH_INLINE_ALL' ],
       }],
     ],
   }],

--- a/Telegram/gyp/telegram/telegram.gypi
+++ b/Telegram/gyp/telegram/telegram.gypi
@@ -74,6 +74,7 @@
       'codegen.gyp:codegen_numbers',
       'codegen.gyp:codegen_style',
       'tests/tests.gyp:tests',
+      'utils.gyp:Dumb',
       '../ThirdParty/libtgvoip/libtgvoip.gyp:libtgvoip',
       'crl.gyp:crl',
       'lib_base.gyp:lib_base',

--- a/Telegram/gyp/telegram/telegram.gypi
+++ b/Telegram/gyp/telegram/telegram.gypi
@@ -48,6 +48,7 @@
       ],
       'build_defines%': '',
       'use_common_xxhash%': 0,
+      'use_packed_resources%': 0,
       'list_sources_command': 'python <(DEPTH)/list_sources.py --input <(DEPTH)/telegram/sources.txt --replace src_loc=<(src_loc)',
       'pch_source': '<(src_loc)/stdafx.cpp',
       'pch_header': '<(src_loc)/stdafx.h',
@@ -112,7 +113,6 @@
       '<(submodules_loc)/xxHash',
     ],
     'sources': [
-      '<@(qrc_files)',
       '<@(style_files)',
       '<(res_loc)/langs/cloud_lang.strings',
       '<(res_loc)/export_html/css/style.css',
@@ -126,6 +126,31 @@
       '<!@(<(list_sources_command) <(qt_moc_list_sources_arg) --exclude_for <(build_os))',
     ],
     'conditions': [
+      [ 'use_packed_resources', {
+        'actions': [
+          {
+            'action_name': 'generate_resource_pack',
+            'inputs': [
+              '<(SHARED_INTERMEDIATE_DIR)/update_dependent_qrc.timestamp',
+            ],
+            'outputs': [
+              '<(PRODUCT_DIR)/tresources.rcc',
+            ],
+            'action': [
+              '<(qt_bindir)/rcc<(exe_ext)', '-binary',
+              '<@(qrc_files)',
+              '-o', '<@(_outputs)',
+            ],
+          },
+        ],
+        'defines': [
+          'TDESKTOP_USE_PACKED_RESOURCES',
+        ],
+      }, {
+        'sources': [
+          '<@(qrc_files)',
+        ],
+      }],
       [ '"<(official_build_target)" != ""', {
         'defines': [
           'TDESKTOP_OFFICIAL_TARGET=<(official_build_target)',

--- a/Telegram/gyp/utils.gyp
+++ b/Telegram/gyp/utils.gyp
@@ -13,6 +13,10 @@
     # It is strange but GYP generates only Default configuration otherwise.
     'target_name': 'Dumb',
     'type': 'none',
+    'configurations': {
+      'Debug': { },
+      'Release': { },
+    },
   }, {
     'target_name': 'Updater',
     'variables': {

--- a/Telegram/gyp/utils.gyp
+++ b/Telegram/gyp/utils.gyp
@@ -9,6 +9,11 @@
     'common/common.gypi',
   ],
   'targets': [{
+    # This is a special blank target to export list of available configurations.
+    # It is strange but GYP generates only Default configuration otherwise.
+    'target_name': 'Dumb',
+    'type': 'none',
+  }, {
     'target_name': 'Updater',
     'variables': {
       'src_loc': '../SourceFiles',


### PR DESCRIPTION
This adds some GYP variables (cpu_type, bitness, qt_loc, use_common_libs, etc.) to affect build configuration. All additional features are available when the corresponding flag is set. Default behavior is untouched (I hope so).