### PR TITLE
Actual link to Vazir Fonts license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Version **1.8.15** was the last that supports older systems
 * Guideline Support Library ([MIT License](https://github.com/Microsoft/GSL/blob/master/LICENSE))
 * Range-v3 ([Boost License](https://github.com/ericniebler/range-v3/blob/master/LICENSE.txt))
 * Open Sans font ([Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html))
-* Vazir font ([License](https://github.com/rastikerdar/vazir-font/blob/master/LICENSE))
+* Vazir font ([SIL Open Font License 1.1](https://github.com/rastikerdar/vazir-font/blob/master/OFL.txt))
 * Emoji alpha codes ([MIT License](https://github.com/emojione/emojione/blob/master/extras/alpha-codes/LICENSE.md))
 * Catch test framework ([Boost License](https://github.com/philsquared/Catch/blob/master/LICENSE.txt))
 * xxHash ([BSD License](https://github.com/Cyan4973/xxHash/blob/dev/LICENSE))


### PR DESCRIPTION
The previous link led to the license text which was relevant up to [v26.0.2](https://github.com/rastikerdar/vazir-font/tree/v26.0.2), but removed in [v27.0.0](https://github.com/rastikerdar/vazir-font/blob/v27.0.0/LICENSE)