### PR TITLE
Separate dependencies and Telegram build to jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,10 +42,23 @@ on:
       - 'Telegram/configure.bat'
       - 'Telegram/Telegram.plist'
 
+env:
+  GIT: "https://github.com"
+  QT: "5_12_8"
+  QT_PREFIX: "/usr/local/desktop-app/Qt-5.12.8"
+  OPENSSL_VER: "1_1_1"
+  OPENSSL_PREFIX: "/usr/local/desktop-app/openssl-1.1.1"
+  CMAKE_VER: "3.17.0"
+  UPLOAD_ARTIFACT: "false"
+  ONLY_CACHE: "false"
+  MANUAL_CACHING: "6"
+  DOC_PATH: "docs/building-cmake.md"
+  AUTO_CACHING: "1"
+
 jobs:
 
-  linux:
-    name: Ubuntu 14.04
+  dependencies:
+    name: "Ubuntu 14.04: dependencies"
     runs-on: ubuntu-latest
     container: ubuntu:trusty
 
@@ -53,21 +66,6 @@ jobs:
       matrix:
         defines:
           - ""
-          - "DESKTOP_APP_DISABLE_DBUS_INTEGRATION"
-          - "TDESKTOP_DISABLE_GTK_INTEGRATION"
-
-    env:
-      GIT: "https://github.com"
-      QT: "5_12_8"
-      QT_PREFIX: "/usr/local/desktop-app/Qt-5.12.8"
-      OPENSSL_VER: "1_1_1"
-      OPENSSL_PREFIX: "/usr/local/desktop-app/openssl-1.1.1"
-      CMAKE_VER: "3.17.0"
-      UPLOAD_ARTIFACT: "false"
-      ONLY_CACHE: "false"
-      MANUAL_CACHING: "6"
-      DOC_PATH: "docs/building-cmake.md"
-      AUTO_CACHING: "1"
 
     steps:
       - name: Get repository name.
@@ -111,10 +109,10 @@ jobs:
           sudo update-alternatives --config gcc && \
           sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
 
+      # We don't need recursive clone to build dependencies.
       - name: Clone.
         uses: actions/checkout@v2
         with:
-          submodules: recursive
           path: ${{ env.REPO_NAME }}
 
       - name: First set up.
@@ -177,30 +175,6 @@ jobs:
         run: |
           cd $LibrariesPath/opus
           sudo make install
-
-      - name: Libva.
-        run: |
-          cd $LibrariesPath
-
-          git clone $GIT/01org/libva.git
-          cd libva
-          ./autogen.sh --enable-static
-          make -j$(nproc)
-          sudo make install
-          cd ..
-          rm -rf libva
-
-      - name: Libvdpau.
-        run: |
-          cd $LibrariesPath
-
-          git clone -b libvdpau-1.2 --depth=1 https://gitlab.freedesktop.org/vdpau/libvdpau.git
-          cd libvdpau
-          ./autogen.sh --enable-static
-          make -j$(nproc)
-          sudo make install
-          cd ..
-          rm -rf libvdpau
 
       - name: FFmpeg cache.
         id: cache-ffmpeg
@@ -361,6 +335,7 @@ jobs:
         with:
           path: ${{ env.LibrariesPath }}/openssl-cache
           key: ${{ runner.OS }}-${{ env.OPENSSL_VER }}-${{ env.CACHE_KEY }}
+
       - name: OpenSSL build.
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         run: |
@@ -375,25 +350,11 @@ jobs:
           sudo make DESTDIR="$LibrariesPath/openssl-cache" install_sw
           cd ..
           # rm -rf $opensslDir # Keep this folder for WebRTC.
+
       - name: OpenSSL install.
         run: |
           cd $LibrariesPath
           sudo cp -R openssl-cache/. /
-
-      - name: Libwayland.
-        run: |
-          cd $LibrariesPath
-
-          git clone -b 1.18.0 https://gitlab.freedesktop.org/wayland/wayland
-          cd wayland
-          ./autogen.sh \
-          --enable-static \
-          --disable-documentation \
-          --disable-dtd-validation
-          make -j$(nproc)
-          sudo make install
-          cd ..
-          rm -rf wayland
 
       - name: Libxkbcommon.
         run: |
@@ -410,6 +371,21 @@ jobs:
           sudo make install
           cd ..
           rm -rf libxkbcommon
