### PR TITLE
Remove Portaudio from building instructions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -335,19 +335,6 @@ jobs:
 
           sudo cp -R ffmpeg-cache/. /
 
-      - name: PortAudio.
-        run: |
-          cd $LibrariesPath
-
-          git clone https://git.assembla.com/portaudio.git
-          cd portaudio
-          git checkout 396fe4b669
-          ./configure
-          make -j$(nproc)
-          sudo make install
-          cd ..
-          rm -rf portaudio
-
       - name: OpenAL Soft.
         run: |
           cd $LibrariesPath

--- a/docs/building-cmake.md
+++ b/docs/building-cmake.md
@@ -189,14 +189,6 @@ Go to ***BuildPath*** and run
     sudo make install
     cd ..
 
-    git clone https://git.assembla.com/portaudio.git
-    cd portaudio
-    git checkout 396fe4b669
-    ./configure
-    make $MAKE_THREADS_CNT
-    sudo make install
-    cd ..
-
     git clone git://repo.or.cz/openal-soft.git
     cd openal-soft
     git checkout openal-soft-1.20.1


### PR DESCRIPTION
Since it loaded at runtime with dlopen anyway and headers from the system package are OK