### PR TITLE
Added CLion-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ stage
 /Linux/
 /Telegram/Makefile
 *.*~
+.idea/
+cmake-build-debug/


### PR DESCRIPTION
CLion IDE generates cmake-build-debug and .idea files, which is not ignored by tdesktop .gitignore.
