### PR TITLE
Use QStringList::join to print notifications capabilities

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -52,19 +52,19 @@ std::vector<QString> GetServerInformation(
 	return serverInformation;
 }
 
-std::vector<QString> GetCapabilities(
+QStringList GetCapabilities(
 		const std::shared_ptr<QDBusInterface> &notificationInterface) {
 	QDBusReply<QStringList> capabilitiesReply = notificationInterface
 		->call(qsl("GetCapabilities"));
 
 	if (capabilitiesReply.isValid()) {
-		return capabilitiesReply.value().toVector().toStdVector();
+		return capabilitiesReply.value();
 	} else {
 		LOG(("Native notification error: %1")
 			.arg(capabilitiesReply.error().message()));
 	}
 
-	return std::vector<QString>();
+	return {};
 }
 
 QVersionNumber ParseSpecificationVersion(
@@ -303,14 +303,7 @@ Manager::Private::Private(Manager *manager, Type type)
 	}
 
 	if (!capabilities.empty()) {
-		const auto capabilitiesString = std::accumulate(
-			capabilities.begin(),
-			capabilities.end(),
-			QString{},
-			[](auto &s, auto &p) {
-				return s + (p + qstr(", "));
-			}).chopped(2);
-
+		const auto capabilitiesString = capabilities.join(", ");
 		LOG(("Notification daemon capabilities: %1").arg(capabilitiesString));
 	}
 }


### PR DESCRIPTION
This makes the code a bit simpler and compatible with Qt 5.9 since the QString::chopped method is not used.