### PR TITLE
Remove old `cd` to platforminputcontexts plugins

### DIFF
--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -244,7 +244,6 @@ Go to ***BuildPath*** and run
     git submodule update qtsvg
     cd qtbase
     git apply ../../patches/qtbase_5_12_8.diff
-    cd src/plugins/platforminputcontexts
     cd ..
 
     OPENSSL_DIR=/usr/local/desktop-app/openssl-1.1.1


### PR DESCRIPTION
This PR fixes CMake docs. There is no need to clone hime, nimf and fcitx to `qtbase/src/plugins/platforminputcontexts`, and `cd` to this folder was removed in CI, but wasn't removed in docs.