### PR TITLE
Fix Linux notification markup support detection

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -370,7 +370,8 @@ void Manager::Private::init(Manager *manager) {
 		LOG(("LibNotify capabilities: %1").arg(_capabilities.join(qstr(", "))));
 		if (_capabilities.contains(qsl("actions"))) {
 			_actionsSupported = true;
-		} else if (_capabilities.contains(qsl("body-markup"))) {
+		}
+		if (_capabilities.contains(qsl("body-markup"))) {
 			_markupSupported = true;
 		}
 	} else {


### PR DESCRIPTION
`actions` and `body-markup` are never mutually exclusive. This corrects detection for `body-markup` if `action` is supported.