+
+      - name: Libwayland.
+        run: |
+          cd $LibrariesPath
+
+          git clone -b 1.18.0 https://gitlab.freedesktop.org/wayland/wayland
+          cd wayland
+          ./autogen.sh \
+          --enable-static \
+          --disable-documentation \
+          --disable-dtd-validation
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf wayland
 
       - name: Qt 5.12.8 cache.
         id: cache-qt
@@ -455,10 +431,6 @@ jobs:
           sudo make INSTALL_ROOT="$LibrariesPath/qt-cache" install
           cd ..
           rm -rf qt_${QT}
-      - name: Qt 5.12.8 install.
-        run: |
-          cd $LibrariesPath
-          sudo cp -R qt-cache/. /
 
       - name: Breakpad cache.
         id: cache-breakpad
@@ -506,12 +478,6 @@ jobs:
           mv dump_syms $BreakpadCache/
           cd ..
           rm -rf gyp breakpad
-      - name: Breakpad install.
-        run: |
-          cd $LibrariesPath
-          sudo cp -R breakpad-cache/. /
-          mkdir -p breakpad/out/Default/
-          cp breakpad-cache/dump_syms breakpad/out/Default/dump_syms
 
       - name: WebRTC cache.
         id: cache-webrtc
@@ -545,6 +511,266 @@ jobs:
           mv libtg_owt.a out/Debug/libtg_owt.a
 
           rm -rf $LibrariesPath/openssl_${OPENSSL_VER}
