### PR TITLE
Fix empty dates JSON serialization

### DIFF
--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -70,7 +70,7 @@ QByteArray SerializeString(const QByteArray &value) {
 }
 
 QByteArray SerializeDate(TimeId date) {
-	return SerializeString(
+	return date == 0 ? QByteArray("null") : SerializeString(
 		QDateTime::fromTime_t(date).toString(Qt::ISODate).toUtf8());
 }
 


### PR DESCRIPTION
Empty dates are serialized as `1970-01-01T03:00:00` now.
I think it's not that easy to parse such dates.

I'm not quite familiar with Qt, C++ and TDesktop codebase, so I didn't even test this, but it should obviously work.