### PR TITLE
Fixed misuse of comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the complete source code and the build instructions for the alpha versio
 
 [![Preview of Telegram Desktop][preview_image]][preview_image_url]
 
-The source code is published under GPLv3 with OpenSSL exception, the license is available [here][license].
+The source code is published under GPLv3 with OpenSSL exception; the license is available [here][license].
 
 ## Supported systems
 


### PR DESCRIPTION
Instead of the comma, I added a semicolon, but a period can also be used.
This is necessary because the sentence has two independent clauses. This means it can either be compound sentence or two separate sentences.