+
+  telegram:
+    name: "Ubuntu 14.04: Telegram"
+    runs-on: ubuntu-latest
+    needs: dependencies
+    container: ubuntu:trusty
+
+    strategy:
+      matrix:
+        defines:
+          - ""
+          - "DESKTOP_APP_DISABLE_DBUS_INTEGRATION"
+          - "TDESKTOP_DISABLE_GTK_INTEGRATION"
+
+    steps:
+      - name: Get repository name.
+        run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}
+
+      - name: Disable man for further package installs.
+        run: |
+          cfgFile="/etc/dpkg/dpkg.cfg.d/no_man"
+          sudo touch $cfgFile
+          p() {
+            sudo echo "path-exclude=/usr/share/$1/*" >> $cfgFile
+          }
+
+          p man
+          p locale
+          p doc
+
+      - name: Apt install.
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install software-properties-common -y && \
+          sudo add-apt-repository ppa:git-core/ppa -y && \
+          sudo apt-get update && \
+          sudo apt-get install git libexif-dev liblzma-dev libz-dev libssl-dev \
+          libgtk2.0-dev libice-dev libsm-dev libicu-dev libdrm-dev dh-autoreconf \
+          autoconf automake build-essential libxml2-dev libass-dev libfreetype6-dev \
+          libgpac-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev \
+          libvorbis-dev libxcb1-dev libxcb-image0-dev libxcb-shm0-dev \
+          libxcb-screensaver0-dev libjpeg-dev ninja-build \
+          libxcb-xfixes0-dev libxcb-keysyms1-dev libxcb-icccm4-dev libatspi2.0-dev \
+          libxcb-render-util0-dev libxcb-util0-dev libxcb-xkb-dev libxrender-dev \
+          libasound-dev libpulse-dev libxcb-sync0-dev libxcb-randr0-dev libegl1-mesa-dev \
+          libx11-xcb-dev libffi-dev libncurses5-dev pkg-config texi2html bison yasm \
+          zlib1g-dev xutils-dev python-xcbgen chrpath gperf wget -y --force-yes && \
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+          sudo apt-get update && \
+          sudo apt-get install gcc-8 g++-8 -y && \
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 && \
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 60 && \
+          sudo update-alternatives --config gcc && \
+          sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
+
+      - name: Clone.
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          path: ${{ env.REPO_NAME }}
+
+      - name: First set up.
+        shell: bash
+        run: |
+          gcc --version
+
+          gcc --version > CACHE_KEY.txt
+          echo $MANUAL_CACHING >> CACHE_KEY.txt
+          if [ "$AUTO_CACHING" == "1" ]; then
+            thisFile=$REPO_NAME/.github/workflows/linux.yml
+            echo `md5sum $thisFile | cut -c -32` >> CACHE_KEY.txt
+          fi
+          md5cache=$(md5sum CACHE_KEY.txt | cut -c -32)
+          echo ::set-env name=CACHE_KEY::$md5cache
+
+          mkdir -p Libraries
+          cd Libraries
+          echo ::set-env name=LibrariesPath::`pwd`
+
+      - name: Patches.
+        run: |
+          echo "Find necessary commit from doc."
+          checkoutCommit=$(grep -A 1 "cd patches" $REPO_NAME/$DOC_PATH | sed -n 2p)
+          cd $LibrariesPath
+          git clone $GIT/desktop-app/patches.git
+          cd patches
+          eval $checkoutCommit
+
+      - name: CMake.
+        run: |
+          cd $LibrariesPath
+
+          file=cmake-$CMAKE_VER-Linux-x86_64.sh
+          wget $GIT/Kitware/CMake/releases/download/v$CMAKE_VER/$file
+          sudo mkdir /opt/cmake
+          sudo sh $file --prefix=/opt/cmake --skip-license
+          sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+          rm $file
+
+          cmake --version
+
+      - name: Libva.
+        run: |
+          cd $LibrariesPath
+
+          git clone $GIT/01org/libva.git
+          cd libva
+          ./autogen.sh --enable-static
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf libva
+
+      - name: Libvdpau.
+        run: |
+          cd $LibrariesPath
+
+          git clone -b libvdpau-1.2 --depth=1 https://gitlab.freedesktop.org/vdpau/libvdpau.git
+          cd libvdpau
+          ./autogen.sh --enable-static
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf libvdpau
+
+      - name: Opus cache.
+        id: cache-opus
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/opus
+          key: ${{ runner.OS }}-opus-${{ env.CACHE_KEY }}
+      - name: Opus install.
+        run: |
+          cd $LibrariesPath/opus
+          sudo make install
+
+      - name: FFmpeg cache.
+        id: cache-ffmpeg
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/ffmpeg-cache
+          key: ${{ runner.OS }}-ffmpeg-${{ env.CACHE_KEY }}
+      - name: FFmpeg install.
+        run: |
+          cd $LibrariesPath
+          #List of files from cmake/external/ffmpeg/CMakeLists.txt.
+          copyLib() {
+            mkdir -p ffmpeg/$1
+            yes | cp -i ffmpeg-cache/usr/local/lib/$1.a ffmpeg/$1/$1.a
+          }
+          copyLib libavformat
+          copyLib libavcodec
+          copyLib libswresample
+          copyLib libswscale
+          copyLib libavutil
+
+          sudo cp -R ffmpeg-cache/. /
+
+      - name: OpenAL Soft.
+        run: |
+          cd $LibrariesPath
+
+          git clone -b openal-soft-1.20.1 --depth=1 $GIT/kcat/openal-soft.git
+          cd openal-soft/build
+          cmake .. \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DLIBTYPE:STRING=STATIC \
+          -DALSOFT_EXAMPLES=OFF \
+          -DALSOFT_TESTS=OFF \
+          -DALSOFT_UTILS=OFF \
+          -DALSOFT_CONFIG=OFF
+          make -j$(nproc)
+          sudo make install
+          cd -
+          rm -rf openal-soft
+
+      - name: OpenSSL cache.
+        id: cache-openssl
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/openssl-cache
+          key: ${{ runner.OS }}-${{ env.OPENSSL_VER }}-${{ env.CACHE_KEY }}
+
+      - name: OpenSSL install.
+        run: |
+          cd $LibrariesPath
+          sudo cp -R openssl-cache/. /
+
+      - name: Libxkbcommon.
+        run: |
+          cd $LibrariesPath
+
+          git clone -b xkbcommon-0.8.4 --depth=1 $GIT/xkbcommon/libxkbcommon.git
+          cd libxkbcommon
+          ./autogen.sh \
+          --disable-docs \
+          --disable-wayland \
+          --with-xkb-config-root=/usr/share/X11/xkb \
+          --with-x-locale-root=/usr/share/X11/locale
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf libxkbcommon
+
+      - name: Libwayland.
+        run: |
+          cd $LibrariesPath
+
+          git clone -b 1.18.0 https://gitlab.freedesktop.org/wayland/wayland
+          cd wayland
+          ./autogen.sh \
+          --enable-static \
+          --disable-documentation \
+          --disable-dtd-validation
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf wayland
+
+      - name: Qt 5.12.8 cache.
+        id: cache-qt
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/qt-cache
+          key: ${{ runner.OS }}-qt-${{ env.CACHE_KEY }}-${{ hashFiles('**/qt*_5_12_8/*') }}
+      - name: Qt 5.12.8 install.
+        run: |
+          cd $LibrariesPath
+          sudo cp -R qt-cache/. /
+
+      - name: Breakpad cache.
+        id: cache-breakpad
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/breakpad-cache
+          key: ${{ runner.OS }}-breakpad-${{ env.CACHE_KEY }}
+      - name: Breakpad clone.
+        run: |
+          cd $LibrariesPath
+
+          git clone https://chromium.googlesource.com/breakpad/breakpad
+          cd breakpad
+          git checkout bc8fb886
+          git clone https://chromium.googlesource.com/linux-syscall-support src/third_party/lss
+          cd src/third_party/lss
+          git checkout a91633d1
+      - name: Breakpad install.
+        run: |
+          cd $LibrariesPath
+          sudo cp -R breakpad-cache/. /
+          mkdir -p breakpad/out/Default/
+          cp breakpad-cache/dump_syms breakpad/out/Default/dump_syms
+
+      - name: WebRTC cache.
+        id: cache-webrtc
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/tg_owt
+          key: ${{ runner.OS }}-webrtc-${{ env.CACHE_KEY }}
 
       - name: Telegram Desktop build.
         if: env.ONLY_CACHE == 'false'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,11 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:trusty
 
