### PR TITLE
Remove separate switch for GTK integration and fix condition for GTK file dialog

### DIFF
--- a/Telegram/cmake/telegram_options.cmake
+++ b/Telegram/cmake/telegram_options.cmake
@@ -7,7 +7,6 @@
 option(TDESKTOP_FORCE_GTK_FILE_DIALOG "Force using GTK file dialog (Linux only)." OFF)
 option(TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME "Disable automatic 'tg://' URL scheme handler registration." ${DESKTOP_APP_USE_PACKAGED})
 option(TDESKTOP_DISABLE_NETWORK_PROXY "Disable all code for working through Socks5 or MTProxy." OFF)
-option(TDESKTOP_DISABLE_GTK_INTEGRATION "Disable all code for GTK integration (Linux only)." ON)
 option(TDESKTOP_USE_PACKAGED_TGVOIP "Find libtgvoip using CMake instead of bundled one." ${DESKTOP_APP_USE_PACKAGED})
 option(TDESKTOP_API_TEST "Use test API credentials." OFF)
 set(TDESKTOP_API_ID "0" CACHE STRING "Provide 'api_id' for the Telegram API access.")
@@ -42,12 +41,12 @@ if (TDESKTOP_API_ID STREQUAL "0" OR TDESKTOP_API_HASH STREQUAL "")
     " ")
 endif()
 
-if (NOT DESKTOP_APP_SPECIAL_TARGET STREQUAL "")
+if (NOT DESKTOP_APP_USE_PACKAGED)
     set(TDESKTOP_FORCE_GTK_FILE_DIALOG ON)
 endif()
 
-if (TDESKTOP_FORCE_GTK_FILE_DIALOG)
-    set(TDESKTOP_DISABLE_GTK_INTEGRATION OFF)
+if (NOT TDESKTOP_FORCE_GTK_FILE_DIALOG)
+    set(TDESKTOP_DISABLE_GTK_INTEGRATION ON)
 endif()
 
 if (DESKTOP_APP_DISABLE_SPELLCHECK)


### PR DESCRIPTION
GTK integration is used only for GTK file dialog, so there are no need in separate option in cmake
Enabling of TDESKTOP_FORCE_GTK_FILE_DIALOG is changed to by `NOT DESKTOP_APP_USE_PACKAGED` rather than by `NOT DESKTOP_APP_SPECIAL_TARGET STREQUAL ""` since any static build has ugly file dialog (also debug builds on GitHub actions would have GTK file dialog due to this change)