### PR TITLE
Detect more dark themes on Linux

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -779,7 +779,7 @@ std::optional<bool> IsDarkMode() {
 
 		const auto themeName = Libs::GtkSetting("gtk-theme-name").toLower();
 
-		if (themeName.endsWith(qsl("-dark"))) {
+		if (themeName.contains(qsl("-dark"))) {
 			return true;
 		}
 


### PR DESCRIPTION
QGnomePlatform changed its detection method as well https://github.com/FedoraQt/QGnomePlatform/commit/23ee752d31069c222ab2e05ce4c37482fc22ddf4