### PR TITLE
Replace min width of 380px width 360px

### DIFF
--- a/Telegram/SourceFiles/window/window.style
+++ b/Telegram/SourceFiles/window/window.style
@@ -10,14 +10,14 @@ using "ui/widgets/widgets.style";
 using "history/history.style";
 using "boxes/boxes.style"; // UserpicButton
 
-windowMinWidth: 380px;
+windowMinWidth: 360px;
 windowMinHeight: 480px;
 windowDefaultWidth: 800px;
 windowDefaultHeight: 600px;
 
 columnMinimalWidthLeft: 260px;
 columnMaximalWidthLeft: 540px;
-columnMinimalWidthMain: 380px;
+columnMinimalWidthMain: 360px;
 columnDesiredWidthMain: 512px;
 columnMinimalWidthThird: 292px;
 columnMaximalWidthThird: 392px;


### PR DESCRIPTION
It would be awesome to have Telegram Desktop on the [librem5](https://puri.sm/products/librem-5/). Since the app is already adaptive there isn't much to change, but the min width of 380px is slightly to wide. Therefore this changes the width to 360 which doesn't impact the functionality of Telegram Desktop, but allows it to run on the phone without shooting out of the screen.