### PR TITLE
Don't request IsStatusNotifierHostRegistered when SNI become available

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -585,7 +585,7 @@ void MainWindow::onSNIOwnerChanged(
 	}
 	trayIcon = nullptr;
 
-	SNIAvailable = IsSNIAvailable();
+	SNIAvailable = !newOwner.isEmpty();
 
 	const auto trayAvailable = SNIAvailable
 		|| QSystemTrayIcon::isSystemTrayAvailable();


### PR DESCRIPTION
To avoid situations when StatusNotifierItem registers icon, but tdesktop assumes that there are still no SNI