### PR TITLE
Don't generate 64px tray icon since badge counter generator doesn't support it

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -151,7 +151,6 @@ QIcon TrayIconGen(int counter, bool muted) {
 		24,
 		32,
 		48,
-		64
 	};
 
 	for (const auto iconSize : iconSizes) {


### PR DESCRIPTION
Fixes a regression with new Cinnamon on Mint 20 (left one is the release version, right one is this PR)
![image](https://user-images.githubusercontent.com/17829319/87840168-bcb2cd80-c88d-11ea-9152-6704b302c806.png)
