### PR TITLE
Build WebRTC without NEON for armhf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -268,6 +268,8 @@ parts:
       - -DBUILD_SHARED_LIBS=OFF
       - -DJPEG_LIBRARY_RELEASE=$SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libjpeg.so
       - -DJPEG_INCLUDE_DIR=$SNAPCRAFT_STAGE/usr/include
+      # NEON support for arm 32-bit is broken and no one seem to fix it
+      - -DTG_OWT_ARCH_ARMV7_USE_NEON=OFF
     prime: [-./*]
     after:
       - ffmpeg


### PR DESCRIPTION
ARM support is community maintained in tg_owt and no one seem to fix build with NEON, thus disabling it to get new armhf builds on snapcraft.