### PR TITLE
Fix voice record button infinite animation

### DIFF
--- a/Telegram/SourceFiles/history/view/controls/history_view_voice_record_button.cpp
+++ b/Telegram/SourceFiles/history/view/controls/history_view_voice_record_button.cpp
@@ -87,7 +87,7 @@ void VoiceRecordButton::init() {
 			_blobs->setLevel(0.);
 		}
 		_blobsHideLastTime = hide ? crl::now() : 0;
-		if (!hide && !_animation.animating()) {
+		if (!hide && !_animation.animating() && isVisible()) {
 			_animation.start();
 		}
 	}, lifetime());


### PR DESCRIPTION
Enabling animations triggers an animation of the voice record button that keeps firing uselessly at ~120 calls per second until the button is manually toggled. The animation callback cannot stop itself since it expects the button to be visible.

This commit fixes the issue by preventing spawning the animation if the widget is hidden.