### PR TITLE
Update VS2019 build instructions

### DIFF
--- a/docs/building-msvc-x64.md
+++ b/docs/building-msvc-x64.md
@@ -195,7 +195,7 @@ Open **x64 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
     jom -j8 install
     cd ..
 
-    git clone https://github.com/desktop-app/tg_owt.git
+    git clone --recursive https://github.com/desktop-app/tg_owt.git
     cd tg_owt
     mkdir out
     cd out

--- a/docs/building-msvc.md
+++ b/docs/building-msvc.md
@@ -195,7 +195,7 @@ Open **x86 Native Tools Command Prompt for VS 2019.bat**, go to ***BuildPath*** 
     jom -j8 install
     cd ..
 
-    git clone https://github.com/desktop-app/tg_owt.git
+    git clone --recursive https://github.com/desktop-app/tg_owt.git
     cd tg_owt
     mkdir out
     cd out


### PR DESCRIPTION
there is a submodule that need to clone, see https://github.com/desktop-app/tg_owt/tree/master/src/third_party