### PR TITLE
Changed libvdpau source url

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -147,9 +147,8 @@ jobs:
         run: |
           cd $LibrariesPath
 
-          git clone git://anongit.freedesktop.org/vdpau/libvdpau
+          git clone https://gitlab.freedesktop.org/vdpau/libvdpau.git --depth=1 -b libvdpau-1.2
           cd libvdpau
-          git checkout libvdpau-1.2
           ./autogen.sh --enable-static
           make -j$(nproc)
           sudo make install

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -74,9 +74,8 @@ Go to ***BuildPath*** and run
     sudo make install
     cd ..
 
-    git clone git://anongit.freedesktop.org/vdpau/libvdpau
+    git clone https://gitlab.freedesktop.org/vdpau/libvdpau.git --depth=1 -b libvdpau-1.2
     cd libvdpau
-    git checkout libvdpau-1.2
     ./autogen.sh --enable-static
     make $MAKE_THREADS_CNT
     sudo make install


### PR DESCRIPTION
Anongit of FreeDesktop is not working now, and because of that libvdpau won't clone.

Since FreeDesktop uses GitLab instance for their projects, this PR changes libvdpau source url to their GitLab.