### PR TITLE
Complete report action callback

### DIFF
--- a/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
@@ -25,6 +25,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/toast/toast.h"
 #include "ui/text/text_utilities.h" // Ui::Text::ToUpper
 #include "history/history_location_manager.h" // LocationClickHandler.
+#include "history/view/history_view_context_menu.h"
 #include "boxes/abstract_box.h"
 #include "boxes/confirm_box.h"
 #include "boxes/peer_list_box.h"
@@ -555,8 +556,9 @@ void ActionsFiller::addBotCommandActions(not_null<UserData*> user) {
 
 void ActionsFiller::addReportAction() {
 	const auto peer = _peer;
+	const auto controller = _controller->parentController();
 	const auto report = [=] {
-
+		HistoryView::ShowReportPeerBox(controller, peer);
 	};
 	AddActionButton(
 		_wrap,

--- a/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
@@ -25,7 +25,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/toast/toast.h"
 #include "ui/text/text_utilities.h" // Ui::Text::ToUpper
 #include "history/history_location_manager.h" // LocationClickHandler.
-#include "history/view/history_view_context_menu.h"
+#include "history/view/history_view_context_menu.h" // HistoryView::ShowReportPeerBox
 #include "boxes/abstract_box.h"
 #include "boxes/confirm_box.h"
 #include "boxes/peer_list_box.h"


### PR DESCRIPTION
Since v2.6.0, clicking the "Report" button on the profile page does not pop up the ReportBox.

This PR fixed this bug.