-    strategy:
-      matrix:
-        defines:
-          - ""
-
     steps:
       - name: Get repository name.
         run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,6 +356,21 @@ jobs:
           cd $LibrariesPath
           sudo cp -R openssl-cache/. /
 
+      - name: Libwayland.
+        run: |
+          cd $LibrariesPath
+
+          git clone -b 1.18.0 https://gitlab.freedesktop.org/wayland/wayland
+          cd wayland
+          ./autogen.sh \
+          --enable-static \
+          --disable-documentation \
+          --disable-dtd-validation
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf wayland
+
       - name: Libxkbcommon.
         run: |
           cd $LibrariesPath
@@ -371,21 +386,6 @@ jobs:
           sudo make install
           cd ..
           rm -rf libxkbcommon
-
-      - name: Libwayland.
-        run: |
-          cd $LibrariesPath
-
-          git clone -b 1.18.0 https://gitlab.freedesktop.org/wayland/wayland
-          cd wayland
-          ./autogen.sh \
-          --enable-static \
-          --disable-documentation \
-          --disable-dtd-validation
-          make -j$(nproc)
-          sudo make install
-          cd ..
-          rm -rf wayland
 
       - name: Qt 5.12.8 cache.
         id: cache-qt

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -63,11 +63,6 @@ jobs:
     name: "MacOS: dependencies"
     runs-on: macos-latest
 
-    strategy:
-      matrix:
-        defines:
-          - ""
-
     steps:
       - name: Get repository name.
         run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -40,41 +40,42 @@ on:
       - 'Telegram/SourceFiles/platform/linux/**'
       - 'Telegram/configure.bat'
 
+env:
+  MIN_MAC: "-mmacosx-version-min=10.12"
+  UNGUARDED: "-Werror=unguarded-availability-new"
+  GIT: "https://github.com"
+  PREFIX: "/usr/local/macos"
+  MACOSX_DEPLOYMENT_TARGET: "10.12"
+  XZ: "xz-5.2.4"
+  QT: "5_12_8"
+  OPENSSL_VER: "1_1_1"
+  QT_PREFIX: "/usr/local/desktop-app/Qt-5.12.8"
+  LIBICONV_VER: "libiconv-1.16"
+  UPLOAD_ARTIFACT: "false"
+  ONLY_CACHE: "false"
+  MANUAL_CACHING: "2"
+  DOC_PATH: "docs/building-xcode.md"
+  AUTO_CACHING: "1"
+
 jobs:
 
-  macos:
-    name: MacOS
+  dependencies:
+    name: "MacOS: dependencies"
     runs-on: macos-latest
 
     strategy:
       matrix:
         defines:
           - ""
-    env:
-      MIN_MAC: "-mmacosx-version-min=10.12"
-      UNGUARDED: "-Werror=unguarded-availability-new"
-      GIT: "https://github.com"
-      PREFIX: "/usr/local/macos"
-      MACOSX_DEPLOYMENT_TARGET: "10.12"
-      XZ: "xz-5.2.4"
-      QT: "5_12_8"
-      OPENSSL_VER: "1_1_1"
-      QT_PREFIX: "/usr/local/desktop-app/Qt-5.12.8"
-      LIBICONV_VER: "libiconv-1.16"
-      UPLOAD_ARTIFACT: "false"
-      ONLY_CACHE: "false"
-      MANUAL_CACHING: "2"
-      DOC_PATH: "docs/building-xcode.md"
-      AUTO_CACHING: "1"
 
     steps:
       - name: Get repository name.
         run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}
 
+      # We don't need recursive clone to build dependencies.
       - name: Clone.
         uses: actions/checkout@v2
         with:
