### PR TITLE
Fix building with LINK_TO_GTK

### DIFF
--- a/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp
@@ -80,10 +80,10 @@ f_gdk_wayland_window_set_transient_for_exported gdk_wayland_window_set_transient
 #endif // !DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION
 
 void GdkHelperLoadGtk2(QLibrary &lib) {
-#ifndef DESKTOP_APP_DISABLE_X11_INTEGRATION
+#if !defined DESKTOP_APP_DISABLE_X11_INTEGRATION && !defined LINK_TO_GTK
 	LOAD_GTK_SYMBOL(lib, gdk_x11_drawable_get_xdisplay);
 	LOAD_GTK_SYMBOL(lib, gdk_x11_drawable_get_xid);
-#endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION
+#endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION && !LINK_TO_GTK
 }
 
 void GdkHelperLoadGtk3(QLibrary &lib) {


### PR DESCRIPTION
This patch avoids linking issues that previously weren't present.

Regression introduced in https://github.com/telegramdesktop/tdesktop/commit/680a9a7ca7d9dde6c79a6340e3ca003e6ccfd8a5

```
In file included from /home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp:11:
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp: In function ‘void Platform::internal::{anonymous}::GdkHelperLoadGtk2(QLibrary&)’:
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp:84:30: error: ‘::gdk_x11_drawable_get_xdisplay’ has not been declared; did you mean ‘Platform::internal::{anonymous}::gdk_x11_drawable_get_xdisplay’?
   84 |         LOAD_GTK_SYMBOL(lib, gdk_x11_drawable_get_xdisplay);
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/lib_base/base/platform/linux/base_linux_gtk_integration_p.h:21:46: note: in definition of macro ‘LOAD_GTK_SYMBOL’
   21 | #define LOAD_GTK_SYMBOL(lib, func) (func = ::func)
      |                                              ^~~~
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp:44:33: note: ‘Platform::internal::{anonymous}::gdk_x11_drawable_get_xdisplay’ declared here
   44 | f_gdk_x11_drawable_get_xdisplay gdk_x11_drawable_get_xdisplay = nullptr;
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp:11:
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp:85:30: error: ‘::gdk_x11_drawable_get_xid’ has not been declared; did you mean ‘Platform::internal::{anonymous}::gdk_x11_drawable_get_xid’?
   85 |         LOAD_GTK_SYMBOL(lib, gdk_x11_drawable_get_xid);
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/lib_base/base/platform/linux/base_linux_gtk_integration_p.h:21:46: note: in definition of macro ‘LOAD_GTK_SYMBOL’
   21 | #define LOAD_GTK_SYMBOL(lib, func) (func = ::func)
      |                                              ^~~~
/home/.root/var/tmp/portage/net-im/telegram-desktop-2.7.8/work/tdesktop-2.7.8-full/Telegram/SourceFiles/platform/linux/linux_gdk_helper.cpp:47:28: note: ‘Platform::internal::{anonymous}::gdk_x11_drawable_get_xid’ declared here
   47 | f_gdk_x11_drawable_get_xid gdk_x11_drawable_get_xid = nullptr;
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~
```
