### PR TITLE
Enhancement: Hide photo viewer overlay after zooming an image

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view.style
+++ b/Telegram/SourceFiles/media/view/media_view.style
@@ -247,6 +247,9 @@ mediaviewWaitHide: 2000;
 mediaviewHideDuration: 1000;
 mediaviewShowDuration: 200;
 mediaviewFadeDuration: 150;
+mediaviewZoomWait: 150;
+mediaviewZoomHide: 150;
+mediaviewZoomShow: 150;
 
 mediaviewDeltaFromLastAction: 5px;
 mediaviewSwipeDistance: 80px;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -964,7 +964,7 @@ void OverlayWidget::waitingAnimationCallback() {
 }
 
 void OverlayWidget::updateCursor() {
-	setCursor(_controlsState == ControlsHidden
+	setCursor(_controlsState == ControlsHidden && !isZoomedIn()
 		? Qt::BlankCursor
 		: (_over == OverNone ? style::cur_default : style::cur_pointer));
 }
@@ -3291,7 +3291,7 @@ void OverlayWidget::paintEvent(QPaintEvent *e) {
 		}
 
 		// more area
-		if (_moreNavIcon.intersects(r)) {
+		if (_moreNavIcon.intersects(r) && !isZoomedIn()) {
 			auto o = overLevel(OverMore);
 			p.setOpacity((o * st::mediaviewIconOverOpacity + (1 - o) * st::mediaviewIconOpacity) * co);
 			st::mediaviewMore.paintInCenter(p, _moreNavIcon);
@@ -4131,7 +4131,7 @@ void OverlayWidget::updateOver(QPoint pos) {
 		updateOverState(OverRotate);
 	} else if (_document && documentBubbleShown() && _docIconRect.contains(pos)) {
 		updateOverState(OverIcon);
-	} else if (_moreNav.contains(pos)) {
+	} else if (_moreNav.contains(pos) && !isZoomedIn()) {
 		updateOverState(OverMore);
 	} else if (_closeNav.contains(pos)) {
 		updateOverState(OverClose);

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -3711,8 +3711,8 @@ void OverlayWidget::setZoomLevel(int newZoom, bool force) {
 		_x = qRound(nx / (-z + 1) + width() / 2.);
 		_y = qRound(ny / (-z + 1) + height() / 2.);
 	}
-	if(isZoomedIn()){
-		if(_controlsState == ControlsHiding){
+	if (isZoomedIn()) {
+		if (_controlsState == ControlsHiding) {
 			_controlsState = ControlsShown;
 		}
 		onHideControls();

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -4213,7 +4213,7 @@ void OverlayWidget::mouseReleaseEvent(QMouseEvent *e) {
 		_pressed = false;
 	}
 	_down = OverNone;
-	if (isHidden() && _controlsState == ControlsHidden) {
+	if (!isHidden() || (isZoomedIn() && _controlsState == ControlsHidden)) {
 		activateControls();
 	}
 }

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -3631,6 +3631,8 @@ void OverlayWidget::keyPressEvent(QKeyEvent *e) {
 			playbackPauseResume();
 		} else if (_document && !_document->loading() && (documentBubbleShown() || !_documentMedia->loaded())) {
 			onDocClick();
+		} else {
+			zoomReset();
 		}
 	} else if (e->key() == Qt::Key_Left) {
 		if (_controlsHideTimer.isActive()) {
@@ -3652,6 +3654,12 @@ void OverlayWidget::keyPressEvent(QKeyEvent *e) {
 		} else if (e->key() == Qt::Key_I) {
 			update();
 		}
+	} else if (e->key() == Qt::Key_Plus) {
+		zoomIn();
+	} else if (e->key() == Qt::Key_Minus) {
+		zoomOut();
+	} else if (e->key() == Qt::Key_Asterisk) {
+		zoomReset();
 	}
 }
 

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -436,6 +436,7 @@ private:
 	int _x = 0, _y = 0, _w = 0, _h = 0;
 	int _xStart = 0, _yStart = 0;
 	int _zoom = 0; // < 0 - out, 0 - none, > 0 - in
+	int _initialZoom = 0;
 	float64 _zoomToScreen = 0.; // for documents
 	float64 _zoomToDefault = 0.;
 	QPoint _mStart;
@@ -498,6 +499,7 @@ private:
 		ControlsShown,
 		ControlsHiding,
 		ControlsHidden,
+		ControlsDisabled
 	};
 	ControlsState _controlsState = ControlsShown;
 	crl::time _controlsAnimStarted = 0;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -361,6 +361,7 @@ private:
 	void updateOverRect(OverState state);
 	bool updateOverState(OverState newState);
 	float64 overLevel(OverState control) const;
+  bool isZoomedIn();
 
 	void checkGroupThumbsAnimation();
 	void initGroupThumbs();
@@ -499,7 +500,6 @@ private:
 		ControlsShown,
 		ControlsHiding,
 		ControlsHidden,
-		ControlsDisabled
 	};
 	ControlsState _controlsState = ControlsShown;
 	crl::time _controlsAnimStarted = 0;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -361,7 +361,7 @@ private:
 	void updateOverRect(OverState state);
 	bool updateOverState(OverState newState);
 	float64 overLevel(OverState control) const;
-  bool isZoomedIn();
+	bool isZoomedIn();
 
 	void checkGroupThumbsAnimation();
 	void initGroupThumbs();


### PR DESCRIPTION
Fixes #7931.

In OverlayWidget, I've added new ControlsState called ControlsDisabled, which locks visibility of all overlay controls and prevents mouse interaction for anything other than previous/next navigation and close button.

It is enabled when user zooms in the image or presses reset-zoom button (middle mouse). Then all overlay controls are instantly disappearing, while mouse cursor will be permanently visible (to allow the user to click on navigation buttons, though invisible).

After zooming out the image or after switching to another photo, the overlay controls will appear gradually.

To make this feature more accessible, I've also added extra hotkeys to change zoom level: NumPad Plus and NumPad Minus to zoom in and out (which currently required to hold Ctrl key) and NumPad Multiply to reset zoom level, just as middle mouse button (currently this is only possible by Ctrl+Zero, which is not working reliably for some reason).

Also for simple photos (not videos and not documents) the Enter and Space keys will reset zoom level, effectively enlarging and hiding controls. This is convenient, because after switching to another photo (left/right keys) the controls will always appear again.