-          submodules: recursive
           path: ${{ env.REPO_NAME }}
 
       - name: First set up.
@@ -110,27 +111,6 @@ jobs:
           git clone $GIT/desktop-app/patches.git
           cd Patches
           eval $checkoutCommit
-
-      - name: XZ.
-        run: |
-          cd $LibrariesPath
-
-          wget https://tukaani.org/xz/$XZ.tar.gz
-          tar -xvzf $XZ.tar.gz
-          cd $XZ
-          CFLAGS="$MIN_MAC" LDFLAGS="$MIN_MAC" ./configure --prefix=$PREFIX
-          make -j$(nproc)
-          sudo make install
-
-      - name: Zlib.
-        run: |
-          cd $LibrariesPath
-
-          git clone $GIT/desktop-app/zlib.git
-          cd zlib
-          CFLAGS="$MIN_MAC $UNGUARDED" LDFLAGS="$MIN_MAC" ./configure --prefix=$PREFIX
-          make -j$(nproc)
-          sudo make install
 
       - name: OpenSSL cache.
         id: cache-openssl
@@ -201,10 +181,6 @@ jobs:
           cd $LIBICONV_VER
           CFLAGS="$MIN_MAC $UNGUARDED" CPPFLAGS="$MIN_MAC $UNGUARDED" LDFLAGS="$MIN_MAC" ./configure --enable-static --prefix=$PREFIX
           make -j$(nproc)
-      - name: Libiconv install.
-        run: |
-          cd $LibrariesPath/$LIBICONV_VER
-          sudo make install
 
       - name: FFmpeg cache.
         id: cache-ffmpeg
@@ -344,24 +320,6 @@ jobs:
           sudo cp -R ffmpeg-cache/. /usr/local/
           sudo cp -R ffmpeg-cache/include/. ffmpeg/
 
-      - name: OpenAL Soft.
-        run: |
-          cd $LibrariesPath
-
-          git clone $GIT/kcat/openal-soft.git
-          cd openal-soft
-          git checkout openal-soft-1.19.1
-          cd build
-
-          CFLAGS="$UNGUARDED" CPPFLAGS="$UNGUARDED" cmake \
-          -D CMAKE_INSTALL_PREFIX:PATH=$PREFIX \
-          -D ALSOFT_EXAMPLES=OFF \
-          -D LIBTYPE:STRING=STATIC \
-          -D CMAKE_OSX_DEPLOYMENT_TARGET:STRING=$MACOSX_DEPLOYMENT_TARGET ..
-
-          make -j$(nproc)
-          sudo make install
-
       - name: Crashpad cache.
         id: cache-crashpad
         uses: actions/cache@v2
@@ -478,6 +436,179 @@ jobs:
           rm -rf out
           mkdir -p out/Debug
           mv libtg_owt.a out/Debug/libtg_owt.a
