### PR TITLE
Media Play key is expected to behave like Toggle Media Play/Pause

### DIFF
--- a/Telegram/SourceFiles/media/player/media_player_instance.cpp
+++ b/Telegram/SourceFiles/media/player/media_player_instance.cpp
@@ -733,7 +733,7 @@ void Instance::setupShortcuts() {
 	) | rpl::start_with_next([=](not_null<Shortcuts::Request*> request) {
 		using Command = Shortcuts::Command;
 		request->check(Command::MediaPlay) && request->handle([=] {
-			play();
+			playPause();
 			return true;
 		});
 		request->check(Command::MediaPause) && request->handle([=] {


### PR DESCRIPTION
Looks like Qt maps "Media Play" to the common play/pause button on keyboards:
https://github.com/qt/qtbase/blob/5.15/src/platformsupport/input/xkbcommon/qxkbcommon.cpp#L293
https://github.com/qt/qtbase/blob/5.15/src/plugins/platforms/windows/qwindowskeymapper.cpp#L392
https://github.com/qt/qtbase/blob/5.15/src/plugins/platforms/android/androidjniinput.cpp#L519
https://github.com/qt/qtbase/blob/5.15/src/plugins/platforms/android/androidjniinput.cpp#L607

While "Toggle Media Play/Pause" is some special case:
https://github.com/qt/qtbase/blob/5.15/src/plugins/platforms/windows/qwindowskeymapper.cpp#L488
https://github.com/qt/qtbase/blob/5.15/src/plugins/platforms/ios/quiview.mm#L584

It is worth to behave on "Media Play" like on "Toggle Media Play/Pause".

Fixes #3342