### PR TITLE
Add support for G-S-D's media-keys extension

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -812,6 +812,8 @@ PRIVATE
     platform/linux/linux_desktop_environment.h
     platform/linux/linux_gdk_helper.cpp
     platform/linux/linux_gdk_helper.h
+    platform/linux/linux_gsd_media_keys.cpp
+    platform/linux/linux_gsd_media_keys.h
     platform/linux/linux_libs.cpp
     platform/linux/linux_libs.h
     platform/linux/linux_wayland_integration.cpp
@@ -1098,6 +1100,13 @@ if (NOT LINUX)
     remove_target_sources(Telegram ${src_loc}
         window/window_title_qt.cpp
         window/window_title_qt.h
+    )
+endif()
+
+if (LINUX AND DESKTOP_APP_DISABLE_DBUS_INTEGRATION)
+    remove_target_sources(Telegram ${src_loc}
+        platform/linux/linux_gsd_media_keys.cpp
+        platform/linux/linux_gsd_media_keys.h
     )
 endif()
 

--- a/Telegram/SourceFiles/platform/linux/linux_gsd_media_keys.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_gsd_media_keys.cpp
@@ -1,0 +1,182 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "platform/linux/linux_gsd_media_keys.h"
+
+#include "core/sandbox.h"
+#include "media/player/media_player_instance.h"
+
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusConnectionInterface>
+
+extern "C" {
+#undef signals
+#include <gio/gio.h>
+#define signals public
+} // extern "C"
+
+namespace Platform {
+namespace internal {
+namespace {
+
+constexpr auto kDBusTimeout = 30000;
+constexpr auto kService = "org.gnome.SettingsDaemon.MediaKeys"_cs;
+constexpr auto kOldService = "org.gnome.SettingsDaemon"_cs;
+constexpr auto kMATEService = "org.mate.SettingsDaemon"_cs;
+constexpr auto kObjectPath = "/org/gnome/SettingsDaemon/MediaKeys"_cs;
+constexpr auto kMATEObjectPath = "/org/mate/SettingsDaemon/MediaKeys"_cs;
+constexpr auto kInterface = kService;
+constexpr auto kMATEInterface = "org.mate.SettingsDaemon.MediaKeys"_cs;
+
+void KeyPressed(
+		GDBusConnection *connection,
+		const gchar *sender_name,
+		const gchar *object_path,
+		const gchar *interface_name,
+		const gchar *signal_name,
+		GVariant *parameters,
+		gpointer user_data) {
+	gchar *appUtf8;
+	gchar *keyUtf8;
+	g_variant_get(parameters, "(ss)", &appUtf8, &keyUtf8);
+	const auto app = QString::fromUtf8(appUtf8);
+	const auto key = QString::fromUtf8(keyUtf8);
+	g_free(keyUtf8);
+	g_free(appUtf8);
+
+	if (app != QCoreApplication::applicationName()) {
+		return;
+	}
+
+	Core::Sandbox::Instance().customEnterFromEventLoop([&] {
+		if (key == qstr("Play")) {
+			Media::Player::instance()->playPause();
+		} else if (key == qstr("Stop")) {
+			Media::Player::instance()->stop();
+		} else if (key == qstr("Next")) {
+			Media::Player::instance()->next();
+		} else if (key == qstr("Previous")) {
+			Media::Player::instance()->previous();
+		}
+	});
+}
+
+} // namespace
+
+GSDMediaKeys::GSDMediaKeys() {
+	GError *error = nullptr;
+	const auto interface = QDBusConnection::sessionBus().interface();
+
+	if (!interface) {
+		return;
+	}
+
+	if (interface->isServiceRegistered(kService.utf16())) {
+		_service = kService.utf16();
+		_objectPath = kObjectPath.utf16();
+		_interface = kInterface.utf16();
+	} else if (interface->isServiceRegistered(kOldService.utf16())) {
+		_service = kOldService.utf16();
+		_objectPath = kObjectPath.utf16();
+		_interface = kInterface.utf16();
+	} else if (interface->isServiceRegistered(kMATEService.utf16())) {
+		_service = kMATEService.utf16();
+		_objectPath = kMATEObjectPath.utf16();
+		_interface = kMATEInterface.utf16();
+	} else {
+		return;
+	}
+
+	_dbusConnection = g_bus_get_sync(
+		G_BUS_TYPE_SESSION,
+		nullptr,
+		&error);
+
+	if (error) {
+		LOG(("GSD Media Keys Error: %1").arg(error->message));
+		g_error_free(error);
+		return;
+	}
+
+	auto reply = g_dbus_connection_call_sync(
+		_dbusConnection,
+		_service.toUtf8(),
+		_objectPath.toUtf8(),
+		_interface.toUtf8(),
+		"GrabMediaPlayerKeys",
+		g_variant_new(
+			"(su)",
+			QCoreApplication::applicationName().toUtf8().constData(),
+			0),
+		nullptr,
+		G_DBUS_CALL_FLAGS_NONE,
+		kDBusTimeout,
+		nullptr,
+		&error);
+
+	if (!error) {
+		_grabbed = true;
+		g_variant_unref(reply);
+	} else {
+		LOG(("GSD Media Keys Error: %1").arg(error->message));
+		g_error_free(error);
+	}
+
+	_signalId = g_dbus_connection_signal_subscribe(
+		_dbusConnection,
+		_service.toUtf8(),
+		_interface.toUtf8(),
+		"MediaPlayerKeyPressed",
+		_objectPath.toUtf8(),
+		nullptr,
+		G_DBUS_SIGNAL_FLAGS_NONE,
+		KeyPressed,
+		nullptr,
+		nullptr);
+}
+
+GSDMediaKeys::~GSDMediaKeys() {
+	GError *error = nullptr;
+
+	if (_signalId != 0) {
+		g_dbus_connection_signal_unsubscribe(
+			_dbusConnection,
+			_signalId);
+	}
+
+	if (_grabbed) {
+		auto reply = g_dbus_connection_call_sync(
+			_dbusConnection,
+			_service.toUtf8(),
+			_objectPath.toUtf8(),
+			_interface.toUtf8(),
+			"ReleaseMediaPlayerKeys",
+			g_variant_new(
+				"(s)",
+				QCoreApplication::applicationName().toUtf8().constData()),
+			nullptr,
+			G_DBUS_CALL_FLAGS_NONE,
+			kDBusTimeout,
+			nullptr,
+			&error);
+
+		if (!error) {
+			_grabbed = false;
+			g_variant_unref(reply);
+		} else {
+			LOG(("GSD Media Keys Error: %1").arg(error->message));
+			g_error_free(error);
+		}
+	}
+
+	if (_dbusConnection) {
+		g_object_unref(_dbusConnection);
+	}
+}
+
+} // namespace internal
+} // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/linux_gsd_media_keys.h
+++ b/Telegram/SourceFiles/platform/linux/linux_gsd_media_keys.h
@@ -1,0 +1,36 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+typedef struct _GDBusConnection GDBusConnection;
+
+namespace Platform {
+namespace internal {
+
+class GSDMediaKeys {
+public:
+	GSDMediaKeys();
+
+	GSDMediaKeys(const GSDMediaKeys &other) = delete;
+	GSDMediaKeys &operator=(const GSDMediaKeys &other) = delete;
+	GSDMediaKeys(GSDMediaKeys &&other) = delete;
+	GSDMediaKeys &operator=(GSDMediaKeys &&other) = delete;
+
+	~GSDMediaKeys();
+
+private:
+	GDBusConnection *_dbusConnection = nullptr;
+	QString _service;
+	QString _objectPath;
+	QString _interface;
+	uint _signalId = 0;
+	bool _grabbed = false;
+};
+
+} // namespace internal
+} // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -48,6 +48,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtDBus/QDBusMessage>
 #include <QtDBus/QDBusReply>
 #include <QtDBus/QDBusError>