+
+  telegram:
+    name: "MacOS: Telegram"
+    runs-on: macos-latest
+    needs: dependencies
+
+    strategy:
+      matrix:
+        defines:
+          - ""
+
+    steps:
+      - name: Get repository name.
+        run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}
+
+      - name: Clone.
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          path: ${{ env.REPO_NAME }}
+
+      - name: First set up.
+        run: |
+          sudo chown -R `whoami`:admin /usr/local/share
+          brew install automake fdk-aac lame libass libtool libvorbis libvpx \
+          ninja opus sdl shtool texi2html theora x264 xvid yasm pkg-config
+
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+          xcodebuild -version > CACHE_KEY.txt
+          echo $MIN_MAC >> CACHE_KEY.txt
+          echo $PREFIX >> CACHE_KEY.txt
+          echo $MANUAL_CACHING >> CACHE_KEY.txt
+          echo "$GITHUB_WORKSPACE" >> CACHE_KEY.txt
+          if [ "$AUTO_CACHING" == "1" ]; then
+            thisFile=$REPO_NAME/.github/workflows/mac.yml
+            echo `md5 -q $thisFile` >> CACHE_KEY.txt
+          fi
+          echo ::set-env name=CACHE_KEY::`md5 -q CACHE_KEY.txt`
+
+          echo ::add-path::$PWD/Libraries/depot_tools
+
+          mkdir -p Libraries/macos
+          cd Libraries/macos
+          echo ::set-env name=LibrariesPath::`pwd`
+
+      - name: Patches.
+        run: |
+          echo "Find necessary commit from doc."
+          checkoutCommit=$(grep -A 1 "cd patches" $REPO_NAME/$DOC_PATH | sed -n 2p)
+          cd $LibrariesPath
+          git clone $GIT/desktop-app/patches.git
+          cd Patches
+          eval $checkoutCommit
+
+      - name: XZ.
+        run: |
+          cd $LibrariesPath
+
+          wget https://tukaani.org/xz/$XZ.tar.gz
+          tar -xvzf $XZ.tar.gz
+          cd $XZ
+          CFLAGS="$MIN_MAC" LDFLAGS="$MIN_MAC" ./configure --prefix=$PREFIX
+          make -j$(nproc)
+          sudo make install
+
+      - name: Zlib.
+        run: |
+          cd $LibrariesPath
+
+          git clone $GIT/desktop-app/zlib.git
+          cd zlib
+          CFLAGS="$MIN_MAC $UNGUARDED" LDFLAGS="$MIN_MAC" ./configure --prefix=$PREFIX
+          make -j$(nproc)
+          sudo make install
+
+      - name: OpenSSL cache.
+        id: cache-openssl
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/openssl_${{ env.OPENSSL_VER }}
+          key: ${{ runner.OS }}-${{ env.OPENSSL_VER }}-${{ env.CACHE_KEY }}
+
+      - name: Opus cache.
+        id: cache-opus
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/opus
+          key: ${{ runner.OS }}-opus-${{ env.CACHE_KEY }}
+      - name: Opus install.
+        run: |
+          cd $LibrariesPath/opus
+          sudo make install
+
+      - name: Libiconv cache.
+        id: cache-libiconv
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/${{ env.LIBICONV_VER }}
+          key: ${{ runner.OS }}-${{ env.LIBICONV_VER }}-${{ env.CACHE_KEY }}
+      - name: Libiconv install.
+        run: |
+          cd $LibrariesPath/$LIBICONV_VER
+          sudo make install
+
+      - name: FFmpeg cache.
+        id: cache-ffmpeg
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/ffmpeg-cache
+          key: ${{ runner.OS }}-ffmpeg-${{ env.CACHE_KEY }}
+      - name: FFmpeg install.
+        run: |
+          cd $LibrariesPath
+          #List of files from cmake/external/ffmpeg/CMakeLists.txt.
+          copyLib() {
+            mkdir -p ffmpeg/$1
+            \cp -fR ffmpeg-cache/lib/$1.a ffmpeg/$1/$1.a
+          }
+          copyLib libavformat
+          copyLib libavcodec
+          copyLib libswresample
+          copyLib libswscale
+          copyLib libavutil
+
+          sudo cp -R ffmpeg-cache/. /usr/local/
+          sudo cp -R ffmpeg-cache/include/. ffmpeg/
+
+      - name: OpenAL Soft.
+        run: |
+          cd $LibrariesPath
+
+          git clone $GIT/kcat/openal-soft.git
+          cd openal-soft
+          git checkout openal-soft-1.19.1
+          cd build
+
+          CFLAGS="$UNGUARDED" CPPFLAGS="$UNGUARDED" cmake \
+          -D CMAKE_INSTALL_PREFIX:PATH=$PREFIX \
+          -D ALSOFT_EXAMPLES=OFF \
+          -D LIBTYPE:STRING=STATIC \
+          -D CMAKE_OSX_DEPLOYMENT_TARGET:STRING=$MACOSX_DEPLOYMENT_TARGET ..
+
+          make -j$(nproc)
+          sudo make install
+
+      - name: Crashpad cache.
+        id: cache-crashpad
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/crashpad
+          key: ${{ runner.OS }}-crashpad-${{ env.CACHE_KEY }}-${{ hashFiles('**/crashpad.diff') }}-${{ hashFiles('**/mini_chromium.diff') }}
+
+      - name: Qt 5.12.8 cache.
+        id: cache-qt
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/qt-cache
+          key: ${{ runner.OS }}-qt-${{ env.CACHE_KEY }}-${{ hashFiles('**/qtbase_5_12_8/*') }}
+      - name: Use cached Qt 5.12.8.
+        if: steps.cache-qt.outputs.cache-hit == 'true'
+        run: |
+          cd $LibrariesPath
+          mv qt-cache Qt-5.12.8
+          sudo mkdir -p $QT_PREFIX
+          sudo mv -f Qt-5.12.8 "$(dirname "$QT_PREFIX")"/
+
+      - name: WebRTC cache.
+        id: cache-webrtc
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/tg_owt
+          key: ${{ runner.OS }}-webrtc-${{ env.CACHE_KEY }}
 
       - name: Telegram Desktop build.
         if: env.ONLY_CACHE == 'false'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -45,38 +45,39 @@ on:
       - 'Telegram/configure.sh'
       - 'Telegram/Telegram.plist'
 
