### PR TITLE
set msbuild platform to x86

### DIFF
--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -70,8 +70,8 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
 
     git clone https://github.com/desktop-app/lzma.git
     cd lzma\C\Util\LzmaLib
-    msbuild LzmaLib.sln /property:Configuration=Debug
-    msbuild LzmaLib.sln /property:Configuration=Release
+    msbuild LzmaLib.sln /property:Configuration=Debug /property:Platform=x86
+    msbuild LzmaLib.sln /property:Configuration=Release /property:Platform=x86
     cd ..\..\..\..
 
     git clone https://github.com/openssl/openssl.git openssl_1_1_1


### PR DESCRIPTION
On my 64-bit machine it tries to look for a x64 platform and fails, this forces it to x86 and build succeeds.  I'm having other build problems with NASM at the moment though so I'm not sure if this needs to be applied in more places.