### PR TITLE
Export chats with ISO 8601 dates

### DIFF
--- a/Telegram/SourceFiles/export/output/export_output_abstract.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_abstract.cpp
@@ -33,11 +33,9 @@ QString NormalizePath(const Settings &settings) {
 	}
 	const auto date = QDate::currentDate();
 	const auto base = QString(settings.onlySinglePeer()
-		? "ChatExport_%1_%2_%3"
-		: "DataExport_%1_%2_%3"
-	).arg(date.day(), 2, 10, QChar('0')
-	).arg(date.month(), 2, 10, QChar('0')
-	).arg(date.year());
+		? "ChatExport_%1"
+		: "DataExport_%1"
+	).arg(date.toString(Qt::ISODate));
 	const auto add = [&](int i) {
 		return base + (i ? " (" + QString::number(i) + ')' : QString());
 	};


### PR DESCRIPTION
Instead of ChatExport_06_07_2020 we get ChatExport_2020-07-06, which conforms to ISO 8601 and has the advantage that it cannot be misinterpreted in countries where it is common to start with the month instead of the day.

Also sorting directories by name now also means automatically being chronologically sorted.

See #6020