### PR TITLE
Fixes for build instructions

### DIFF
--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -259,7 +259,11 @@ Go to ***BuildPath*** and run
     ./configure
     make $MAKE_THREADS_CNT
     sudo make install
-    cd src/tools
+    cd src
+    rm -r testing
+    git clone https://github.com/google/googletest testing
+    cd tools
+    sed -i 's/minidump_upload.m/minidump_upload.cc/' linux/tools_linux.gypi
     ../../../gyp/gyp  --depth=. --generator-output=.. -Goutput_dir=../out tools.gyp --format=cmake
     cd ../../out/Default
     cmake .

--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -32,7 +32,7 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
     cd ThirdParty
     git clone https://github.com/desktop-app/patches.git
     cd patches
-    git checkout b0ec5df4
+    git checkout b0ec5df
     cd ../
     git clone https://chromium.googlesource.com/external/gyp
     cd gyp
@@ -95,7 +95,6 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
 
     git clone https://github.com/desktop-app/zlib.git
     cd zlib
-    git checkout tdesktop
     cd contrib\vstudio\vc14
     msbuild zlibstat.vcxproj /property:Configuration=Debug
     msbuild zlibstat.vcxproj /property:Configuration=ReleaseWithoutAsm


### PR DESCRIPTION
### On Windows
1. Corrected commit to checkout for `ThirdParty/patches`: `b0ec5df4` was not found. Probably `b0ec5df` was implied as it was used on `Libraries/patches`.
2. Removed `git checkout tdesktop` for zlib since `desktop-app/zlib` doesn't have `tdesktop` branch.

### On Linux
1. Since googletest is empty, it should be cloned manually (with removal of empty folders beforehand).
2. CMake can't find `minidump_upload.m` because it doesn't exist. Actual file that needs to be searched is `minidump_upload.cc`. There is only one match and no false positives, so it should be safe to replace it with sed.