+#include <QtDBus/QDBusObjectPath>
 #include <QtDBus/QDBusMetaType>
 
 #include <statusnotifieritem.h>
@@ -451,7 +452,7 @@ bool IsAppMenuSupported() {
 	return interface->isServiceRegistered(kAppMenuService.utf16());
 }
 
-void RegisterAppMenu(uint winId, const QDBusObjectPath &menuPath) {
+void RegisterAppMenu(uint winId, const QString &menuPath) {
 	auto message = QDBusMessage::createMethodCall(
 		kAppMenuService.utf16(),
 		kAppMenuObjectPath.utf16(),
@@ -460,7 +461,7 @@ void RegisterAppMenu(uint winId, const QDBusObjectPath &menuPath) {
 
 	message.setArguments({
 		winId,
-		QVariant::fromValue(menuPath)
+		QVariant::fromValue(QDBusObjectPath(menuPath))
 	});
 
 	QDBusConnection::sessionBus().send(message);
@@ -759,7 +760,7 @@ void MainWindow::handleAppMenuOwnerChanged(
 		LOG(("Not using D-Bus global menu."));
 	}
 
-	if (_appMenuSupported && !_mainMenuPath.path().isEmpty()) {
+	if (_appMenuSupported && !_mainMenuPath.isEmpty()) {
 		RegisterAppMenu(winId(), _mainMenuPath);
 	} else {
 		UnregisterAppMenu(winId());
@@ -1075,10 +1076,10 @@ void MainWindow::createGlobalMenu() {
 
 	about->setMenuRole(QAction::AboutQtRole);
 
-	_mainMenuPath.setPath(qsl("/MenuBar"));
+	_mainMenuPath = qsl("/MenuBar");
 
 	_mainMenuExporter = new DBusMenuExporter(
-		_mainMenuPath.path(),
+		_mainMenuPath,
 		psMainMenu);
 
 	if (_appMenuSupported) {
@@ -1214,7 +1215,7 @@ void MainWindow::handleVisibleChangedHook(bool visible) {
 	}
 
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
-	if (_appMenuSupported && !_mainMenuPath.path().isEmpty()) {
+	if (_appMenuSupported && !_mainMenuPath.isEmpty()) {
 		if (visible) {
 			RegisterAppMenu(winId(), _mainMenuPath);
 		} else {

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -31,6 +31,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "platform/linux/linux_gsd_media_keys.h"
 #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 #include "base/call_delayed.h"
+#include "ui/widgets/popup_menu.h"
 #include "ui/widgets/input_fields.h"
 #include "facades.h"
 #include "app.h"
@@ -39,6 +40,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtGui/QWindow>
 
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#include <QtCore/QTemporaryFile>
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusConnectionInterface>
@@ -48,7 +50,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtDBus/QDBusError>
 #include <QtDBus/QDBusMetaType>
 
-#include <xcb/xcb.h>
+#include <statusnotifieritem.h>
+#include <dbusmenuexporter.h>
 
 extern "C" {
 #undef signals

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.h
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.h
@@ -14,8 +14,6 @@ class PopupMenu;
 } // namespace Ui
 
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
-#include <QtDBus/QDBusObjectPath>
-
 class QTemporaryFile;
 class DBusMenuExporter;
 class StatusNotifierItem;
@@ -94,7 +92,7 @@ private:
 
 	bool _appMenuSupported = false;
 	DBusMenuExporter *_mainMenuExporter = nullptr;
-	QDBusObjectPath _mainMenuPath;
+	QString _mainMenuPath;
 
 	std::unique_ptr<internal::GSDMediaKeys> _gsdMediaKeys;
 

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.h
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.h
@@ -9,13 +9,16 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "platform/platform_main_window.h"
 
-#include "ui/widgets/popup_menu.h"
+namespace Ui {
+class PopupMenu;
+} // namespace Ui
 
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
-#include "statusnotifieritem.h"
-#include <QtCore/QTemporaryFile>
 #include <QtDBus/QDBusObjectPath>
-#include <dbusmenuexporter.h>
+
+class QTemporaryFile;
+class DBusMenuExporter;
+class StatusNotifierItem;
 
 typedef void* gpointer;
 typedef char gchar;
@@ -87,7 +90,7 @@ private:
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 	StatusNotifierItem *_sniTrayIcon = nullptr;
 	GDBusProxy *_sniDBusProxy = nullptr;
-	std::unique_ptr<QTemporaryFile> _trayIconFile = nullptr;
+	std::unique_ptr<QTemporaryFile> _trayIconFile;
 
 	bool _appMenuSupported = false;
 	DBusMenuExporter *_mainMenuExporter = nullptr;

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.h
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.h
@@ -24,6 +24,11 @@ typedef struct _GDBusProxy GDBusProxy;
 #endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 
 namespace Platform {
+#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+namespace internal {
+class GSDMediaKeys;
+} // namespace internal
+#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 
 class MainWindow : public Window::MainWindow {
 public:
@@ -87,6 +92,8 @@ private:
 	bool _appMenuSupported = false;
 	DBusMenuExporter *_mainMenuExporter = nullptr;
 	QDBusObjectPath _mainMenuPath;
+
+	std::unique_ptr<internal::GSDMediaKeys> _gsdMediaKeys;
 
 	QMenu *psMainMenu = nullptr;
 	QAction *psLogout = nullptr;

--- a/Telegram/SourceFiles/platform/win/main_window_win.cpp
+++ b/Telegram/SourceFiles/platform/win/main_window_win.cpp
@@ -217,7 +217,11 @@ void MainWindow::psSetupTrayIcon() {
 		auto icon = QIcon(App::pixmapFromImageInPlace(Core::App().logoNoMargin()));
 
 		trayIcon->setIcon(icon);
-		connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(showFromTray()));
+		connect(
+			trayIcon,
+			&QSystemTrayIcon::messageClicked,
+			this,
+			[=] { App::wnd()->showFromTray(); });
 		attachToTrayIcon(trayIcon);
 	}
 	updateIconCounters();


### PR DESCRIPTION
This fixes media keys handling on (but not limited to, probably):
* GNOME
* Cinnamon
* MATE
* Budgie
* Pantheon (elementaryOS)
* Unity

Fixes #3960