### PR TITLE
Restore 16px tray icon size

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -202,6 +202,7 @@ QIcon TrayIconGen(int counter, bool muted) {
 	QIcon systemIcon;
 
 	static const auto iconSizes = {
+		16,
 		22,
 		24,
 		32,


### PR DESCRIPTION
Looks like there are support for this size since b703f4e5557053d4cc320e42861db197c0ce7790