+env:
+  SDK: "10.0.18362.0"
+  VC: "call vcvars32.bat && cd Libraries"
+  GIT: "https://github.com"
+  QT: "5_12_8"
+  QT_VER: "5.12.8"
+  OPENSSL_VER: "1_1_1"
+  UPLOAD_ARTIFACT: "false"
+  ONLY_CACHE: "false"
+  MANUAL_CACHING: "2"
+  DOC_PATH: "docs/building-msvc.md"
+  AUTO_CACHING: "1"
+
 jobs:
 
-  windows:
-    name: Windows
+  dependencies:
+    name: "Windows: dependencies"
     runs-on: windows-latest
 
     strategy:
       matrix:
         defines:
           - ""
-    env:
-      SDK: "10.0.18362.0"
-      VC: "call vcvars32.bat && cd Libraries"
-      GIT: "https://github.com"
-      QT: "5_12_8"
-      QT_VER: "5.12.8"
-      OPENSSL_VER: "1_1_1"
-      UPLOAD_ARTIFACT: "false"
-      ONLY_CACHE: "false"
-      MANUAL_CACHING: "2"
-      DOC_PATH: "docs/building-msvc.md"
-      AUTO_CACHING: "1"
 
     steps:
       - name: Get repository name.
         shell: bash
         run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}
 
+      # We don't need recursive clone to build dependencies.
       - name: Clone.
         uses: actions/checkout@v2
         with:
-          submodules: recursive
           path: ${{ env.REPO_NAME }}
 
       - name: Set up environment variables.
@@ -136,16 +137,6 @@ jobs:
           echo Found %PY2%.
           echo ::set-env name=PY2::%PY2%
 
-      - name: LZMA.
-        shell: cmd
-        run: |
-          %VC%
-
-          git clone %GIT%/telegramdesktop/lzma.git
-          cd lzma
-          cd C\Util\LzmaLib
-          msbuild -m LzmaLib.sln /property:Configuration=Debug
-
       - name: OpenSSL cache.
         id: cache-openssl
         uses: actions/cache@v2
@@ -178,17 +169,6 @@ jobs:
 
           rmdir /S /Q test
           rmdir /S /Q .git
-
-      - name: Zlib.
-        shell: cmd
-        run: |
-          %VC%
-
-          git clone %GIT%/telegramdesktop/zlib.git
-          cd zlib
-          git checkout tdesktop
-          cd contrib\vstudio\vc14
-          msbuild -m zlibstat.vcxproj /property:Configuration=Debug
 
       - name: OpenAL Soft cache.
         id: cache-openal
@@ -398,6 +378,154 @@ jobs:
 
           cd %LibrariesPath%
           rmdir /S /Q qt_%QT%
