### PR TITLE
Fixed animated stickers cache

### DIFF
--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
@@ -70,7 +70,7 @@ void PremultiplyLine(uchar *dst, const uchar *src, int intsCount) {
 
 #ifndef TDESKTOP_OFFICIAL_TARGET
 	for (auto i = 0; i != intsCount; ++i) {
-		dst[i] = qPremultiply(src[i]);
+		udst[i] = qPremultiply(usrc[i]);
 	}
 #elif QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
 	static const auto layout = &qPixelLayouts[QImage::Format_ARGB32];


### PR DESCRIPTION
When building TD 1.9+ from sources, animated stickers are breaking after first play cycle. This patch corrects typo in ffmpeg_utility, which fixes this problem.