### PR TITLE
Remove dangling timer in MTP Session

### DIFF
--- a/Telegram/SourceFiles/mtproto/session.cpp
+++ b/Telegram/SourceFiles/mtproto/session.cpp
@@ -162,7 +162,6 @@ Session::Session(
 , _data(std::make_shared<SessionData>(this))
 , _thread(thread)
 , _sender([=] { needToResumeAndSend(); }) {
-	_timeouter.callEach(1000);
 	refreshOptions();
 	watchDcKeyChanges();
 	watchDcOptionsChanges();

--- a/Telegram/SourceFiles/mtproto/session.h
+++ b/Telegram/SourceFiles/mtproto/session.h
@@ -211,7 +211,6 @@ private:
 
 	bool _ping = false;
 
-	base::Timer _timeouter;
 	base::Timer _sender;
 
 	rpl::lifetime _lifetime;


### PR DESCRIPTION
Commit bdc7f4114faa472407e5afbc27eb826e4cd38bf2 got rid of `_timeouter`'s callback without removing the timer that still fires every second.