### PR TITLE
Fix opening hashtag when in archive

### DIFF
--- a/Telegram/SourceFiles/facades.cpp
+++ b/Telegram/SourceFiles/facades.cpp
@@ -159,14 +159,21 @@ void activateBotCommand(
 }
 
 void searchByHashtag(const QString &tag, PeerData *inPeer) {
-	if (const auto m = App::main()) {
+	if (const auto window = App::wnd()) {
+		if (const auto controller = window->sessionController()) {
+			if (controller->openedFolder().current()) {
+				controller->closeFolder();
+			}
+		}
 		Ui::hideSettingsAndLayer();
 		Core::App().hideMediaView();
-		m->searchMessages(
-			tag + ' ',
-			(inPeer && !inPeer->isUser())
-				? inPeer->owner().history(inPeer).get()
-				: Dialogs::Key());
+		if (const auto m = window->mainWidget()) {
+			m->searchMessages(
+				tag + ' ',
+				(inPeer && !inPeer->isUser())
+					? inPeer->owner().history(inPeer).get()
+					: Dialogs::Key());
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes "hashtag bug".

How to reproduce:
1. Open archived chats
2. Click on any hashtag in chat or channel

What should happen:
![](https://user-images.githubusercontent.com/2903496/73129960-90b24000-4000-11ea-9f4b-9417b58a0183.png)

What actually happens:
![](https://user-images.githubusercontent.com/2903496/73129983-01f1f300-4001-11ea-875e-9e44b191097c.png)

Additionally, if you click "X" button near channel or chat name, you'll get this:
![](https://user-images.githubusercontent.com/2903496/73129972-e981d880-4000-11ea-96e2-44a8620439a6.png)

