### PR TITLE
Properly escape markup text for libnotify

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -89,7 +89,7 @@ QString escapeHtml(const QString &text) {
 class NotificationData {
 public:
 	NotificationData(const std::shared_ptr<Manager*> &guarded, const QString &title, const QString &body, const QStringList &capabilities, PeerId peerId, MsgId msgId)
-	: _data(Libs::notify_notification_new(title.toUtf8().constData(), body.toUtf8().constData(), nullptr)) {
+	: _data(Libs::notify_notification_new(title.toUtf8().constData(), g_markup_escape_text(body.toUtf8().constData(), -1), nullptr)) {
 		if (valid()) {
 			init(guarded, capabilities, peerId, msgId);
 		}


### PR DESCRIPTION
Message text was passed to libnotify as is, but libnotify expects
properly escaped markup. Sending unscrapted characters results in
warnings:

xfce4-notifyd[2831]: Failed to set text 'foo & bar' from markup due to
error parsing markup: Error on line 1: Entity did not end with a semicolon;
most likely you used an ampersand character without intending to start
an entity — escape a mpersand as &amp;

This adds a call to g_markup_escape_text() to properly escape the text.