### PR TITLE
Fix the bug where client won't preview uncompressed images when enabled 'Ask download path for each file' and the source file is removed

### DIFF
--- a/Telegram/SourceFiles/data/data_document.cpp
+++ b/Telegram/SourceFiles/data/data_document.cpp
@@ -352,7 +352,7 @@ void DocumentOpenClickHandler::Open(
 		} else {
 			Core::App().showDocument(data, context);
 		}
-	} else if (data->saveFromDataSilent()) {
+	} else if (data->saveFromData()) {
 		openFile();
 	} else if (data->status == FileReady
 		|| data->status == FileDownloadFailed) {


### PR DESCRIPTION
Please check out https://github.com/telegramdesktop/tdesktop/issues/10237 for the problem description and repro:

Before the fix: image won't be saved to disk and preview won't pop up.

After the fix: image is prompted to be saved to disk. If saved, the preview window will show immediately after the image is 
downloaded.

Please kindly review. :)