### PR TITLE
Desktop environment detection fixes

### DIFF
--- a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
+++ b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
@@ -18,9 +18,7 @@ enum class Type {
 	KDE5,
 	Ubuntu,
 	Unity,
-	XFCE,
 	Pantheon,
-	Awesome,
 };
 
 Type Get();
@@ -53,16 +51,8 @@ inline bool IsUnity() {
 	return Get() == Type::Unity;
 }
 
-inline bool IsXFCE() {
-	return Get() == Type::XFCE;
-}
-
 inline bool IsPantheon() {
 	return Get() == Type::Pantheon;
-}
-
-inline bool IsAwesome() {
-	return Get() == Type::Awesome;
 }
 
 bool TryQtTrayIcon();

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -360,6 +360,7 @@ bool OpenSystemSettings(SystemSettingsType type) {
 		} else if (DesktopEnvironment::IsGnome()) {
 			add("gnome-control-center sound");
 		}
+		add("pavucontrol-qt");
 		add("pavucontrol");
 		add("alsamixergui");
 		return ranges::find_if(options, [](const QString &command) {


### PR DESCRIPTION
This PR
* adds flatpak to PreferAppIndicatorTrayIcon since Qt has problems with SNI implementation in flatpak
* removes Awesome since Qt icon works well with it and Awesome users use startx in general, that doesn't set XDG_CURRENT_DESKTOP/DESKTOP_SESSION anyway
* removes XFCE since Qt icon works well with it
* removes MATE since it is not GNOME and works well with Qt icon also
* adds the check for a path in DESKTOP_SESSION
* adds pavucontrol-qt to OpenSystemSettings