### PR TITLE
Make Telegram Desktop usable on phones

### DIFF
--- a/Telegram/SourceFiles/window/window.style
+++ b/Telegram/SourceFiles/window/window.style
@@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";
 using "history/history.style";
 using "boxes/boxes.style"; // UserpicButton
 
-windowMinWidth: 380px;
+windowMinWidth: 360px;
 windowMinHeight: 480px;
 windowDefaultWidth: 800px;
 windowDefaultHeight: 600px;
@@ -19,7 +19,7 @@ windowBigDefaultHeight: 768px;
 
 columnMinimalWidthLeft: 260px;
 columnMaximalWidthLeft: 540px;
-columnMinimalWidthMain: 380px;
+columnMinimalWidthMain: 360px;
 columnDesiredWidthMain: 512px;
 columnMinimalWidthThird: 292px;
 columnMaximalWidthThird: 392px;


### PR DESCRIPTION
Phones running Linux, such as the Librem5 and PinePhone, use a 360x720
resolution for the display. This causes Telegram Desktop to overflow by
20px, which leads to usablility issues.

Setting the minimum width to 360px is enough to make it scale properly
and retain full usability.