### PR TITLE
Fallback to D-Bus methods if XCB-based LastUserInputTime failed

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -1013,7 +1013,10 @@ QImage GetImageFromClipboard() {
 
 std::optional<crl::time> LastUserInputTime() {
 	if (!IsWayland()) {
-		return XCBLastUserInputTime();
+		const auto xcbResult = XCBLastUserInputTime();
+		if (xcbResult.has_value()) {
+			return xcbResult;
+		}
 	}
 
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION


### PR DESCRIPTION
Before 6635d03818c90f62cfddb516acadc293255b8905 XCBLastUserInputTime could fail only when there are no X connection, after that it is clear that it can fail even with X connection and fallback is needed.