### PR TITLE
Update building-msvc.md

### DIFF
--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -101,7 +101,7 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
 
     git clone https://github.com/telegramdesktop/openal-soft.git
     cd openal-soft
-    git checkout fix_capture
+    git checkout v1.19
     cd build
     cmake -G "Visual Studio 16 2019" -A Win32 -D LIBTYPE:STRING=STATIC -D FORCE_STATIC_VCRT:STRING=ON ..
     msbuild OpenAL.vcxproj /property:Configuration=Debug


### PR DESCRIPTION
Using old version of OpenAL causes aliasing distortion in high-frequency band. I've built the client using v1.19 version of OpenAL
Check out my [investigation](https://telegra.ph/Using-old-version-of-OpenAL-causes-aliasing-distortion-in-high-frequency-band-05-29):
