### PR TITLE
[] lib_tgvoip.cmake: Match against x86 arches.

### DIFF
--- a/Telegram/cmake/lib_tgvoip.cmake
+++ b/Telegram/cmake/lib_tgvoip.cmake
@@ -756,7 +756,7 @@ else()
         -Wno-error=sequence-point
         -Wno-error=unused-result
     )
-    if (build_linux32)
+    if (build_linux32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*")
         target_compile_options(lib_tgvoip PRIVATE -msse2)
     endif()
     target_compile_definitions(lib_tgvoip


### PR DESCRIPTION
This avoids matching against other 32bit arches like armv7/armhf that
doesn't have msse2 but are 32bit and need other 32bit-specific flags to
allow for compilation like -g0.