### PR TITLE
Build wayland support optionally

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,6 +54,7 @@ jobs:
         defines:
           - ""
           - "DESKTOP_APP_DISABLE_DBUS_INTEGRATION"
+          - "DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION"
           - "TDESKTOP_DISABLE_GTK_INTEGRATION"
 
     env:

--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -817,6 +817,7 @@ PRIVATE
     platform/linux/notifications_manager_linux.h
     platform/linux/specific_linux.cpp
     platform/linux/specific_linux.h
+    platform/linux/window_title_linux.cpp
     platform/linux/window_title_linux.h
     platform/mac/file_utilities_mac.mm
     platform/mac/file_utilities_mac.h

--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -70,7 +70,6 @@ PRIVATE
 if (LINUX)
     target_link_libraries(Telegram
     PRIVATE
-        desktop-app::external_materialdecoration
         desktop-app::external_nimf_qt5
         desktop-app::external_qt5ct_support
         desktop-app::external_xcb_screensaver
@@ -89,14 +88,22 @@ if (LINUX)
         )
     endif()
 
-    if (DESKTOP_APP_USE_PACKAGED AND Qt5WaylandClient_VERSION VERSION_LESS 5.13.0)
-        find_package(PkgConfig REQUIRED)
-        pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
-
-        target_include_directories(Telegram
+    if (NOT DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION)
+        target_link_libraries(Telegram
         PRIVATE
-            ${WAYLAND_CLIENT_INCLUDE_DIRS}
+            desktop-app::external_materialdecoration
         )
+
+        if (DESKTOP_APP_USE_PACKAGED
+            AND Qt5WaylandClient_VERSION VERSION_LESS 5.13.0)
+            find_package(PkgConfig REQUIRED)
+            pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+
+            target_include_directories(Telegram
+            PRIVATE
+                ${WAYLAND_CLIENT_INCLUDE_DIRS}
+            )
+        endif()
     endif()
 
     if (NOT TDESKTOP_DISABLE_GTK_INTEGRATION)
@@ -796,6 +803,8 @@ PRIVATE
     platform/linux/linux_gdk_helper.h
     platform/linux/linux_libs.cpp
     platform/linux/linux_libs.h
+    platform/linux/linux_wayland_integration.cpp
+    platform/linux/linux_wayland_integration.h
     platform/linux/linux_xlib_helper.cpp
     platform/linux/linux_xlib_helper.h
     platform/linux/file_utilities_linux.cpp
@@ -1079,6 +1088,11 @@ if (NOT LINUX)
         window/window_title_qt.cpp
         window/window_title_qt.h
     )