+
+  telegram:
+    name: "Windows: Telegram"
+    runs-on: windows-latest
+    needs: dependencies
+
+    strategy:
+      matrix:
+        defines:
+          - ""
+
+    steps:
+      - name: Get repository name.
+        shell: bash
+        run: echo ::set-env name=REPO_NAME::${GITHUB_REPOSITORY##*/}
+
+      - name: Clone.
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          path: ${{ env.REPO_NAME }}
+
+      - name: Set up environment variables.
+        shell: cmd
+        run: |
+          echo ::add-path::C:\Strawberry\perl\bin\
+          echo ::add-path::"%programfiles%\NASM"
+
+          C:
+          cd "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\"
+          echo ::add-path::%cd%
+
+          call vcvars32.bat
+          D:
+          cd %GITHUB_WORKSPACE%
+          msbuild -version > CACHE_KEY.txt
+          echo %MANUAL_CACHING% >> CACHE_KEY.txt
+
+          mkdir Libraries
+          cd Libraries
+          echo ::set-env name=LibrariesPath::%cd%
+
+      - name: Generate cache key.
+        shell: bash
+        run: |
+          if [ "$AUTO_CACHING" == "1" ]; then
+            thisFile=$REPO_NAME/.github/workflows/win.yml
+            echo `md5sum $thisFile | awk '{ print $1 }'` >> CACHE_KEY.txt
+          fi
+          echo ::set-env name=CACHE_KEY::`md5sum CACHE_KEY.txt | awk '{ print $1 }'`
+
+      - name: Choco installs.
+        run: |
+          choco install --no-progress -y nasm yasm jom ninja
+
+      - name: Patches.
+        shell: bash
+        run: |
+          echo "Find necessary commit from doc."
+          checkoutCommit=$(grep -A 1 "cd patches" $REPO_NAME/$DOC_PATH | sed -n 2p)
+          cd $LibrariesPath
+          git clone $GIT/desktop-app/patches.git
+          cd Patches
+          eval $checkoutCommit
+
+      - name: Find any version of Python 2.
+        shell: cmd
+        run: |
+          echo Find any version of Python 2.
+          for /D %%a in (C:\hostedtoolcache\windows\Python\2.*) do (
+            SET PY2=%%a\x64
+          )
+          if [%PY2%] == [] (
+            echo Python 2 is not found.
+            exit 1
+          )
+          echo Found %PY2%.
+          echo ::set-env name=PY2::%PY2%
+
+      - name: LZMA.
+        shell: cmd
+        run: |
+          %VC%
+
+          git clone %GIT%/telegramdesktop/lzma.git
+          cd lzma
+          cd C\Util\LzmaLib
+          msbuild -m LzmaLib.sln /property:Configuration=Debug
+
+      - name: OpenSSL cache.
+        id: cache-openssl
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/openssl_${{ env.OPENSSL_VER }}
+          key: ${{ runner.OS }}-${{ env.CACHE_KEY }}-${{ env.OPENSSL_VER }}
+
+      - name: Zlib.
+        shell: cmd
+        run: |
+          %VC%
+
+          git clone %GIT%/telegramdesktop/zlib.git
+          cd zlib
+          git checkout tdesktop
+          cd contrib\vstudio\vc14
+          msbuild -m zlibstat.vcxproj /property:Configuration=Debug
+
+      - name: OpenAL Soft cache.
+        id: cache-openal
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/openal-soft
+          key: ${{ runner.OS }}-openal-soft-${{ env.CACHE_KEY }}
+
+      - name: Breakpad cache.
+        id: cache-breakpad
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/breakpad
+          key: ${{ runner.OS }}-breakpad-${{ env.CACHE_KEY }}-${{ hashFiles('**/breakpad.diff') }}
+
+      - name: Opus cache.
+        id: cache-opus
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/opus
+          key: ${{ runner.OS }}-opus-${{ env.CACHE_KEY }}
+
+      - name: FFmpeg cache.
+        id: cache-ffmpeg
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/ffmpeg
+          key: ${{ runner.OS }}-ffmpeg-${{ env.CACHE_KEY }}-2-${{ hashFiles('**/build_ffmpeg_win.sh') }}
+
+      - name: Qt 5.12.8 cache.
+        id: cache-qt
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/Qt-${{ env.QT_VER }}
+          key: ${{ runner.OS }}-qt-${{ env.CACHE_KEY }}-${{ hashFiles('**/qtbase_5_12_8/*') }}
+
+      - name: WebRTC cache.
+        id: cache-webrtc
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LibrariesPath }}/tg_owt
+          key: ${{ runner.OS }}-webrtc-${{ env.CACHE_KEY }}
 
       - name: Read defines.
         shell: bash

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -64,11 +64,6 @@ jobs:
     name: "Windows: dependencies"
     runs-on: windows-latest
 
-    strategy:
-      matrix:
-        defines:
-          - ""
-
     steps:
       - name: Get repository name.
         shell: bash

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -438,20 +438,6 @@ jobs:
           cd Patches
           eval $checkoutCommit
 
-      - name: Find any version of Python 2.
-        shell: cmd
-        run: |
-          echo Find any version of Python 2.
-          for /D %%a in (C:\hostedtoolcache\windows\Python\2.*) do (
-            SET PY2=%%a\x64
-          )
-          if [%PY2%] == [] (
-            echo Python 2 is not found.
-            exit 1
-          )
-          echo Found %PY2%.
-          echo ::set-env name=PY2::%PY2%
-
       - name: LZMA.
         shell: cmd
         run: |


### PR DESCRIPTION
This PR addresses the problem with rebuilding on CI.

## About the problem
When CI action fails for whatever reason, next time it will be fully rebuilt, both dependencies and Telegram. This leads to increased build times due to unnecessary rebuilds of dependencies.

## Proposed solution
My currently proposed solution is to split dependencies and Telegram build to separate jobs. That way even if Telegram build will fail, dependencies will be cached and reused on next run.

## Possible questions
#### Why not use `continue-on-error`?
`continue-on-error` will make job marked successfully done even when it fails, so finding errors will be harder. 