### PR TITLE
Disable SNI tray icon name setting in snap

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -451,7 +451,7 @@ void MainWindow::setSNITrayIcon(int counter, bool muted, bool firstShow) {
 	const auto iconName = GetTrayIconName(counter, muted);
 
 	if (qEnvironmentVariableIsSet(kDisableTrayCounter.utf8())
-		&& (!iconName.isEmpty()
+		&& ((!iconName.isEmpty() && !InSnap())
 			|| qEnvironmentVariableIsSet(kForcePanelIcon.utf8()))) {
 		if (_sniTrayIcon->iconName() == iconName) {
 			return;


### PR DESCRIPTION
Otherwise there are a dummy icon when tray counter is disabled