### PR TITLE
Rely on QT_STRINGIFY instead of custom macro

### DIFF
--- a/Telegram/SourceFiles/config.h
+++ b/Telegram/SourceFiles/config.h
@@ -75,7 +75,7 @@ w/CVnbwQOw0g5GBwwFV3r0uTTvy44xx8XXxk+Qknu4eBCsmrAFNnAgMBAAE=\n\
 #if defined TDESKTOP_API_ID && defined TDESKTOP_API_HASH
 
 constexpr auto ApiId = TDESKTOP_API_ID;
-constexpr auto ApiHash = MACRO_TO_STRING(TDESKTOP_API_HASH);
+constexpr auto ApiHash = QT_STRINGIFY(TDESKTOP_API_HASH);
 
 #else // TDESKTOP_API_ID && TDESKTOP_API_HASH
 

--- a/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
@@ -66,7 +66,7 @@ void Launcher::initHook() {
 				AppName.utf16().replace(' ', '_'));
 		}
 
-		return qsl(MACRO_TO_STRING(TDESKTOP_LAUNCHER_BASENAME) ".desktop");
+		return qsl(QT_STRINGIFY(TDESKTOP_LAUNCHER_BASENAME) ".desktop");
 	}());
 }
 


### PR DESCRIPTION
Qt already [provides](https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/global/qglobal.h?h=v5.15.2#n101) a similar macro.