### PR TITLE
Use "subscribers" instead of "members" in channels

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -118,6 +118,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_chat_status_online#one" = "{count} online";
 "lng_chat_status_online#other" = "{count} online";
 "lng_chat_status_members_online" = "{members_count}, {online_count}";
+"lng_chat_status_subscribers#one" = "{count} subscriber";
+"lng_chat_status_subscribers#other" = "{count} subscribers";
 
 "lng_channel_status" = "channel";
 "lng_group_status" = "group";
@@ -764,6 +766,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_profile_common_groups#one" = "{count} group in common";
 "lng_profile_common_groups#other" = "{count} groups in common";
 "lng_profile_participants_section" = "Members";
+"lng_profile_subscribers_section" = "Subscribers";
 "lng_profile_mobile_number" = "Mobile:";
 "lng_profile_username" = "Username:";
 "lng_profile_link" = "Link:";
@@ -885,6 +888,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_manage_channel_info" = "Channel Info";
 "lng_manage_peer_recent_actions" = "Recent Actions";
 "lng_manage_peer_members" = "Members";
+"lng_manage_peer_subscribers" = "Subscribers";
 "lng_manage_peer_administrators" = "Administrators";
 "lng_manage_peer_exceptions" = "Exceptions";
 "lng_manage_peer_removed_users" = "Removed users";

--- a/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
@@ -1056,7 +1056,9 @@ void ParticipantsBoxController::prepare() {
 		switch (_role) {
 		case Role::Admins: return tr::lng_channel_admins();
 		case Role::Profile:
-		case Role::Members: return tr::lng_profile_participants_section();
+		case Role::Members: return (_peer->isChannel() && !_peer->isMegagroup()
+			? tr::lng_profile_subscribers_section()
+			: tr::lng_profile_participants_section());
 		case Role::Restricted: return tr::lng_exceptions_list_title();
 		case Role::Kicked: return tr::lng_removed_list_title();
 		}

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
@@ -967,7 +967,7 @@ void Controller::fillManageSection() {
 	if (canViewMembers) {
 		AddButtonWithCount(
 			_controls.buttonsLayout,
-			tr::lng_manage_peer_members(),
+			(_isGroup ? tr::lng_manage_peer_members() : tr::lng_manage_peer_subscribers()),
 			Info::Profile::MigratedOrMeValue(
 				_peer
 			) | rpl::map(

--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
@@ -873,7 +873,9 @@ void TopBarWidget::updateOnlineDisplay() {
 				text = tr::lng_group_status(tr::now);
 			}
 		} else if (channel->membersCount() > 0) {
-			text = tr::lng_chat_status_members(tr::now, lt_count_decimal, channel->membersCount());
+			text = channel->isMegagroup()
+				? tr::lng_chat_status_members(tr::now, lt_count_decimal, channel->membersCount())
+				: tr::lng_chat_status_subscribers(tr::now, lt_count_decimal, channel->membersCount());
 
 		} else {
 			text = channel->isMegagroup() ? tr::lng_group_status(tr::now) : tr::lng_channel_status(tr::now);

--- a/Telegram/SourceFiles/info/info_top_bar.cpp
+++ b/Telegram/SourceFiles/info/info_top_bar.cpp
@@ -605,6 +605,11 @@ rpl::producer<QString> TitleValue(
 		return tr::lng_profile_common_groups_section();
 
 	case Section::Type::Members:
+		if (const auto channel = peer->asChannel()) {
+			return channel->isMegagroup()
+				? tr::lng_profile_participants_section()
+				: tr::lng_profile_subscribers_section();
+		}
 		return tr::lng_profile_participants_section();
 
 	//case Section::Type::Channels: // #feed

--- a/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
@@ -835,7 +835,7 @@ object_ptr<Ui::RpWidget> SetupChannelMembers(
 			channel,
 			MTPDchannelFull::Flag::f_can_view_participants),
 			(_1 > 0) && _2);
-	auto membersText = tr::lng_chat_status_members(
+	auto membersText = tr::lng_chat_status_subscribers(
 		lt_count_decimal,
 		MembersCountValue(channel) | tr::to_count());
 	auto membersCallback = [=] {

--- a/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
@@ -146,10 +146,15 @@ auto ChatStatusText(int fullCount, int onlineCount, bool isGroup) {
 			lt_online_count,
 			OnlineStatusText(onlineCount));
 	} else if (fullCount > 0) {
-		return tr::lng_chat_status_members(
-			tr::now,
-			lt_count_decimal,
-			fullCount);
+		return isGroup
+			? tr::lng_chat_status_members(
+				tr::now,
+				lt_count_decimal,
+				fullCount)
+			: tr::lng_chat_status_subscribers(
+				tr::now,
+				lt_count_decimal,
+				fullCount);
 	}
 	return isGroup
 		? tr::lng_group_status(tr::now)


### PR DESCRIPTION
This PR changes "members" to "subscribers" in channels, since other official apps uses it too. Fixes #6181.

## Before PR

### Channel top bar
![](https://user-images.githubusercontent.com/2903496/80774529-f5cc8300-8b65-11ea-814b-875fb5a614fa.png)

### Channel profile cover
![](https://user-images.githubusercontent.com/2903496/80774544-054bcc00-8b66-11ea-9327-4c9c603ab18d.png)

### Channel profile info
![](https://user-images.githubusercontent.com/2903496/80774844-bb171a80-8b66-11ea-9908-66d482114eb5.png)

### Channel subscriber list
![](https://user-images.githubusercontent.com/2903496/80774975-0af5e180-8b67-11ea-9c65-4b4841656931.png)

### Channel admin box
![](https://user-images.githubusercontent.com/2903496/80774569-18f73280-8b66-11ea-9c4b-20b3a78f9958.png)


## After PR

### Channel top bar
![](https://user-images.githubusercontent.com/2903496/80774707-67a4cc80-8b66-11ea-9b20-cd7214c6c91d.png)

### Channel profile cover
![](https://user-images.githubusercontent.com/2903496/80774734-7ab79c80-8b66-11ea-9476-e5629563906b.png)

### Channel profile info
![](https://user-images.githubusercontent.com/2903496/80774891-d71abc00-8b66-11ea-8a4b-b0b0fc129a73.png)

### Channel subscriber list
![](https://user-images.githubusercontent.com/2903496/80774954-f9acd500-8b66-11ea-8874-38a213abb08b.png)

### Channel admin box
![](https://user-images.githubusercontent.com/2903496/80774774-97ec6b00-8b66-11ea-803f-d1e251bd4f3f.png)
