### PR TITLE
Add "Archive Sticker" into Sticker Box 3dots menu

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1400,6 +1400,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_stickers_search_sets" = "Search sticker sets";
 "lng_stickers_nothing_found" = "No stickers found";
 "lng_stickers_remove_pack_confirm" = "Remove";
+"lng_stickers_archive_pack" = "Archive Stickers";
+"lng_stickers_has_been_archived" = "Sticker pack has been archived.";
 
 "lng_in_dlg_photo" = "Photo";
 "lng_in_dlg_album" = "Album";

--- a/Telegram/SourceFiles/boxes/sticker_set_box.h
+++ b/Telegram/SourceFiles/boxes/sticker_set_box.h
@@ -42,6 +42,7 @@ private:
 	void updateButtons();
 	void addStickers();
 	void copyStickersLink();
+	void archiveStickers();
 
 	const not_null<Window::SessionController*> _controller;
 	MTPInputStickerSet _set;


### PR DESCRIPTION
This PR allow user archive sticker pack to Archive Stickers via Telegram Desktop.

![{8D9D0501-5B41-4C6A-9D4B-D32D134A3900}](https://user-images.githubusercontent.com/5726473/114483075-4aafbf00-9c3a-11eb-93bb-fc2e4e644a1e.png)

Closes #2357