### PR TITLE
doc

### DIFF
--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -154,7 +154,7 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
     git submodule update qtbase qtimageformats
     cd qtbase
     git apply ../../patches/qtbase_5_12_8.diff
-    cd ..
+    cd ../..
 
     configure -prefix "%LibrariesPath%\Qt-5.12.8" -debug-and-release -force-debug-info -opensource -confirm-license -static -static-runtime -I "%LibrariesPath%\openssl_1_1_1\include" -no-opengl -openssl-linked OPENSSL_LIBS_DEBUG="%LibrariesPath%\openssl_1_1_1\out32.dbg\libssl.lib %LibrariesPath%\openssl_1_1_1\out32.dbg\libcrypto.lib Ws2_32.lib Gdi32.lib Advapi32.lib Crypt32.lib User32.lib" OPENSSL_LIBS_RELEASE="%LibrariesPath%\openssl_1_1_1\out32\libssl.lib %LibrariesPath%\openssl_1_1_1\out32\libcrypto.lib Ws2_32.lib Gdi32.lib Advapi32.lib Crypt32.lib User32.lib" -mp -nomake examples -nomake tests -platform win32-msvc
 
@@ -176,7 +176,7 @@ Go to ***BuildPath*\\tdesktop\\Telegram** and run (using [your **api_id** and **
 
 For better debugging you may want to install Qt Visual Studio Tools:
 
-* Open **Tools** -> **Extensions and Updates...**
+* Open **Extensions** -> **Manage Extensions**
 * Go to **Online** tab
 * Search for **Qt**
 * Install **Qt Visual Studio Tools** extension


### PR DESCRIPTION
Fix the document.

1.  in vs2019 building instructions, the script doesn't quit to the BuildPath folder
2. the QT Visual Studio tool is located in menu  **Extensions** -> **Manage Extensions** in vs2019