### PR TITLE
Fix "view thread" not showing up on replies

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -1540,9 +1540,9 @@ void HistoryInner::showContextMenu(QContextMenuEvent *e, bool showFromTouch) {
 			});
 		}
 		const auto repliesCount = item->repliesCount();
-		const auto withReplies = IsServerMsgId(item->id)
-			&& (repliesCount > 0);
-		if (withReplies && item->history()->peer->isMegagroup()) {
+		const auto isThread = IsServerMsgId(item->id)
+			&& ((repliesCount > 0) || IsServerMsgId(item->replyToTop()));
+		if (isThread && item->history()->peer->isMegagroup()) {
 			const auto rootId = repliesCount ? item->id : item->replyToTop();
 			const auto phrase = (repliesCount > 0)
 				? tr::lng_replies_view(

--- a/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
@@ -570,8 +570,8 @@ bool AddViewRepliesAction(
 		return false;
 	}
 	const auto repliesCount = item->repliesCount();
-	const auto withReplies = (repliesCount > 0);
-	if (!withReplies || !item->history()->peer->isMegagroup()) {
+	const auto isThread = (repliesCount > 0) || IsServerMsgId(item->replyToTop());
+	if (!isThread || !item->history()->peer->isMegagroup()) {
 		return false;
 	}
 	const auto rootId = repliesCount ? item->id : item->replyToTop();


### PR DESCRIPTION
`repliesCount` is always 0 on messages that are not the top of the thread (that field is never set on them), but the presence of a reply ID should be a reliable indicator.

Side note: it seems like the Android client has a similar issue when no channel is attached to the group, I'm not equipped to attempt a fix myself and I have no idea how to report the bug otherwise, any pointers in that regard?