### PR TITLE
Added a 'auto-hide' notifications setting

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -329,6 +329,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_events_joined" = "Contact joined Telegram";
 "lng_settings_events_pinned" = "Pinned messages";
 "lng_settings_notifications_calls_title" = "Calls";
+"lng_settings_autohide_notifications" = "Hide after a few seconds";
 
 "lng_notification_preview" = "You have a new message";
 "lng_notification_reply" = "Reply";

--- a/Telegram/SourceFiles/core/core_settings.cpp
+++ b/Telegram/SourceFiles/core/core_settings.cpp
@@ -115,7 +115,8 @@ QByteArray Settings::serialize() const {
 			<< _groupCallPushToTalkShortcut
 			<< qint64(_groupCallPushToTalkDelay)
 			<< qint32(0) // Call audio backend
-			<< qint32(_disableCalls ? 1 : 0);
+			<< qint32(_disableCalls ? 1 : 0)
+			<< qint32(_autoHideNotifications ? 1 : 0);
 	}
 	return result;
 }
@@ -188,6 +189,7 @@ void Settings::addFromSerialized(const QByteArray &serialized) {
 	qint64 groupCallPushToTalkDelay = _groupCallPushToTalkDelay;
 	qint32 callAudioBackend = 0;
 	qint32 disableCalls = _disableCalls ? 1 : 0;
+	qint32 autoHideNotifications = _autoHideNotifications ? 1 : 0;
 
 	stream >> themesAccentColors;
 	if (!stream.atEnd()) {
@@ -288,6 +290,9 @@ void Settings::addFromSerialized(const QByteArray &serialized) {
 	}
 	if (!stream.atEnd()) {
 		stream >> disableCalls;
+    }
+    if (!stream.atEnd()) {
+		stream >> autoHideNotifications;
 	}
 	if (stream.status() != QDataStream::Ok) {
 		LOG(("App Error: "
@@ -307,6 +312,7 @@ void Settings::addFromSerialized(const QByteArray &serialized) {
 	_soundNotify = (soundNotify == 1);
 	_desktopNotify = (desktopNotify == 1);
 	_flashBounceNotify = (flashBounceNotify == 1);
+	_autoHideNotifications = (autoHideNotifications == 1);
 	const auto uncheckedNotifyView = static_cast<DBINotifyView>(notifyView);
 	switch (uncheckedNotifyView) {
 	case dbinvShowNothing:
@@ -483,6 +489,7 @@ void Settings::resetOnLastLogout() {
 	_soundNotify = true;
 	_desktopNotify = true;
 	_flashBounceNotify = true;
+	_autoHideNotifications = false;
 	_notifyView = dbinvShowPreview;
 	//_nativeNotifications = std::nullopt;
 	//_notificationsCount = 3;

--- a/Telegram/SourceFiles/core/core_settings.h
+++ b/Telegram/SourceFiles/core/core_settings.h
@@ -129,6 +129,12 @@ public:
 	void setFlashBounceNotify(bool value) {
 		_flashBounceNotify = value;
 	}
+	[[nodiscard]] bool autoHideNotifications() const {
+		return _autoHideNotifications;
+	}
+	void setAutoHideNotifications(bool value) {
+		_autoHideNotifications = value;
+	}
 	[[nodiscard]] DBINotifyView notifyView() const {
 		return _notifyView;
 	}
@@ -531,6 +537,7 @@ private:
 	bool _soundNotify = true;
 	bool _desktopNotify = true;
 	bool _flashBounceNotify = true;
+	bool _autoHideNotifications = false;
 	DBINotifyView _notifyView = dbinvShowPreview;
 	std::optional<bool> _nativeNotifications;
 	int _notificationsCount = 3;

--- a/Telegram/SourceFiles/settings/settings_notifications.cpp
+++ b/Telegram/SourceFiles/settings/settings_notifications.cpp
@@ -628,6 +628,9 @@ void SetupNotificationsContent(
 			? tr::lng_settings_alert_mac
 			: tr::lng_settings_alert_linux)(tr::now),
 		settings.flashBounceNotify());
+	const auto autoHiding = addCheckbox(
+		tr::lng_settings_autohide_notifications(tr::now),
+		settings.autoHideNotifications());
 
 	AddSkip(container, st::settingsCheckboxesSkip);
 	AddDivider(container);
@@ -796,6 +799,14 @@ void SetupNotificationsContent(
 		Core::App().settings().setFlashBounceNotify(checked);
 		changed(Change::FlashBounceEnabled);
 	}, flashbounce->lifetime());
+
+	autoHiding->checkedChanges(
+	) | rpl::filter([](bool checked) {
+		return (checked != Core::App().settings().autoHideNotifications());
+	}) | rpl::start_with_next([=](bool checked) {
+		Core::App().settings().setAutoHideNotifications(checked);
+		changed(Change::AutoHideEnabled);
+	}, autoHiding->lifetime());
 
 	muted->checkedChanges(
 	) | rpl::filter([=](bool checked) {

--- a/Telegram/SourceFiles/window/notifications_manager.h
+++ b/Telegram/SourceFiles/window/notifications_manager.h
@@ -50,6 +50,7 @@ enum class ChangeType {
 	MaxCount,
 	Corner,
 	DemoIsShown,
+	AutoHideEnabled,
 };
 
 } // namespace Notifications

--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -41,6 +41,8 @@ namespace Notifications {
 namespace Default {
 namespace {
 
+constexpr auto kAutoHideInterval = crl::time(2000);
+
 int notificationMaxHeight() {
 	return st::notifyMinHeight + st::notifyReplyArea.heightMax + st::notifyBorderWidth;
 }
@@ -663,6 +665,13 @@ void Notification::prepareActionsCache() {
 
 bool Notification::checkLastInput(bool hasReplyingNotifications) {
 	if (!_waitingForInput) return true;
+	if (Core::App().settings().autoHideNotifications()) {
+		if ((crl::now() - _started > kAutoHideInterval) && !hasReplyingNotifications) {
+			startHiding();
+			_waitingForInput = false;
+			return true;
+		}
+	}
 
 	const auto waitForUserInput = base::Platform::LastUserInputTimeSupported()
 		? (Core::App().lastNonIdleTime() <= _started)


### PR DESCRIPTION
Hi!
I added an "auto-hide"notification setting (it was requested in a now closed issue #4850).
### Motivation
On Telegram Desktop, notification will not hide themselves unless the app detects any user input. This can be annoying when e.g. the user is watching a video/movie and has to move the mouse to make the notification disappear.
### What I did
Simply added a "auto-hide" notifications setting, which, when enabled, will make the notifications hide themselves after a few seconds (2 at the moment). I'm attaching a screenshot below of the new setting.
### Possible improvements

- The amount of seconds to make a notification disappear is hardcoded to 2 seconds at the moment. Could it be useful to let the user decide this quantity?
- I added the english string shown in the settings. Since I'm a native italian speaker, I could add that as well if you wish.

Greetings,
levnikmyskin

![image](https://user-images.githubusercontent.com/24507901/103408171-a9589d80-4b61-11eb-95a6-c494955f7832.png)
