### PR TITLE
Try to use portals for file dialog in snap, again

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,8 +18,6 @@ apps:
     common-id: org.telegram.desktop
     desktop: usr/share/applications/telegram-desktop_telegram-desktop.desktop
     environment:
-      # Use GTK3 cursor theme, icon theme and open/save file dialogs.
-      QT_QPA_PLATFORMTHEME: gtk3
       GTK_USE_PORTAL: 1
     plugs:
       - alsa


### PR DESCRIPTION
snapd has been fixed the issue with portals dbus activation a long time ago, so this shouldn't generate too much reports as it was this summer

Portals offer a native dialog for the DE used by a user that can show all files on the host and pass-through them via the sandbox. Qt uses them by default in snap if there is no override.