### PR TITLE
Fixing FFmpeg not playing videos/gifs/animated stickers on armhf and arm64 #6647

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -222,6 +222,7 @@ parts:
       - --disable-programs
       - --disable-doc
       - --disable-everything
+      - --disable-neon
       - --enable-gpl
       - --enable-version3
       - --enable-libopus


### PR DESCRIPTION
by adding `--disable-neon` to FFMPEG configflags in snap config file
thanks to @ilya-fedin for finding [the fix](https://github.com/telegramdesktop/tdesktop/issues/6647#issuecomment-596870152)