### PR TITLE
Fix pdf being opened as image

### DIFF
--- a/Telegram/SourceFiles/data/data_document.cpp
+++ b/Telegram/SourceFiles/data/data_document.cpp
@@ -308,7 +308,7 @@ void DocumentOpenClickHandler::Open(
 				location.accessDisable();
 			});
 			const auto path = location.name();
-			if (QImageReader(path).canRead()) {
+			if (Core::MimeTypeForFile(path).name().startsWith("image/") && QImageReader(path).canRead()) {
 				Core::App().showDocument(data, context);
 				return;
 			}


### PR DESCRIPTION
See commit message for more details.

I might in the future create another pull request to actually use the PDF thumbnail generation ability to show a PDF thumbnail, but from a quick glance at the code I only saw codepaths for server side thumbnail previews, not any for generating one from local files only.
So it wasn't worth the hassle for a feature that will be used by 1% of users, because 99% will have a tdesktop without QtWebengine, thus no PDF thumbnail feature.

I might be wrong though and if you think it won't be much extra work to add that feature, then please give me a hint and I will work on it.