### PR TITLE
Move "X groups in common" in shared media to bottom

### DIFF
--- a/Telegram/SourceFiles/info/media/info_media_inner_widget.cpp
+++ b/Telegram/SourceFiles/info/media/info_media_inner_widget.cpp
@@ -124,10 +124,10 @@ void InnerWidget::createTypeButtons() {
 	addMediaButton(Type::File, st::infoIconMediaFile);
 	addMediaButton(Type::MusicFile, st::infoIconMediaAudio);
 	addMediaButton(Type::Link, st::infoIconMediaLink);
+	addMediaButton(Type::RoundVoiceFile, st::infoIconMediaVoice);
 	if (auto user = _controller->key().peer()->asUser()) {
 //		addCommonGroupsButton(user, st::infoIconMediaGroup);
 	}
-	addMediaButton(Type::RoundVoiceFile, st::infoIconMediaVoice);
 
 	content->add(object_ptr<Ui::FixedHeightWidget>(
 		content,

--- a/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
@@ -169,10 +169,10 @@ object_ptr<Ui::RpWidget> InnerWidget::setupSharedMedia(
 	addMediaButton(MediaType::File, st::infoIconMediaFile);
 	addMediaButton(MediaType::MusicFile, st::infoIconMediaAudio);
 	addMediaButton(MediaType::Link, st::infoIconMediaLink);
+	addMediaButton(MediaType::RoundVoiceFile, st::infoIconMediaVoice);
 	if (auto user = _peer->asUser()) {
 		addCommonGroupsButton(user, st::infoIconMediaGroup);
 	}
-	addMediaButton(MediaType::RoundVoiceFile, st::infoIconMediaVoice);
 
 	auto result = object_ptr<Ui::SlideWrap<Ui::VerticalLayout>>(
 		parent,


### PR DESCRIPTION
This PR moves "X groups in common" button in profile after media types, since "common groups" is not a media type itself. Fixes #5476.

Before:
![](https://user-images.githubusercontent.com/2903496/80973067-91404b00-8e27-11ea-8bad-8305c24218f9.png)

After:
![](https://user-images.githubusercontent.com/2903496/80973137-a87f3880-8e27-11ea-9f2b-2035016d504b.png)
