### PR TITLE
Workaround force setting of WM_TRANSIENT_HINT in Qt's xcb backend

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_pip.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_pip.cpp
@@ -387,7 +387,17 @@ PipPanel::PipPanel(
 	Ui::Platform::InitOnTopPanel(this);
 	setMouseTracking(true);
 	resize(0, 0);
-	show();
+	hide();
+	createWinId();
+}
+
+void PipPanel::setVisibleHook(bool visible) {
+	PipParent::setVisibleHook(visible);
+
+	// workaround Qt's forced transient parent
+	if (visible) {
+		Ui::Platform::ClearTransientParent(this);
+	}
 }
 
 void PipPanel::setAspectRatio(QSize ratio) {

--- a/Telegram/SourceFiles/media/view/media_view_pip.h
+++ b/Telegram/SourceFiles/media/view/media_view_pip.h
@@ -78,6 +78,8 @@ protected:
 	void mouseReleaseEvent(QMouseEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;
 
+	void setVisibleHook(bool visible) override;
+
 private:
 	void setPositionDefault();
 	void setPositionOnScreen(Position position, QRect available);


### PR DESCRIPTION
Depends on https://github.com/desktop-app/lib_ui/pull/48