### PR TITLE
Show bot privacy status in members list

### DIFF
--- a/Telegram/SourceFiles/boxes/peer_list_box.h
+++ b/Telegram/SourceFiles/boxes/peer_list_box.h
@@ -130,7 +130,7 @@ public:
 		LastSeen,
 		Custom,
 	};
-	void refreshStatus();
+	virtual void refreshStatus();
 	crl::time refreshStatusTime() const;
 
 	void setAbsoluteIndex(int index) {

--- a/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
@@ -1786,6 +1786,12 @@ std::unique_ptr<PeerListRow> ParticipantsBoxController::createRow(
 				|| _additional.canEditAdmin(user))) {
 			row->setActionLink(tr::lng_profile_kick(tr::now));
 		}
+		if (_role == Role::Members && user->isBot()) {
+			auto seesAllMessages = (user->botInfo->readsAllHistory || _additional.adminRights(user).has_value());
+			row->setCustomStatus(seesAllMessages
+				? tr::lng_status_bot_reads_all(tr::now)
+				: tr::lng_status_bot_not_reads_all(tr::now));
+		}
 	}
 	return row;
 }

--- a/Telegram/SourceFiles/calls/calls_box_controller.cpp
+++ b/Telegram/SourceFiles/calls/calls_box_controller.cpp
@@ -109,7 +109,7 @@ public:
 		bool actionSelected) override;
 
 private:
-	void refreshStatus();
+	void refreshStatus() override;
 	static Type ComputeType(not_null<const HistoryItem*> item);
 
 	std::vector<not_null<HistoryItem*>> _items;

--- a/Telegram/SourceFiles/info/profile/info_profile_members_controllers.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_members_controllers.cpp
@@ -93,6 +93,17 @@ void MemberListRow::paintNameIcon(
 	icon->paint(p, x, y, outerWidth);
 }
 
+void MemberListRow::refreshStatus() {
+	if (user()->isBot()) {
+		auto seesAllMessages = (user()->botInfo->readsAllHistory || _type.rights != Rights::Normal);
+		setCustomStatus(seesAllMessages
+			? tr::lng_status_bot_reads_all(tr::now)
+			: tr::lng_status_bot_not_reads_all(tr::now));
+	} else {
+		PeerListRow::refreshStatus();
+	}
+}
+
 std::unique_ptr<PeerListController> CreateMembersController(
 		not_null<Window::SessionNavigation*> navigation,
 		not_null<PeerData*> peer) {

--- a/Telegram/SourceFiles/info/profile/info_profile_members_controllers.h
+++ b/Telegram/SourceFiles/info/profile/info_profile_members_controllers.h
@@ -46,6 +46,7 @@ public:
 		int y,
 		int outerWidth,
 		bool selected) override;
+	void refreshStatus() override;
 
 	not_null<UserData*> user() const;
 	bool canRemove() const {


### PR DESCRIPTION
With this PR bot privacy status will be shown in group member list instead of "bot". Fixes #5344.

Before PR:
![](https://user-images.githubusercontent.com/2903496/80772813-97e96c80-8b60-11ea-83f0-25f6302629a3.png)

After PR:
![](https://user-images.githubusercontent.com/2903496/80772836-aafc3c80-8b60-11ea-84f1-7c6d1edc288a.png)

This also includes group members manage box:
![](https://user-images.githubusercontent.com/2903496/80773062-67ee9900-8b61-11ea-9518-c12daefcc260.png)

