### PR TITLE
Fix opening private linked channel from message

### DIFF
--- a/Telegram/SourceFiles/data/data_peer.cpp
+++ b/Telegram/SourceFiles/data/data_peer.cpp
@@ -86,9 +86,7 @@ void PeerClickHandler::onClick(ClickContext context) const {
 	if (context.button == Qt::LeftButton && App::wnd()) {
 		const auto controller = App::wnd()->sessionController();
 		const auto currentPeer = controller->activeChatCurrent().peer();
-		if (_peer
-			&& _peer->isChannel()
-			&& currentPeer != _peer) {
+		if (_peer && _peer->isChannel() && currentPeer != _peer) {
 			const auto clickedChannel = _peer->asChannel();
 			if (!clickedChannel->isPublic() && !clickedChannel->amIn()
 				&& (!currentPeer->isChannel()

--- a/Telegram/SourceFiles/data/data_peer.cpp
+++ b/Telegram/SourceFiles/data/data_peer.cpp
@@ -85,10 +85,14 @@ PeerClickHandler::PeerClickHandler(not_null<PeerData*> peer)
 void PeerClickHandler::onClick(ClickContext context) const {
 	if (context.button == Qt::LeftButton && App::wnd()) {
 		const auto controller = App::wnd()->sessionController();
+		const auto currentPeer = controller->activeChatCurrent().peer();
 		if (_peer
 			&& _peer->isChannel()
-			&& controller->activeChatCurrent().peer() != _peer) {
-			if (!_peer->asChannel()->isPublic() && !_peer->asChannel()->amIn()) {
+			&& currentPeer != _peer) {
+			const auto clickedChannel = _peer->asChannel();
+			if (!clickedChannel->isPublic() && !clickedChannel->amIn()
+				&& (!currentPeer->isChannel()
+					|| currentPeer->asChannel()->linkedChat() != clickedChannel)) {
 				Ui::show(Box<InformBox>(_peer->isMegagroup()
 					? tr::lng_group_not_accessible(tr::now)
 					: tr::lng_channel_not_accessible(tr::now)));


### PR DESCRIPTION
This PR fixes "private linked channel bug".

How to reproduce:
1. Find or make a group that linked to private channel as a discussion.
2. Find a message from this channel in chat (post it if there are no messages).
3. Click channel profile pic or channel name in message.

Expected:
You open linked channel of this discussion group.

Actual behavior:
You'll receive "Sorry, this channel is not accessible." message, though it works fine when opening from arrow button that leads to post.