### PR TITLE
Fix macOS cache validating

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -88,6 +88,7 @@ jobs:
           echo $MIN_MAC >> CACHE_KEY.txt
           echo $PREFIX >> CACHE_KEY.txt
           echo $MANUAL_CACHING >> CACHE_KEY.txt
+          echo "$GITHUB_WORKSPACE" >> CACHE_KEY.txt
           if [ "$AUTO_CACHING" == "1" ]; then
             thisFile=$REPO_NAME/.github/workflows/mac.yml
             echo `md5 -q $thisFile` >> CACHE_KEY.txt


### PR DESCRIPTION
macOS action has runner version in the workdir path, it should be a part of the cache key