### PR TITLE
Fix video player volume level changing

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -1260,12 +1260,6 @@ void OverlayWidget::showSaveMsgFile() {
 	File::ShowInFolder(_saveMsgFilename);
 }
 
-void OverlayWidget::updateMixerVideoVolume() const {
-	if (_streamed) {
-		Player::mixer()->setVideoVolume(Core::App().settings().videoVolume());
-	}
-}
-
 void OverlayWidget::close() {
 	Core::App().hideMediaView();
 }
@@ -2941,9 +2935,11 @@ void OverlayWidget::playbackControlsSeekFinished(crl::time position) {
 }
 
 void OverlayWidget::playbackControlsVolumeChanged(float64 volume) {
+	if (_streamed) {
+		Player::mixer()->setVideoVolume(volume);
+	}
 	Core::App().settings().setVideoVolume(volume);
 	Core::App().saveSettingsDelayed();
-	updateMixerVideoVolume();
 }
 
 float64 OverlayWidget::playbackControlsCurrentVolume() {

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -241,7 +241,6 @@ private:
 
 	void refreshLang();
 	void showSaveMsgFile();
-	void updateMixerVideoVolume() const;
 
 	struct SharedMedia;
 	using SharedMediaType = SharedMediaWithLastSlice::Type;


### PR DESCRIPTION
Bug:
Sometimes changing of the volume level or mute/unmute has no effect.
It happens because Fader::onTimer get a current volume level from the Mixer,
but it gets an event about the volume modification from the settings.
Bug appear when the method onTimer calling between updating
of the settings and the Mixer volume.

Solution:
Updating the Mixer volume before the settings.
(maybe will be better to get the volume level
from the settings in place of the Mixer,
but I am not sure about other side effects of this)