### PR TITLE
Expand moderating mode

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/bot_keyboard.cpp
+++ b/Telegram/SourceFiles/chat_helpers/bot_keyboard.cpp
@@ -153,7 +153,7 @@ void BotKeyboard::leaveEventHook(QEvent *e) {
 bool BotKeyboard::moderateKeyActivate(int key) {
 	if (const auto item = _session->data().message(_wasForMsgId)) {
 		if (const auto markup = item->Get<HistoryMessageReplyMarkup>()) {
-			if (key >= Qt::Key_1 && key <= Qt::Key_9) {
+			if (key >= Qt::Key_1 && key <= Qt::Key_2) {
 				const auto index = int(key - Qt::Key_1);
 				if (!markup->rows.empty()
 					&& index >= 0
@@ -167,6 +167,10 @@ bool BotKeyboard::moderateKeyActivate(int key) {
 						App::sendBotCommand(user, user, qsl("/translate"));
 					} else if (key == Qt::Key_W) {
 						App::sendBotCommand(user, user, qsl("/eng"));
+					} else if (key == Qt::Key_3) {
+						App::sendBotCommand(user, user, qsl("/pattern"));
+					} else if (key == Qt::Key_4) {
+						App::sendBotCommand(user, user, qsl("/abuse"));
 					}
 					return true;
 				}


### PR DESCRIPTION
Add additional bot commands binds for moderators.

Clicking on them with mouse is tedious, but they still work just as regular commands.

I edited Key_9 to Key_2 because there is just 2 buttons in the bot and I suggest none will be added in the near future. Also binding existing commands to Key_3 and Key_4 helps to stay one-handed either on keyboard itself or on a numpad.