### PR TITLE
feat: add setting checkbox to change messages width wide/tight

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -359,6 +359,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_bg_show_all" = "Show all themes";
 "lng_settings_bg_tile" = "Tile background";
 "lng_settings_adaptive_wide" = "Adaptive layout for wide screens";
+"lng_settings_wide_msg_width" = "Wide message width";
 
 "lng_settings_section_call_settings" = "Calls Settings";
 "lng_settings_call_section_output" = "Speakers and headphones";

--- a/Telegram/SourceFiles/facades.cpp
+++ b/Telegram/SourceFiles/facades.cpp
@@ -308,7 +308,9 @@ struct Data {
 	Adaptive::WindowLayout AdaptiveWindowLayout = Adaptive::WindowLayout::Normal;
 	Adaptive::ChatLayout AdaptiveChatLayout = Adaptive::ChatLayout::Normal;
 	bool AdaptiveForWide = true;
+	bool WideMessageWidth = false;
 	base::Observable<void> AdaptiveChanged;
+	base::Observable<void> WideMessageWidthChanged;
 
 	bool DialogsFiltersEnabled = false;
 	bool ModerateModeEnabled = false;
@@ -437,7 +439,9 @@ DefineRefVar(Global, SingleQueuedInvokation, HandleDelayedPeerUpdates);
 DefineVar(Global, Adaptive::WindowLayout, AdaptiveWindowLayout);
 DefineVar(Global, Adaptive::ChatLayout, AdaptiveChatLayout);
 DefineVar(Global, bool, AdaptiveForWide);
+DefineVar(Global, bool, WideMessageWidth);
 DefineRefVar(Global, base::Observable<void>, AdaptiveChanged);
+DefineRefVar(Global, base::Observable<void>, WideMessageWidthChanged);
 
 DefineVar(Global, bool, DialogsFiltersEnabled);
 DefineVar(Global, bool, ModerateModeEnabled);

--- a/Telegram/SourceFiles/facades.h
+++ b/Telegram/SourceFiles/facades.h
@@ -147,7 +147,9 @@ DeclareRefVar(SingleQueuedInvokation, HandleDelayedPeerUpdates);
 DeclareVar(Adaptive::WindowLayout, AdaptiveWindowLayout);
 DeclareVar(Adaptive::ChatLayout, AdaptiveChatLayout);
 DeclareVar(bool, AdaptiveForWide);
+DeclareVar(bool, WideMessageWidth);
 DeclareRefVar(base::Observable<void>, AdaptiveChanged);
+DeclareRefVar(base::Observable<void>, WideMessageWidthChanged);
 
 DeclareVar(bool, DialogsFiltersEnabled);
 DeclareVar(bool, ModerateModeEnabled);
@@ -247,6 +249,10 @@ inline base::Observable<void> &Changed() {
 	return Global::RefAdaptiveChanged();
 }
 
+inline base::Observable<void> &WideMessageChanged() {
+	return Global::RefWideMessageWidthChanged();
+}
+
 inline bool OneColumn() {
 	return Global::AdaptiveWindowLayout() == WindowLayout::OneColumn;
 }
@@ -266,6 +272,10 @@ inline bool ChatNormal() {
 
 inline bool ChatWide() {
 	return !ChatNormal();
+}
+
+inline bool ChatWideMessage() {
+	return Global::WideMessageWidth();
 }
 
 } // namespace Adaptive

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -468,6 +468,17 @@ HistoryWidget::HistoryWidget(
 		}
 	});
 
