### PR TITLE
Fixes for linux action:

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -189,23 +189,28 @@ jobs:
 
           git clone --branch release/3.4 $GIT/FFmpeg/FFmpeg ffmpeg
           cd ffmpeg
-          ./configure --prefix=$LibrariesPath/ffmpeg-cache \
-          --enable-protocol=file --enable-libopus \
+          ./configure \
+          --disable-debug \
           --disable-programs \
           --disable-doc \
           --disable-network \
+          --disable-autodetect \
           --disable-everything \
+          --disable-neon \
+          --disable-iconv \
+          --enable-libopus \
+          --enable-vaapi \
+          --enable-vdpau \
+          --enable-protocol=file \
           --enable-hwaccel=h264_vaapi \
           --enable-hwaccel=h264_vdpau \
           --enable-hwaccel=mpeg4_vaapi \
           --enable-hwaccel=mpeg4_vdpau \
           --enable-decoder=aac \
-          --enable-decoder=aac_at \
           --enable-decoder=aac_fixed \
           --enable-decoder=aac_latm \
           --enable-decoder=aasc \
           --enable-decoder=alac \
-          --enable-decoder=alac_at \
           --enable-decoder=flac \
           --enable-decoder=gif \
           --enable-decoder=h264 \
@@ -227,14 +232,12 @@ jobs:
           --enable-decoder=msmpeg4v3 \
           --enable-decoder=opus \
           --enable-decoder=pcm_alaw \
-          --enable-decoder=pcm_alaw_at \
           --enable-decoder=pcm_f32be \
           --enable-decoder=pcm_f32le \
           --enable-decoder=pcm_f64be \
           --enable-decoder=pcm_f64le \
           --enable-decoder=pcm_lxf \
           --enable-decoder=pcm_mulaw \
-          --enable-decoder=pcm_mulaw_at \
           --enable-decoder=pcm_s16be \
           --enable-decoder=pcm_s16be_planar \
           --enable-decoder=pcm_s16le \
@@ -289,7 +292,7 @@ jobs:
           --enable-muxer=opus
 
           make -j$(nproc)
-          sudo make install
+          sudo make DESTDIR="$LibrariesPath/ffmpeg-cache" install
           cd ..
           rm -rf ffmpeg
       - name: FFmpeg install.
@@ -298,7 +301,7 @@ jobs:
           #List of files from cmake/external/ffmpeg/CMakeLists.txt.
           copyLib() {
             mkdir -p ffmpeg/$1
-            yes | cp -i ffmpeg-cache/lib/$1.a ffmpeg/$1/$1.a
+            yes | cp -i ffmpeg-cache/usr/local/lib/$1.a ffmpeg/$1/$1.a
           }
           copyLib libavformat
           copyLib libavcodec
@@ -306,7 +309,7 @@ jobs:
           copyLib libswscale
           copyLib libavutil
 
-          sudo cp -R ffmpeg-cache/. /usr/local/
+          sudo cp -R ffmpeg-cache/. /
 
       - name: PortAudio.
         run: |
@@ -327,7 +330,13 @@ jobs:
 
           git clone -b openal-soft-1.20.1 --depth=1 $GIT/kcat/openal-soft.git
           cd openal-soft/build
-          cmake -D LIBTYPE:STRING=STATIC ..
+          cmake .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DLIBTYPE:STRING=STATIC \
+          -DALSOFT_EXAMPLES=OFF \
+          -DALSOFT_TESTS=OFF \
+          -DALSOFT_UTILS=OFF \
+          -DALSOFT_CONFIG=OFF
           make -j$(nproc)
           sudo make install
           cd -
@@ -348,16 +357,15 @@ jobs:
           git clone -b OpenSSL_${OPENSSL_VER}-stable --depth=1 \
             $GIT/openssl/openssl $opensslDir
           cd $opensslDir
-          ./config --prefix=$LibrariesPath/openssl-cache
+          ./config --prefix="$OPENSSL_PREFIX"
           make -j$(nproc)
-          sudo make install_sw
+          sudo make DESTDIR="$LibrariesPath/openssl-cache" install_sw
           cd ..
           rm -rf $opensslDir
       - name: OpenSSL install.
         run: |
           cd $LibrariesPath
-          sudo mkdir -p $OPENSSL_PREFIX
-          sudo cp -R openssl-cache/. $OPENSSL_PREFIX/
+          sudo cp -R openssl-cache/. /
 
       - name: Libxkbcommon.
         run: |
@@ -377,7 +385,7 @@ jobs:
 
           git clone -b 1.16 https://gitlab.freedesktop.org/wayland/wayland
           cd wayland
-          ./autogen.sh --enable-static --disable-documentation
+          ./autogen.sh --enable-static --disable-documentation  --disable-dtd-validation
           make -j$(nproc)
           sudo make install
           cd ..
@@ -406,9 +414,8 @@ jobs:
           git clone $GIT/desktop-app/nimf.git
           cd ../../../..
 
-          ./configure -prefix "$LibrariesPath/qt-cache" \
+          ./configure -prefix "$QT_PREFIX" \
           -release \
-          -force-debug-info \
           -opensource \
           -confirm-license \
           -qt-zlib \
