### PR TITLE
Perform test for additional libatomic

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(lib_lottie)
 add_subdirectory(lib_qr)
 add_subdirectory(codegen)
 
+include(CheckCXXSourceCompiles)
 include(lib_ui/cmake/generate_styles.cmake)
 include(cmake/generate_lang.cmake)
 include(cmake/generate_numbers.cmake)
@@ -103,6 +104,16 @@ PRIVATE
 
 if (NOT DESKTOP_APP_USE_PACKAGED)
     target_link_libraries(Telegram PRIVATE desktop-app::external_opus)
+endif()
+
+# Telegram uses long atomic types, so on some architectures libatomic is needed.
+check_cxx_source_compiles("
+#include <atomic>
+std::atomic_int64_t foo;
+int main() {return foo;}
+" HAVE_LONG_ATOMIC_WITHOUT_LIB)
+if (NOT HAVE_LONG_ATOMIC_WITHOUT_LIB)
+    target_link_libraries(Telegram PRIVATE atomic)
 endif()
 
 target_precompile_headers(Telegram PRIVATE ${src_loc}/stdafx.h)


### PR DESCRIPTION
Telegram [uses][1] long atomic types, so at least on 32-bit ARM, MIPS, and PowerPC linking against libatomic is needed.

 [1]: https://github.com/telegramdesktop/tdesktop/blob/2c64676415a8ddc8340f9337bff8691aed47cdf2/Telegram/SourceFiles/export/output/export_output_stats.h#L28