### PR TITLE
Respect user settings "Send by ..."

### DIFF
--- a/Telegram/SourceFiles/boxes/add_contact_box.cpp
+++ b/Telegram/SourceFiles/boxes/add_contact_box.cpp
@@ -494,6 +494,7 @@ void GroupInfoBox::prepare() {
 		_description->setInstantReplaces(Ui::InstantReplaces::Default());
 		_description->setInstantReplacesEnabled(
 			_navigation->session().settings().replaceEmojiValue());
+		_description->setSubmitSettings(_navigation->session().settings().sendSubmitWay());
 
 		connect(_description, &Ui::InputField::resized, [=] { descriptionResized(); });
 		connect(_description, &Ui::InputField::submitted, [=] { submit(); });

--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
@@ -767,6 +767,7 @@ not_null<Ui::InputField*> CreatePollBox::setupQuestion(
 		st::createPollFieldPadding);
 	InitField(getDelegate()->outerContainer(), question, _session);
 	question->setMaxLength(kQuestionLimit + kErrorLimit);
+	question->setSubmitSettings(_session->settings().sendSubmitWay());
 
 	const auto warning = CreateWarningLabel(
 		container,

--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
@@ -767,7 +767,7 @@ not_null<Ui::InputField*> CreatePollBox::setupQuestion(
 		st::createPollFieldPadding);
 	InitField(getDelegate()->outerContainer(), question, _session);
 	question->setMaxLength(kQuestionLimit + kErrorLimit);
-	question->setSubmitSettings(_session->settings().sendSubmitWay());
+	question->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
 
 	const auto warning = CreateWarningLabel(
 		container,

--- a/Telegram/SourceFiles/boxes/edit_caption_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_caption_box.cpp
@@ -260,7 +260,7 @@ EditCaptionBox::EditCaptionBox(
 		tr::lng_photo_caption(),
 		editData);
 	_field->setMaxLength(Global::CaptionLengthMax());
-	_field->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
+	_field->setSubmitSettings(_controller->session().settings().sendSubmitWay());
 	_field->setInstantReplaces(Ui::InstantReplaces::Default());
 	_field->setInstantReplacesEnabled(
 		_controller->session().settings().replaceEmojiValue());

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
@@ -500,6 +500,7 @@ object_ptr<Ui::RpWidget> Controller::createDescriptionEdit() {
 	result->entity()->setInstantReplaces(Ui::InstantReplaces::Default());
 	result->entity()->setInstantReplacesEnabled(
 		_peer->session().settings().replaceEmojiValue());
+	result->entity()->setSubmitSettings(_peer->session().settings().sendSubmitWay());
 	Ui::Emoji::SuggestionsController::Init(
 		_wrap->window(),
 		result->entity(),

--- a/Telegram/SourceFiles/boxes/rate_call_box.cpp
+++ b/Telegram/SourceFiles/boxes/rate_call_box.cpp
@@ -85,7 +85,7 @@ void RateCallBox::ratingChanged(int value) {
 				Ui::InputField::Mode::MultiLine,
 				tr::lng_call_rate_comment());
 			_comment->show();
-			_comment->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
+			_comment->setSubmitSettings(_session->settings().sendSubmitWay());
 			_comment->setMaxLength(kRateCallCommentLengthMax);
 			_comment->resize(width() - (st::callRatingPadding.left() + st::callRatingPadding.right()), _comment->height());
 

--- a/Telegram/SourceFiles/boxes/report_box.cpp
+++ b/Telegram/SourceFiles/boxes/report_box.cpp
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "lang/lang_keys.h"
 #include "data/data_peer.h"
+#include "main/main_session.h"
 #include "boxes/confirm_box.h"
 #include "ui/widgets/checkbox.h"
 #include "ui/widgets/buttons.h"
@@ -106,7 +107,7 @@ void ReportBox::reasonChanged(Reason reason) {
 				Ui::InputField::Mode::MultiLine,
 				tr::lng_report_reason_description());
 			_reasonOtherText->show();
-			_reasonOtherText->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
+			_reasonOtherText->setSubmitSettings(_peer->session().settings().sendSubmitWay());
 			_reasonOtherText->setMaxLength(kReportReasonLengthMax);
 			_reasonOtherText->resize(width() - (st::boxPadding.left() + st::boxOptionListPadding.left() + st::boxPadding.right()), _reasonOtherText->height());
 

--- a/Telegram/SourceFiles/boxes/send_files_box.cpp
+++ b/Telegram/SourceFiles/boxes/send_files_box.cpp
@@ -2046,7 +2046,7 @@ void SendFilesBox::applyAlbumOrder() {
 
 void SendFilesBox::setupCaption() {
 	_caption->setMaxLength(Global::CaptionLengthMax());
-	_caption->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
+	_caption->setSubmitSettings(_controller->session().settings().sendSubmitWay());
 	connect(_caption, &Ui::InputField::resized, [=] {
 		captionResized();
 	});

--- a/Telegram/SourceFiles/boxes/share_box.cpp
+++ b/Telegram/SourceFiles/boxes/share_box.cpp
@@ -206,6 +206,7 @@ void ShareBox::prepareCommentField() {
 	field->setMarkdownReplacesEnabled(rpl::single(true));
 	field->setEditLinkCallback(
 		DefaultEditLinkCallback(&_navigation->session(), field));
+	field->setSubmitSettings(_navigation->session().settings().sendSubmitWay());
 
 	InitSpellchecker(&_navigation->session(), field);
 	Ui::SendPendingMoveResizeEvents(_comment);

--- a/Telegram/SourceFiles/history/view/history_view_compose_controls.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_compose_controls.cpp
@@ -201,6 +201,7 @@ void ComposeControls::init() {
 
 void ComposeControls::initField() {
 	_field->setMaxHeight(st::historyComposeFieldMaxHeight);
+	_field->setSubmitSettings(_window->session().settings().sendSubmitWay());
 	//Ui::Connect(_field, &Ui::InputField::submitted, [=] { send(); });
 	Ui::Connect(_field, &Ui::InputField::cancelled, [=] { escape(); });
 	//Ui::Connect(_field, &Ui::InputField::tabbed, [=] { fieldTabbed(); });

--- a/Telegram/SourceFiles/support/support_helper.cpp
+++ b/Telegram/SourceFiles/support/support_helper.cpp
@@ -77,7 +77,7 @@ EditInfoBox::EditInfoBox(
 	text)
 , _submit(std::move(submit)) {
 	_field->setMaxLength(kMaxSupportInfoLength);
-	_field->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
+	_field->setSubmitSettings(session->settings().sendSubmitWay());
 	_field->setInstantReplaces(Ui::InstantReplaces::Default());
 	_field->setInstantReplacesEnabled(
 		session->settings().replaceEmojiValue());

--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -858,7 +858,7 @@ void Notification::showReplyField() {
 	_replyArea->show();
 	_replyArea->setFocus();
 	_replyArea->setMaxLength(MaxMessageSize);
-	_replyArea->setSubmitSettings(_item->history()->session().settings().sendSubmitWay());
+	_replyArea->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
 	_replyArea->setInstantReplaces(Ui::InstantReplaces::Default());
 	_replyArea->setInstantReplacesEnabled(
 		_item->history()->session().settings().replaceEmojiValue());

--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -858,7 +858,7 @@ void Notification::showReplyField() {
 	_replyArea->show();
 	_replyArea->setFocus();
 	_replyArea->setMaxLength(MaxMessageSize);
-	_replyArea->setSubmitSettings(Ui::InputField::SubmitSettings::Both);
+	_replyArea->setSubmitSettings(_item->history()->session().settings().sendSubmitWay());
 	_replyArea->setInstantReplaces(Ui::InstantReplaces::Default());
 	_replyArea->setInstantReplacesEnabled(
 		_item->history()->session().settings().replaceEmojiValue());


### PR DESCRIPTION
Respect user settings "Send by ..." for:

- forward dialog
- send file dialog
- edit caption dialog
- schedule messages
- new channel dialog
- group description edit dialog 
- rate call dialog
- report bot dialog
- support mode

Fixes #6634.

Change Enter only to Enter and Ctrl+Enter in create poll dialog.