### PR TITLE
Use startSystemMove/startSystemResize in PiP window on Wayland

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_pip.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_pip.cpp
@@ -438,7 +438,8 @@ PipPanel::Position PipPanel::countPosition() const {
 	const auto right = left + result.geometry.width();
 	const auto top = result.geometry.y();
 	const auto bottom = top + result.geometry.height();
-	if (!_dragState || *_dragState != RectPart::Center) {
+	if ((!_dragState || *_dragState != RectPart::Center)
+		&& !Platform::IsWayland()) {
 		if (left == available.x()) {
 			result.attached |= RectPart::Left;
 		} else if (right == available.x() + available.width()) {
@@ -514,6 +515,11 @@ void PipPanel::setPositionOnScreen(Position position, QRect available) {
 		std::max(normalized.width(), minimalSize.width()),
 		std::max(normalized.height(), minimalSize.height()));
 
+	// Apply maximal size.
+	const auto maximalSize = (_ratio.width() > _ratio.height())
+		? QSize(fit.width(), fit.width() * _ratio.height() / _ratio.width())
+		: QSize(fit.height() * _ratio.width() / _ratio.height(), fit.height());
+
 	// Apply left-right screen borders.
 	const auto skip = st::pipBorderSkip;
 	const auto inner = screen.marginsRemoved({ skip, skip, skip, skip });
@@ -547,8 +553,8 @@ void PipPanel::setPositionOnScreen(Position position, QRect available) {
 	geometry += _padding;
 
 	setGeometry(geometry);
-	setMinimumSize(geometry.size());
-	setMaximumSize(geometry.size());
+	setMinimumSize(minimalSize);
+	setMaximumSize(maximalSize);
 	updateDecorations();
 	update();
 }
@@ -671,6 +677,40 @@ void PipPanel::mouseMoveEvent(QMouseEvent *e) {
 	if (!_dragState
 		&& (point - _pressPoint).manhattanLength() > distance
 		&& !_dragDisabled) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0) || defined DESKTOP_APP_QT_PATCHED
+		if (Platform::IsWayland()) {
+			switch (*_pressState) {
+			case RectPart::Center:
+				windowHandle()->startSystemMove();
+				break;
+			case RectPart::TopLeft:
+				windowHandle()->startSystemResize(Qt::TopEdge | Qt::LeftEdge);
+				break;
+			case RectPart::TopRight:
+				windowHandle()->startSystemResize(Qt::TopEdge | Qt::RightEdge);
+				break;
+			case RectPart::BottomRight:
+				windowHandle()->startSystemResize(Qt::BottomEdge | Qt::RightEdge);
+				break;
+			case RectPart::BottomLeft:
+				windowHandle()->startSystemResize(Qt::BottomEdge | Qt::LeftEdge);
+				break;
+			case RectPart::Left:
+				windowHandle()->startSystemResize(Qt::LeftEdge);
+				break;
+			case RectPart::Top:
+				windowHandle()->startSystemResize(Qt::TopEdge);
+				break;
+			case RectPart::Right:
+				windowHandle()->startSystemResize(Qt::RightEdge);
+				break;
+			case RectPart::Bottom:
+				windowHandle()->startSystemResize(Qt::BottomEdge);
+				break;
+			}
+			return;
+		}
+#endif // Qt >= 5.15 || DESKTOP_APP_QT_PATCHED
 		_dragState = _pressState;
 		updateDecorations();
 		_dragStartGeometry = geometry().marginsRemoved(_padding);
@@ -722,8 +762,6 @@ void PipPanel::processDrag(QPoint point) {
 		const auto newGeometry = valid.marginsAdded(_padding);
 		_positionAnimation.stop();
 		setGeometry(newGeometry);
-		setMinimumSize(newGeometry.size());
-		setMaximumSize(newGeometry.size());
 	}
 }
 
@@ -810,8 +848,6 @@ void PipPanel::updateDecorations() {
 	_useTransparency = use;
 	setAttribute(Qt::WA_OpaquePaintEvent, !_useTransparency);
 	setGeometry(newGeometry);
-	setMinimumSize(newGeometry.size());
-	setMaximumSize(newGeometry.size());
 	update();
 }
 


### PR DESCRIPTION
Since startSystemMove is the only way to move a window on Wayland

And since custom resize works bad due to the lack of moving (resize with left and top corners works just like resize with right and bottom corners)