### PR TITLE
Add .webp to ImageExtensions list

### DIFF
--- a/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
@@ -16,6 +16,7 @@ const QStringList &ImageExtensions() {
 		u".jpeg"_q,
 		u".png"_q,
 		u".gif"_q,
+		u".webp"_q,
 	};
 	return result;
 }


### PR DESCRIPTION
This would allow .webp images to be sent as an **image** rather than a file without any trickery.

I found that .webp images can be natually sent with the client. In fact if one renames the extension of an .webp image to .png (yes this becomes an extension mismatch), it can still be sent and received correctly. This should indicate that the .webp decoding capability comes for free (not the case for .avif images though, unfortunately). Tested under Windows 10 20H2.

e.g. https://www.gstatic.com/webp/gallery/1.sm.webp

Not sure if I should add this to `ExtensionsForCompression` list as well. Please advise.

Thanks.
