### PR TITLE
Fix #8427: folder exclusion filters should always take priority over inclusion

### DIFF
--- a/Telegram/SourceFiles/data/data_chat_filters.cpp
+++ b/Telegram/SourceFiles/data/data_chat_filters.cpp
@@ -198,8 +198,7 @@ bool ChatFilter::contains(not_null<History*> history) const {
 	if (_never.contains(history)) {
 		return false;
 	}
-	return false
-		|| ((_flags & flag)
+	return ((_flags & flag) || _always.contains(history))
 			&& (!(_flags & Flag::NoMuted)
 				|| !history->mute()
 				|| (history->hasUnreadMentions()
@@ -211,8 +210,7 @@ bool ChatFilter::contains(not_null<History*> history) const {
 				|| history->hasUnreadMentions()
 				|| history->fakeUnreadWhileOpened())
 			&& (!(_flags & Flag::NoArchived)
-				|| (history->folderKnown() && !history->folder())))
-		|| _always.contains(history);
+				|| (history->folderKnown() && !history->folder()));
 }
 
 ChatFilters::ChatFilters(not_null<Session*> owner) : _owner(owner) {


### PR DESCRIPTION
NOTE: completely untested, but may fix #8427.

Previously if you had a chat individually included in a folder (via `_always`) it could not be excluded by a mass exclusion filter (e.g. `NoArchived`). Now these filters are always applied.

Maybe a small refactoring is a good idea: check all exclusion filters right after `if (_never.contains(history))`, and then simply `return (_flags & flag) || _always.contains(history);` in the very end. That will make the logic much clearer: apply all exclusions, and then include only some.