### PR TITLE
Fix patches revision

### DIFF
--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -64,7 +64,7 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
 
     git clone https://github.com/desktop-app/patches.git
     cd patches
-    git checkout 2b9afa7
+    git checkout 0ba67e2
     cd ..
 
     git clone https://github.com/desktop-app/lzma.git


### PR DESCRIPTION
Build docs for Windows are at older commit of desktop-app/patches, which causes build failure with patched Qt. This PR fixes it.