### PR TITLE
Increase media cache memory size to solve flicker issue

### DIFF
--- a/Telegram/SourceFiles/data/data_document.cpp
+++ b/Telegram/SourceFiles/data/data_document.cpp
@@ -42,7 +42,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace {
 
-constexpr auto kMemoryForCache = 32 * 1024 * 1024;
+// Updated Mar 3, 2020: Increase the size of the memory cache for media, to prevent items still being displayed from being unloaded.
+constexpr auto kMemoryForCache = 128 * 1024 * 1024; // was 32, updated to 128
 const auto kAnimatedStickerDimensions = QSize(512, 512);
 
 using FilePathResolve = DocumentData::FilePathResolve;


### PR DESCRIPTION
When displaying large numbers of GIFs, Telegram's Media Cache runs out of size and unloads items that are still being displayed.

You can see this issue in this video:
https://twitter.com/avwuff/status/1220169234682195970

**BACKGROUND:**
Telegram Desktop has an internal media cache limit, hardcoded to 32 megabytes.  When more than 32 mb of media is in memory, the media cache starts to unload items.  However, sometimes the items being unloaded are still on screen, resulting in them immediately trying to load themselves back into memory.

This can be seen with the flickering stickers.  What you are seeing is the following:
1. Normal sticker is being drawn
2. Normal sticker is unloaded, causing the blurry thumbnail to be drawn
3. This will also trigger the sticker to be loaded again
4. Now the large sticker is back in memory, it is drawn again.  Repeat.

**CAUSE:** 
This is especially noticeable when many GIFs are being rendered at once, such as when opening the saved GIF panel.  It is especially noticeable if many of those GIFs are high-quality, high-framerate GIFs.  But it can happen in any circumstance.

**FIX:**
A hard-coded media cache size of only 32mb is too small. I recommend increasing the size to 128mb.  This is still a small amount of memory for most computers that will be running Telegram Desktop.