### PR TITLE
Change socket path length condition to >=

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -815,7 +815,7 @@ QString SingleInstanceLocalServerName(const QString &hash) {
 		+ '-'
 		+ cGUIDStr();
 
-	if (idealSocketPath.size() > 108) {
+	if (idealSocketPath.size() >= 108) {
 		return AppRuntimeDirectory() + hash;
 	} else {
 		return idealSocketPath;


### PR DESCRIPTION
Looks like 108 is the length including \0, therefore actual limit is 107

Fixes #8883