### PR TITLE
Add -mxgot flag to td_scheme on MIPS64

### DIFF
--- a/Telegram/cmake/td_scheme.cmake
+++ b/Telegram/cmake/td_scheme.cmake
@@ -33,3 +33,12 @@ PUBLIC
     desktop-app::lib_base
     desktop-app::lib_tl
 )
+
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "mips64")
+    # Sometimes final linking may fail with error "relocation truncated to fit"
+    # due to large scheme size.
+    target_compile_options(td_scheme
+    PRIVATE
+        -mxgot
+    )
+endif()


### PR DESCRIPTION
This fixes "relocation truncated to fit ..." error on final linking. It should not introduce a lot of overhead since the code is used only in network communications.

This errors appears sometimes and I do not know exact conditions, I daresay it is related to large size of an object file with the schema.

More docs see at https://gcc.gnu.org/onlinedocs/gcc/MIPS-Options.html#index-mxgot-1
Example of failed build: https://buildd.debian.org/status/fetch.php?pkg=telegram-desktop&arch=mips64el&ver=2.5.8%2Bds-1&stamp=1612773725&raw=0