### PR TITLE
Do not pop up emoji tabbed panel and media menu on mouse over

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/tabbed_panel.cpp
+++ b/Telegram/SourceFiles/chat_helpers/tabbed_panel.cpp
@@ -231,10 +231,6 @@ void TabbedPanel::leaveEventHook(QEvent *e) {
 	return TWidget::leaveEventHook(e);
 }
 
-void TabbedPanel::otherEnter() {
-	showAnimated();
-}
-
 void TabbedPanel::otherLeave() {
 	if (preventAutoHide()) {
 		return;
@@ -402,9 +398,7 @@ void TabbedPanel::showStarted() {
 }
 
 bool TabbedPanel::eventFilter(QObject *obj, QEvent *e) {
-	if (e->type() == QEvent::Enter) {
-		otherEnter();
-	} else if (e->type() == QEvent::Leave) {
+	if (e->type() == QEvent::Leave) {
 		otherLeave();
 	}
 	return false;

--- a/Telegram/SourceFiles/chat_helpers/tabbed_panel.h
+++ b/Telegram/SourceFiles/chat_helpers/tabbed_panel.h
@@ -60,7 +60,6 @@ public:
 protected:
 	void enterEventHook(QEvent *e) override;
 	void leaveEventHook(QEvent *e) override;
-	void otherEnter();
 	void otherLeave();
 
 	void paintEvent(QPaintEvent *e) override;

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -678,8 +678,13 @@ void HistoryWidget::refreshTabbedPanel() {
 void HistoryWidget::initTabbedSelector() {
 	refreshTabbedPanel();
 
-	_tabbedSelectorToggle->addClickHandler([=] {
-		toggleTabbedSelectorMode();
+	_tabbedSelectorToggle->setAcceptBoth();
+	_tabbedSelectorToggle->addClickHandler([=](Qt::MouseButton mod) {
+		if (mod == Qt::LeftButton) {
+			_tabbedPanel->toggleAnimated();
+		} else if (mod == Qt::RightButton) {
+			toggleTabbedSelectorMode();
+		}
 	});
 
 	const auto selector = controller()->tabbedSelector();

--- a/Telegram/SourceFiles/history/view/history_view_compose_controls.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_compose_controls.cpp
@@ -227,8 +227,13 @@ void ComposeControls::initTabbedSelector() {
 		setTabbedPanel(nullptr);
 	}
 
-	_tabbedSelectorToggle->addClickHandler([=] {
-		toggleTabbedSelectorMode();
+	_tabbedSelectorToggle->setAcceptBoth();
+	_tabbedSelectorToggle->addClickHandler([=](Qt::MouseButton mod) {
+		if (mod == Qt::LeftButton) {
+			_tabbedPanel->toggleAnimated();
+		} else if (mod == Qt::RightButton) {
+			toggleTabbedSelectorMode();
+		}
 	});
 
 	const auto selector = _window->tabbedSelector();

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -296,8 +296,7 @@ OverlayWidget::OverlayWidget()
 , _radial([=](crl::time now) { return radialAnimationCallback(now); })
 , _lastAction(-st::mediaviewDeltaFromLastAction, -st::mediaviewDeltaFromLastAction)
 , _stateAnimation([=](crl::time now) { return stateAnimationCallback(now); })
-, _dropdown(this, st::mediaviewDropdownMenu)
-, _dropdownShowTimer(this) {
+, _dropdown(this, st::mediaviewDropdownMenu) {
 	subscribe(Lang::Current().updated(), [this] { refreshLang(); });
 
 	_lastPositiveVolume = (Global::VideoVolume() > 0.)
@@ -388,8 +387,6 @@ OverlayWidget::OverlayWidget()
 	_docCancel->addClickHandler([=] { onSaveCancel(); });
 
 	_dropdown->setHiddenCallback([this] { dropdownHidden(); });
-	_dropdownShowTimer->setSingleShot(true);
-	connect(_dropdownShowTimer, SIGNAL(timeout()), this, SLOT(onDropdown()));
 }
 
 void OverlayWidget::refreshLang() {
@@ -3616,11 +3613,6 @@ void OverlayWidget::updateOverRect(OverState state) {
 bool OverlayWidget::updateOverState(OverState newState) {
 	bool result = true;
 	if (_over != newState) {
-		if (newState == OverMore && !_ignoringDropdown) {
-			_dropdownShowTimer->start(0);
-		} else {
-			_dropdownShowTimer->stop();
-		}
 		updateOverRect(_over);
 		updateOverRect(newState);
 		if (_over != OverNone) {

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -468,7 +468,6 @@ private:
 
 	Ui::PopupMenu *_menu = nullptr;
 	object_ptr<Ui::DropdownMenu> _dropdown;
-	object_ptr<QTimer> _dropdownShowTimer;
 
 	struct ActionData {
 		QString text;


### PR DESCRIPTION
I suggest to not spawn popups on simple mouse over. When a user just moves a mouse, they does not expect to raise any windows. In Telegram, this may lead to really annoying missclicking when the user wishes to send a text or choose a message for reply.

I was going to leave activation a third panel by double left click on emoji button. Although, I did not find an `addDoubleClickHandler` or similar in `Ui::AbstractButton`. So for now I use single right click to toggle the third panel in history widget. You may consider this as a start approach.