### PR TITLE
Remove glib dependency from Qt

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
       CMAKE_VER: "3.16.3"
       UPLOAD_ARTIFACT: "false"
       ONLY_CACHE: "false"
-      MANUAL_CACHING: "1"
+      MANUAL_CACHING: "2"
       DOC_PATH: "docs/building-cmake.md"
 
     steps:
@@ -390,6 +390,7 @@ jobs:
           -system-freetype \
           -fontconfig \
           -no-opengl \
+          -no-glib \
           -no-gtk \
           -static \
           -openssl-linked \

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -262,6 +262,7 @@ Go to ***BuildPath*** and run
     -system-freetype \
     -fontconfig \
     -no-opengl \
+    -no-glib \
     -no-gtk \
     -static \
     -openssl-linked \


### PR DESCRIPTION
This enables the use of [Qt's own event dispatcher](https://github.com/qt/qtbase/blob/dev/src/corelib/kernel/qeventdispatcher_unix.cpp) instead of [glib one](https://github.com/qt/qtbase/blob/dev/src/corelib/kernel/qeventdispatcher_glib.cpp)
See also: https://github.com/desktop-app/cmake_helpers/pull/20