+endif()
+
+if (LINUX AND DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION)
+    remove_target_sources(Telegram ${src_loc} platform/linux/linux_wayland_integration.cpp)
+    nice_target_sources(Telegram ${src_loc} PRIVATE platform/linux/linux_wayland_integration_dummy.cpp)
 endif()
 
 if (NOT DESKTOP_APP_USE_PACKAGED)

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
@@ -1,0 +1,116 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "platform/linux/linux_wayland_integration.h"
+
+#include "base/platform/base_platform_info.h"
+
+#include <QtGui/QWindow>
+
+#include <private/qwaylanddisplay_p.h>
+#include <private/qwaylandwindow_p.h>
+#include <private/qwaylandshellsurface_p.h>
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0) && !defined DESKTOP_APP_QT_PATCHED
+#include <wayland-client.h>
+#endif // Qt < 5.13 && !DESKTOP_APP_QT_PATCHED
+
+using QtWaylandClient::QWaylandWindow;
+
+namespace Platform {
+namespace internal {
+
+namespace {
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0) && !defined DESKTOP_APP_QT_PATCHED
+enum wl_shell_surface_resize WlResizeFromEdges(Qt::Edges edges) {
+	if (edges == (Qt::TopEdge | Qt::LeftEdge))
+		return WL_SHELL_SURFACE_RESIZE_TOP_LEFT;
+	if (edges == Qt::TopEdge)
+		return WL_SHELL_SURFACE_RESIZE_TOP;
+	if (edges == (Qt::TopEdge | Qt::RightEdge))
+		return WL_SHELL_SURFACE_RESIZE_TOP_RIGHT;
+	if (edges == Qt::RightEdge)
+		return WL_SHELL_SURFACE_RESIZE_RIGHT;
+	if (edges == (Qt::RightEdge | Qt::BottomEdge))
+		return WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT;
+	if (edges == Qt::BottomEdge)
+		return WL_SHELL_SURFACE_RESIZE_BOTTOM;
+	if (edges == (Qt::BottomEdge | Qt::LeftEdge))
+		return WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT;
+	if (edges == Qt::LeftEdge)
+		return WL_SHELL_SURFACE_RESIZE_LEFT;
+
+	return WL_SHELL_SURFACE_RESIZE_NONE;
+}
+#endif // Qt < 5.13 && !DESKTOP_APP_QT_PATCHED
+
+} // namespace
+
+WaylandIntegration::WaylandIntegration() {
+}
+
+WaylandIntegration *WaylandIntegration::Instance() {
+	static WaylandIntegration instance;
+	return &instance;
+}
+
+bool WaylandIntegration::startMove(QWindow *window) {
+	// There are startSystemMove on Qt 5.15
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) && !defined DESKTOP_APP_QT_PATCHED
+	if (const auto waylandWindow = static_cast<QWaylandWindow*>(
+		window->handle())) {
+		if (const auto seat = waylandWindow->display()->lastInputDevice()) {
+			if (const auto shellSurface = waylandWindow->shellSurface()) {
+				return shellSurface->move(seat);
+			}
+		}
+	}
+#endif // Qt < 5.15 && !DESKTOP_APP_QT_PATCHED
+
+	return false;
+}
+
+bool WaylandIntegration::startResize(QWindow *window, Qt::Edges edges) {
+	// There are startSystemResize on Qt 5.15
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) && !defined DESKTOP_APP_QT_PATCHED
+	if (const auto waylandWindow = static_cast<QWaylandWindow*>(
+		window->handle())) {
+		if (const auto seat = waylandWindow->display()->lastInputDevice()) {
+			if (const auto shellSurface = waylandWindow->shellSurface()) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
+				shellSurface->resize(seat, edges);
+				return true;
+#else // Qt >= 5.13
+				shellSurface->resize(seat, WlResizeFromEdges(edges));
+				return true;
+#endif // Qt < 5.13
+			}
+		}
+	}
+#endif // Qt < 5.15 && !DESKTOP_APP_QT_PATCHED
+
+	return false;
+}
+
+bool WaylandIntegration::showWindowMenu(QWindow *window) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0) || defined DESKTOP_APP_QT_PATCHED
+	if (const auto waylandWindow = static_cast<QWaylandWindow*>(
+		window->handle())) {
+		if (const auto seat = waylandWindow->display()->lastInputDevice()) {
+			if (const auto shellSurface = waylandWindow->shellSurface()) {
+				return shellSurface->showWindowMenu(seat);
+			}
+		}
+	}
+#endif // Qt >= 5.13 || DESKTOP_APP_QT_PATCHED
+
+	return false;
+}
+
+} // namespace internal
+} // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
@@ -55,6 +55,7 @@ WaylandIntegration::WaylandIntegration() {
 }
 
 WaylandIntegration *WaylandIntegration::Instance() {
+	if (!IsWayland()) return nullptr;
 	static WaylandIntegration instance;
 	return &instance;
 }

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
@@ -1,0 +1,27 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+class QWindow;
+
+namespace Platform {
+namespace internal {
+
+class WaylandIntegration {
+public:
+	static WaylandIntegration *Instance();
+	bool startMove(QWindow *window);
+	bool startResize(QWindow *window, Qt::Edges edges);
+	bool showWindowMenu(QWindow *window);
+
+private:
+	WaylandIntegration();
+};
+
+} // namespace internal
+} // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
@@ -7,6 +7,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "platform/linux/linux_wayland_integration.h"
 
