### PR TITLE
Count audio with zero duration as Music

### DIFF
--- a/Telegram/SourceFiles/data/data_document.cpp
+++ b/Telegram/SourceFiles/data/data_document.cpp
@@ -1505,7 +1505,7 @@ bool DocumentData::isAudioFile() const {
 
 bool DocumentData::isSharedMediaMusic() const {
 	if (const auto songData = song()) {
-		return (songData->duration > 0);
+		return (songData->duration >= 0);
 	}
 	return false;
 }


### PR DESCRIPTION
Known issues: 
- when chat is loaded first time all music with zero duration is still listed as files

Fixes #8226 