### PR TITLE
Updated supported systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The source code is published under GPLv3 with OpenSSL exception, the license is 
 
 ## Supported systems
 
-* Windows XP - Windows 10 (**not** RT)
-* Mac OS X 10.8 - Mac OS X 10.15
-* Mac OS X 10.6 - Mac OS X 10.7 (separate build)
+* Windows 7 - Windows 10 (**not** RT)
+* macOS 10.12 - macOS 10.15
+* Mac OS X 10.10 - Mac OS X 10.11 (separate build)
 * Ubuntu 12.04 - Ubuntu 20.04
 * Fedora 22 - Fedora 31
 * [Snappy](https://snapcraft.io/telegram-desktop)


### PR DESCRIPTION
XP and Vista are no longer supported. Win 7 is the min version.

Currently there are two installers for Mac: 
- macOS 10.12 - 10.15 
- Mac OS X 10.10 - 10.11

Since 10.12, the Mac system started to be called **macOS**.