+	subscribe(Adaptive::WideMessageChanged(), [=] {
+		if (_history) {
+			_history->forceFullResize();
+			if (_migrated) {
+				_migrated->forceFullResize();
+			}
+			updateHistoryGeometry();
+			update();
+		}
+	});
+
 	session().data().unreadItemAdded(
 	) | rpl::start_with_next([=](not_null<HistoryItem*> item) {
 		unreadMessageAdded(item);

--- a/Telegram/SourceFiles/history/view/history_view_message.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_message.cpp
@@ -1787,7 +1787,9 @@ QRect Message::countGeometry() const {
 	//	contentLeft += st::msgPhotoSkip - (hmaxwidth - hwidth);
 	}
 	accumulate_min(contentWidth, maxWidth());
-	accumulate_min(contentWidth, st::msgMaxWidth);
+	if (!Adaptive::ChatWideMessage()) {
+		accumulate_min(contentWidth, st::msgMaxWidth);
+	}
 	if (mediaWidth < contentWidth) {
 		const auto textualWidth = plainMaxWidth();
 		if (mediaWidth < textualWidth
@@ -1829,7 +1831,9 @@ int Message::resizeContentGetHeight(int newWidth) {
 		contentWidth -= st::msgPhotoSkip;
 	}
 	accumulate_min(contentWidth, maxWidth());
-	accumulate_min(contentWidth, st::msgMaxWidth);
+	if (!Adaptive::ChatWideMessage()) {
+		accumulate_min(contentWidth, st::msgMaxWidth);
+	}
 	if (mediaDisplayed) {
 		media->resizeGetHeight(contentWidth);
 		if (media->width() < contentWidth) {

--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -494,6 +494,7 @@ MainWidget::MainWidget(
 	});
 
 	subscribe(Adaptive::Changed(), [this]() { handleAdaptiveLayoutUpdate(); });
+	subscribe(Adaptive::WideMessageChanged(), [this]() { showAll(); });
 
 	_dialogs->show();
 	if (Adaptive::OneColumn()) {

--- a/Telegram/SourceFiles/settings/settings_chat.cpp
+++ b/Telegram/SourceFiles/settings/settings_chat.cpp
@@ -957,6 +957,15 @@ void SetupChatBackground(
 				Global::AdaptiveForWide(),
 				st::settingsCheckbox),
 			st::settingsSendTypePadding));
+	const auto wideMessageWidth = inner->add(
+		object_ptr<Ui::SlideWrap<Ui::Checkbox>>(
+			inner,
+			object_ptr<Ui::Checkbox>(
+				inner,
+				tr::lng_settings_wide_msg_width(tr::now),
+				Global::WideMessageWidth(),
+				st::settingsCheckbox),
+			st::settingsSendTypePadding));
 
 	tile->checkedChanges(
 	) | rpl::start_with_next([](bool checked) {
@@ -988,6 +997,13 @@ void SetupChatBackground(
 		Adaptive::Changed().notify();
 		Local::writeUserSettings();
 	}, adaptive->lifetime());
+
+	wideMessageWidth->entity()->checkedChanges(
+	) | rpl::start_with_next([](bool checked) {
+		Global::SetWideMessageWidth(checked);
+		Adaptive::WideMessageChanged().notify();
+		Local::writeUserSettings();
+	}, wideMessageWidth->lifetime());
 }
 
 void SetupDefaultThemes(not_null<Ui::VerticalLayout*> container) {

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -695,6 +695,7 @@ enum {
 	dbiHiddenPinnedMessages = 0x39,
 	dbiRecentEmoji = 0x3a,
 	dbiEmojiVariants = 0x3b,
+	dbiWideMessageWidth = 0x3c,
 	dbiDialogsModeOld = 0x40,
 	dbiModerateMode = 0x41,
 	dbiVideoVolume = 0x42,
@@ -1717,6 +1718,14 @@ bool _readSetting(quint32 blockId, QDataStream &stream, int version, ReadSetting
 		Global::SetAdaptiveForWide(v == 1);
 	} break;
 
+	case dbiWideMessageWidth: {
+		qint32 v;
+		stream >> v;
+		if (!_checkStreamStatus(stream)) return false;
+
+		Global::SetWideMessageWidth(v == 1);
+	} break;
+
 	case dbiAutoLock: {
 		qint32 v;
 		stream >> v;
@@ -2208,6 +2217,7 @@ void _writeUserSettings() {
 		<< qint32(Window::Theme::Background()->tileDay() ? 1 : 0)
 		<< qint32(Window::Theme::Background()->tileNight() ? 1 : 0);
 	data.stream << quint32(dbiAdaptiveForWide) << qint32(Global::AdaptiveForWide() ? 1 : 0);
+	data.stream << quint32(dbiWideMessageWidth) << qint32(Global::WideMessageWidth() ? 1 : 0);
 	data.stream << quint32(dbiAutoLock) << qint32(Global::AutoLock());
 	data.stream << quint32(dbiSoundNotify) << qint32(Global::SoundNotify());
 	data.stream << quint32(dbiDesktopNotify) << qint32(Global::DesktopNotify());


### PR DESCRIPTION
Fixes #2060

This PR add setting checkbox in Chat Settings section.
If checkbox is checked, messages in chat doesn't have limit on width beside chat own width.
If checkbox is unchecked, messages width behave like now.

The default is unchecked to preserve default settings.

This is how it looks like when it is enabled:
![chat_settings](https://user-images.githubusercontent.com/2165237/81235955-63602f80-8ffc-11ea-9596-f1d54c0950ea.jpg)

![chat_messages](https://user-images.githubusercontent.com/2165237/81236051-a3bfad80-8ffc-11ea-9582-d77505b51df2.jpg)

P.S. If something is wrong, sorry because my last time with C++ was 15 years ago... Now it looks strange to me...