### PR TITLE
Remember that media view was switched to PIP and open it as PIP again.

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -2217,6 +2217,9 @@ void OverlayWidget::showDocument(
 	displayDocument(document, context, cloud, continueStreaming);
 	preloadData(0);
 	activateControls();
+	if (_showAsPip && !videoIsGifOrUserpic()) {
+		switchToPip();
+	}
 }
 
 void OverlayWidget::displayPhoto(not_null<PhotoData*> photo, HistoryItem *item) {
@@ -2986,8 +2989,10 @@ void OverlayWidget::switchToPip() {
 	const auto document = _document;
 	const auto msgId = _msgid;
 	const auto closeAndContinue = [=] {
+		_showAsPip = false;
 		showDocument(document, document->owner().message(msgId), {}, true);
 	};
+	_showAsPip = true;
 	_pip = std::make_unique<PipWrap>(
 		this,
 		document,

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -443,6 +443,7 @@ private:
 
 	std::unique_ptr<Streamed> _streamed;
 	std::unique_ptr<PipWrap> _pip;
+    bool _showAsPip = false;
 
 	const style::icon *_docIcon = nullptr;
 	style::color _docIconColor;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -443,7 +443,7 @@ private:
 
 	std::unique_ptr<Streamed> _streamed;
 	std::unique_ptr<PipWrap> _pip;
-    bool _showAsPip = false;
+	bool _showAsPip = false;
 
 	const style::icon *_docIcon = nullptr;
 	style::color _docIconColor;


### PR DESCRIPTION
Very useful, especially on large monitors.
Since the permanent opening of the video in full screen interferes and hide other applications.
This functionality allows remembering (in the current session) that the media view has been switched to a PIP mode and will open a new video directly in the PIP mode.