### PR TITLE
Add .opus and .oga files as song formats

### DIFF
--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -552,6 +552,7 @@ bool FileLoadTask::CheckForSong(
 		qstr("audio/aac"),
 		qstr("audio/ogg"),
 		qstr("audio/flac"),
+		qstr("audio/opus"),
 	};
 	static const auto extensions = {
 		qstr(".mp3"),
@@ -559,6 +560,8 @@ bool FileLoadTask::CheckForSong(
 		qstr(".aac"),
 		qstr(".ogg"),
 		qstr(".flac"),
+		qstr(".opus"),
+		qstr(".oga"),
 	};
 	if (!filepath.isEmpty()
 		&& !CheckMimeOrExtensions(


### PR DESCRIPTION
Telegram can already play .ogg Vorbis and Opus files correctly on Desktop and Android.
But .opus and .oga files sent from the Desktop app won't get marked as audio files.

This pull request will make any .opus and .oga files actually marked as music files that can be read from Telegram directly.

I've tested it and files sent from the patched client will work correctly on the current Desktop app and Android app.

![Annotation 2020-04-19 185426](https://user-images.githubusercontent.com/1633366/79694243-6c68a700-826f-11ea-8ab4-856fc19517fe.png)

![Screenshot_20200419-185530](https://user-images.githubusercontent.com/1633366/79694245-6ecb0100-826f-11ea-8578-b7da2b6d49f0.jpg)

Related issues: #5840 #1754 