+#include "base/platform/base_platform_info.h"
+
 namespace Platform {
 namespace internal {
 
@@ -14,6 +16,7 @@ WaylandIntegration::WaylandIntegration() {
 }
 
 WaylandIntegration *WaylandIntegration::Instance() {
+	if (!IsWayland()) return nullptr;
 	static WaylandIntegration instance;
 	return &instance;
 }

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
@@ -1,0 +1,34 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "platform/linux/linux_wayland_integration.h"
+
+namespace Platform {
+namespace internal {
+
+WaylandIntegration::WaylandIntegration() {
+}
+
+WaylandIntegration *WaylandIntegration::Instance() {
+	static WaylandIntegration instance;
+	return &instance;
+}
+
+bool WaylandIntegration::startMove(QWindow *window) {
+	return false;
+}
+
+bool WaylandIntegration::startResize(QWindow *window, Qt::Edges edges) {
+	return false;
+}
+
+bool WaylandIntegration::showWindowMenu(QWindow *window) {
+	return false;
+}
+
+} // namespace internal
+} // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -16,6 +16,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "mainwindow.h"
 #include "platform/linux/linux_desktop_environment.h"
 #include "platform/linux/file_utilities_linux.h"
+#include "platform/linux/linux_wayland_integration.h"
 #include "platform/platform_notifications_manager.h"
 #include "storage/localstorage.h"
 #include "core/crash_reports.h"
@@ -31,10 +32,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtCore/QLibraryInfo>
 #include <QtGui/QWindow>
 
-#include <private/qwaylanddisplay_p.h>
-#include <private/qwaylandwindow_p.h>
-#include <private/qwaylandshellsurface_p.h>
-
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QDBusConnection>
@@ -45,10 +42,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include <xcb/xcb.h>
 #include <xcb/screensaver.h>
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0) && !defined DESKTOP_APP_QT_PATCHED
-#include <wayland-client.h>
-#endif // Qt < 5.13 && !DESKTOP_APP_QT_PATCHED
 
 #include <glib.h>
 
@@ -69,7 +62,7 @@ extern "C" {
 
 using namespace Platform;
 using Platform::File::internal::EscapeShell;
-using QtWaylandClient::QWaylandWindow;
+using Platform::internal::WaylandIntegration;
 
 namespace Platform {
 namespace {
@@ -334,29 +327,6 @@ uint XCBMoveResizeFromEdges(Qt::Edges edges) {
 	return 0;
 }
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0) && !defined DESKTOP_APP_QT_PATCHED
-enum wl_shell_surface_resize WlResizeFromEdges(Qt::Edges edges) {
-	if (edges == (Qt::TopEdge | Qt::LeftEdge))
-		return WL_SHELL_SURFACE_RESIZE_TOP_LEFT;
-	if (edges == Qt::TopEdge)
-		return WL_SHELL_SURFACE_RESIZE_TOP;
-	if (edges == (Qt::TopEdge | Qt::RightEdge))
-		return WL_SHELL_SURFACE_RESIZE_TOP_RIGHT;
-	if (edges == Qt::RightEdge)
-		return WL_SHELL_SURFACE_RESIZE_RIGHT;
-	if (edges == (Qt::RightEdge | Qt::BottomEdge))
-		return WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT;
-	if (edges == Qt::BottomEdge)
-		return WL_SHELL_SURFACE_RESIZE_BOTTOM;
-	if (edges == (Qt::BottomEdge | Qt::LeftEdge))
-		return WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT;
-	if (edges == Qt::LeftEdge)
-		return WL_SHELL_SURFACE_RESIZE_LEFT;
-
-	return WL_SHELL_SURFACE_RESIZE_NONE;
-}
-#endif // Qt < 5.13 && !DESKTOP_APP_QT_PATCHED
-
 bool StartXCBMoveResize(QWindow *window, int edges) {
 	const auto connection = base::Platform::XCB::GetConnectionFromQt();
 	if (!connection) {
@@ -447,59 +417,6 @@ bool ShowXCBWindowMenu(QWindow *window) {
 		reinterpret_cast<const char*>(&xev));
 
 	return true;
-}
-
-bool StartWaylandMove(QWindow *window) {
-	// There are startSystemMove on Qt 5.15
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) && !defined DESKTOP_APP_QT_PATCHED
-	if (const auto waylandWindow = static_cast<QWaylandWindow*>(
-		window->handle())) {
-		if (const auto seat = waylandWindow->display()->lastInputDevice()) {
-			if (const auto shellSurface = waylandWindow->shellSurface()) {
-				return shellSurface->move(seat);
-			}
-		}
-	}
-#endif // Qt < 5.15 && !DESKTOP_APP_QT_PATCHED
-
-	return false;
-}
-
-bool StartWaylandResize(QWindow *window, Qt::Edges edges) {
-	// There are startSystemResize on Qt 5.15
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) && !defined DESKTOP_APP_QT_PATCHED
-	if (const auto waylandWindow = static_cast<QWaylandWindow*>(
-		window->handle())) {
-		if (const auto seat = waylandWindow->display()->lastInputDevice()) {
-			if (const auto shellSurface = waylandWindow->shellSurface()) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
-				shellSurface->resize(seat, edges);
-				return true;
-#else // Qt >= 5.13
-				shellSurface->resize(seat, WlResizeFromEdges(edges));
-				return true;
-#endif // Qt < 5.13
-			}
-		}
-	}
-#endif // Qt < 5.15 && !DESKTOP_APP_QT_PATCHED
-
-	return false;
-}
-
-bool ShowWaylandWindowMenu(QWindow *window) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0) || defined DESKTOP_APP_QT_PATCHED
-	if (const auto waylandWindow = static_cast<QWaylandWindow*>(
-		window->handle())) {
-		if (const auto seat = waylandWindow->display()->lastInputDevice()) {
-			if (const auto shellSurface = waylandWindow->shellSurface()) {
-				return shellSurface->showWindowMenu(seat);
-			}
-		}
-	}
-#endif // Qt >= 5.13 || DESKTOP_APP_QT_PATCHED
-
-	return false;
 }
 
 bool XCBFrameExtentsSupported() {
@@ -860,7 +777,8 @@ bool SkipTaskbarSupported() {
 
 bool StartSystemMove(QWindow *window) {
 	if (IsWayland()) {
-		return StartWaylandMove(window);
+		const auto integration = WaylandIntegration::Instance();
+		return integration->startMove(window);
 	} else {
 		return StartXCBMoveResize(window, 16);
 	}
@@ -868,7 +786,8 @@ bool StartSystemMove(QWindow *window) {
 
 bool StartSystemResize(QWindow *window, Qt::Edges edges) {
 	if (IsWayland()) {
-		return StartWaylandResize(window, edges);
+		const auto integration = WaylandIntegration::Instance();
+		return integration->startResize(window, edges);
 	} else {
 		return StartXCBMoveResize(window, edges);
 	}
@@ -876,7 +795,8 @@ bool StartSystemResize(QWindow *window, Qt::Edges edges) {
 
 bool ShowWindowMenu(QWindow *window) {
 	if (IsWayland()) {
-		return ShowWaylandWindowMenu(window);
+		const auto integration = WaylandIntegration::Instance();
+		return integration->showWindowMenu(window);
 	} else {
 		return ShowXCBWindowMenu(window);
 	}

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -776,8 +776,7 @@ bool SkipTaskbarSupported() {
 }
 
 bool StartSystemMove(QWindow *window) {
-	if (IsWayland()) {
-		const auto integration = WaylandIntegration::Instance();
+	if (const auto integration = WaylandIntegration::Instance()) {
 		return integration->startMove(window);
 	} else {
 		return StartXCBMoveResize(window, 16);
@@ -785,8 +784,7 @@ bool StartSystemMove(QWindow *window) {
 }
 
 bool StartSystemResize(QWindow *window, Qt::Edges edges) {
-	if (IsWayland()) {
-		const auto integration = WaylandIntegration::Instance();
+	if (const auto integration = WaylandIntegration::Instance()) {
 		return integration->startResize(window, edges);
 	} else {
 		return StartXCBMoveResize(window, edges);
@@ -794,8 +792,7 @@ bool StartSystemResize(QWindow *window, Qt::Edges edges) {
 }
 
 bool ShowWindowMenu(QWindow *window) {
-	if (IsWayland()) {
-		const auto integration = WaylandIntegration::Instance();
+	if (const auto integration = WaylandIntegration::Instance()) {
 		return integration->showWindowMenu(window);
 	} else {
 		return ShowXCBWindowMenu(window);

--- a/Telegram/SourceFiles/platform/linux/window_title_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/window_title_linux.cpp
@@ -1,0 +1,38 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "platform/linux/window_title_linux.h"
+
+#include "platform/linux/linux_desktop_environment.h"
+#include "base/platform/base_platform_info.h"
+
+namespace Platform {
+namespace {
+
+bool SystemMoveResizeSupported() {
+#if !defined DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION || QT_VERSION >= QT_VERSION_CHECK(5, 15, 0) || defined DESKTOP_APP_QT_PATCHED
+	return true;
+#else // !DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION || Qt >= 5.15 || DESKTOP_APP_QT_PATCHED
+	return !IsWayland();
+#endif // !DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION || Qt >= 5.15 || DESKTOP_APP_QT_PATCHED
+}
+
+} // namespace
+
+bool AllowNativeWindowFrameToggle() {
+	return SystemMoveResizeSupported()
+		// https://gitlab.gnome.org/GNOME/mutter/-/issues/217
+		&& !(DesktopEnvironment::IsGnome() && IsWayland());
+}
+
+object_ptr<Window::TitleWidget> CreateTitleWidget(QWidget *parent) {
+	return SystemMoveResizeSupported()
+		? object_ptr<Window::TitleWidgetQt>(parent)
+		: object_ptr<Window::TitleWidgetQt>{ nullptr };
+}
+
+} // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/window_title_linux.h
+++ b/Telegram/SourceFiles/platform/linux/window_title_linux.h
@@ -8,8 +8,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "platform/platform_window_title.h"
-#include "platform/linux/linux_desktop_environment.h"
-#include "base/platform/base_platform_info.h"
 #include "base/object_ptr.h"
 
 namespace Window {
@@ -23,14 +21,8 @@ void DefaultPreviewWindowFramePaint(QImage &preview, const style::palette &palet
 
 namespace Platform {
 
-inline bool AllowNativeWindowFrameToggle() {
-	// https://gitlab.gnome.org/GNOME/mutter/-/issues/217
-	return !(DesktopEnvironment::IsGnome() && IsWayland());
-}
-
-inline object_ptr<Window::TitleWidget> CreateTitleWidget(QWidget *parent) {
-	return object_ptr<Window::TitleWidgetQt>(parent);
-}
+bool AllowNativeWindowFrameToggle();
+object_ptr<Window::TitleWidget> CreateTitleWidget(QWidget *parent);
 
 inline bool NativeTitleRequiresShadow() {
 	return false;

--- a/Telegram/SourceFiles/qt_static_plugins.cpp
+++ b/Telegram/SourceFiles/qt_static_plugins.cpp
@@ -21,19 +21,7 @@ Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 Q_IMPORT_PLUGIN(QGenericEnginePlugin)
 #elif defined Q_OS_UNIX // Q_OS_WIN | Q_OS_MAC
-Q_IMPORT_PLUGIN(ShmServerBufferPlugin)
-Q_IMPORT_PLUGIN(DmaBufServerBufferPlugin)
-Q_IMPORT_PLUGIN(DrmEglServerBufferPlugin)
-Q_IMPORT_PLUGIN(QWaylandEglClientBufferPlugin)
-Q_IMPORT_PLUGIN(QWaylandIviShellIntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandWlShellIntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandXdgShellV5IntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandXdgShellV6IntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandXdgShellIntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandBradientDecorationPlugin)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandIntegrationPlugin)
-Q_IMPORT_PLUGIN(QWaylandEglPlatformIntegrationPlugin)
 Q_IMPORT_PLUGIN(QGenericEnginePlugin)
 Q_IMPORT_PLUGIN(QComposePlatformInputContextPlugin)
 Q_IMPORT_PLUGIN(QSvgPlugin)
@@ -44,18 +32,34 @@ Q_IMPORT_PLUGIN(QNetworkManagerEnginePlugin)
 Q_IMPORT_PLUGIN(QIbusPlatformInputContextPlugin)
 Q_IMPORT_PLUGIN(QXdgDesktopPortalThemePlugin)
 #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION
+Q_IMPORT_PLUGIN(ShmServerBufferPlugin)
+Q_IMPORT_PLUGIN(DmaBufServerBufferPlugin)
+Q_IMPORT_PLUGIN(DrmEglServerBufferPlugin)
+Q_IMPORT_PLUGIN(QWaylandEglClientBufferPlugin)
+Q_IMPORT_PLUGIN(QWaylandIviShellIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandWlShellIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandXdgShellV5IntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandXdgShellV6IntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandXdgShellIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandBradientDecorationPlugin)
+Q_IMPORT_PLUGIN(QWaylandIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWaylandEglPlatformIntegrationPlugin)
+#endif // !DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION
 #endif // Q_OS_WIN | Q_OS_MAC | Q_OS_UNIX
 #endif // !DESKTOP_APP_USE_PACKAGED
 
 #if defined Q_OS_UNIX && !defined Q_OS_MAC
 #if !defined DESKTOP_APP_USE_PACKAGED || defined DESKTOP_APP_USE_PACKAGED_LAZY
-Q_IMPORT_PLUGIN(QWaylandMaterialDecorationPlugin)
 Q_IMPORT_PLUGIN(NimfInputContextPlugin)
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 Q_IMPORT_PLUGIN(QFcitxPlatformInputContextPlugin)
 Q_IMPORT_PLUGIN(QFcitx5PlatformInputContextPlugin)
 Q_IMPORT_PLUGIN(QHimePlatformInputContextPlugin)
 #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION
+Q_IMPORT_PLUGIN(QWaylandMaterialDecorationPlugin)
+#endif // !DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION
 #endif // !DESKTOP_APP_USE_PACKAGED || DESKTOP_APP_USE_PACKAGED_LAZY
 
 #if !defined DESKTOP_APP_USE_PACKAGED || defined DESKTOP_APP_USE_PACKAGED_LAZY_PLATFORMTHEMES


### PR DESCRIPTION
Add `DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION` to control the dependency on QtWayland.
Related feature request: https://github.com/telegramdesktop/tdesktop/issues/9031
Submodule pull request: https://github.com/desktop-app/cmake_helpers/pull/67