@@ -417,8 +424,6 @@ jobs:
           -qt-harfbuzz \
           -qt-pcre \
           -qt-xcb \
-          -system-freetype \
-          -fontconfig \
           -no-gtk \
           -static \
           -dbus-runtime \
@@ -428,14 +433,13 @@ jobs:
           -nomake tests
 
           make -j$(nproc)
-          sudo make install
+          sudo make INSTALL_ROOT="$LibrariesPath/qt-cache" install
           cd ..
           rm -rf qt_${QT}
       - name: Qt 5.12.5 install.
         run: |
           cd $LibrariesPath
-          sudo mkdir -p $QT_PREFIX
-          sudo cp -R qt-cache/. $QT_PREFIX/
+          sudo cp -R qt-cache/. /
 
       - name: Breakpad cache.
         id: cache-breakpad
@@ -467,9 +471,9 @@ jobs:
           cd ..
 
           cd breakpad
-          ./configure --prefix=$BreakpadCache
+          ./configure
           make -j$(nproc)
-          sudo make install
+          sudo make DESTDIR="$BreakpadCache" install
           cd src
           rm -r testing
           git clone $GIT/google/googletest testing
@@ -486,7 +490,7 @@ jobs:
       - name: Breakpad install.
         run: |
           cd $LibrariesPath
-          sudo cp -R breakpad-cache/. /usr/local/
+          sudo cp -R breakpad-cache/. /
           mkdir -p breakpad/out/Default/
           cp breakpad-cache/dump_syms breakpad/out/Default/dump_syms
 

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -85,23 +85,27 @@ Go to ***BuildPath*** and run
     cd ffmpeg
     git checkout release/3.4
 
-    ./configure --prefix=/usr/local \
-    --enable-protocol=file --enable-libopus \
+    ./configure \
     --disable-programs \
     --disable-doc \
     --disable-network \
+    --disable-autodetect \
     --disable-everything \
+    --disable-neon \
+    --disable-iconv \
+    --enable-libopus \
+    --enable-vaapi \
+    --enable-vdpau \
+    --enable-protocol=file \
     --enable-hwaccel=h264_vaapi \
     --enable-hwaccel=h264_vdpau \
     --enable-hwaccel=mpeg4_vaapi \
     --enable-hwaccel=mpeg4_vdpau \
     --enable-decoder=aac \
-    --enable-decoder=aac_at \
     --enable-decoder=aac_fixed \
     --enable-decoder=aac_latm \
     --enable-decoder=aasc \
     --enable-decoder=alac \
-    --enable-decoder=alac_at \
     --enable-decoder=flac \
     --enable-decoder=gif \
     --enable-decoder=h264 \
@@ -123,14 +127,12 @@ Go to ***BuildPath*** and run
     --enable-decoder=msmpeg4v3 \
     --enable-decoder=opus \
     --enable-decoder=pcm_alaw \
-    --enable-decoder=pcm_alaw_at \
     --enable-decoder=pcm_f32be \
     --enable-decoder=pcm_f32le \
     --enable-decoder=pcm_f64be \
     --enable-decoder=pcm_f64le \
     --enable-decoder=pcm_lxf \
     --enable-decoder=pcm_mulaw \
-    --enable-decoder=pcm_mulaw_at \
     --enable-decoder=pcm_s16be \
     --enable-decoder=pcm_s16be_planar \
     --enable-decoder=pcm_s16le \
@@ -200,11 +202,12 @@ Go to ***BuildPath*** and run
     cd openal-soft
     git checkout openal-soft-1.20.1
     cd build
-    if [ `uname -p` == "i686" ]; then
-    cmake -D LIBTYPE:STRING=STATIC -D ALSOFT_UTILS:BOOL=OFF ..
-    else
-    cmake -D LIBTYPE:STRING=STATIC ..
-    fi
+    cmake .. \
+    -DLIBTYPE:STRING=STATIC \
+    -DALSOFT_EXAMPLES=OFF \
+    -DALSOFT_TESTS=OFF \
+    -DALSOFT_UTILS=OFF \
+    -DALSOFT_CONFIG=OFF
     make $MAKE_THREADS_CNT
     sudo make install
     cd ../..
@@ -227,7 +230,7 @@ Go to ***BuildPath*** and run
 
     git clone -b 1.16 https://gitlab.freedesktop.org/wayland/wayland
     cd wayland
-    ./autogen.sh --enable-static --disable-documentation
+    ./autogen.sh --enable-static --disable-documentation  --disable-dtd-validation
     make -j$(nproc)
     sudo make install
     cd ..
@@ -260,8 +263,6 @@ Go to ***BuildPath*** and run
     -qt-harfbuzz \
     -qt-pcre \
     -qt-xcb \
-    -system-freetype \
-    -fontconfig \
     -no-gtk \
     -static \
     -dbus-runtime \


### PR DESCRIPTION
* Disable building of unneeded openal tools and tests
* Disable ffmpeg linkage with unneeded libraries
* Disable unneeded dtd validation for libwayland
* Omit Qt flags that set to default values
* Fix prefix usage
* Build dependencies in release mode to reduce build size