### PR TITLE
Revert "Use QMenuBar instead of own global menu implementation on Linux"

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -93,6 +93,7 @@ if (LINUX)
         target_link_libraries(Telegram
         PRIVATE
             desktop-app::external_statusnotifieritem
+            desktop-app::external_dbusmenu_qt
         )
     endif()
 

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.cpp
@@ -14,6 +14,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <surface.h>
 #include <xdgforeign.h>
 #include <plasmashell.h>
+#include <appmenu.h>
 
 using namespace KWayland::Client;
 
@@ -36,6 +37,10 @@ public:
 		return _plasmaShell.get();
 	}
 
+	[[nodiscard]] AppMenuManager *appMenuManager() {
+		return _appMenuManager.get();
+	}
+
 	[[nodiscard]] QEventLoop &interfacesLoop() {
 		return _interfacesLoop;
 	}
@@ -51,6 +56,7 @@ private:
 	Registry _applicationRegistry;
 	std::unique_ptr<XdgExporter> _xdgExporter;
 	std::unique_ptr<PlasmaShell> _plasmaShell;
+	std::unique_ptr<AppMenuManager> _appMenuManager;
 	QEventLoop _interfacesLoop;
 	bool _interfacesAnnounced = false;
 };
@@ -115,6 +121,21 @@ WaylandIntegration::Private::Private()
 				&ConnectionThread::connectionDied,
 				_plasmaShell.get(),
 				&PlasmaShell::destroy);
+		});
+
+	connect(
+		&_applicationRegistry,
+		&Registry::appMenuAnnounced,
+		[=](uint name, uint version) {
+			_appMenuManager = std::unique_ptr<AppMenuManager>{
+				_applicationRegistry.createAppMenuManager(name, version),
+			};
+
+			connect(
+				_applicationConnection,
+				&ConnectionThread::connectionDied,
+				_appMenuManager.get(),
+				&AppMenuManager::destroy);
 		});
 
 	_connection.initConnection();
@@ -185,6 +206,28 @@ void WaylandIntegration::skipTaskbar(QWindow *window, bool skip) {
 	}
 
 	plasmaSurface->setSkipTaskbar(skip);
+}
+
+void WaylandIntegration::registerAppMenu(
+		QWindow *window,
+		const QString &serviceName,
+		const QString &objectPath) {
+	const auto manager = _private->appMenuManager();
+	if (!manager) {
+		return;
+	}
+
+	const auto surface = Surface::fromWindow(window);
+	if (!surface) {
+		return;
+	}
+
+	const auto appMenu = manager->create(surface, surface);
+	if (!appMenu) {
+		return;
+	}
+
+	appMenu->setAddress(serviceName, objectPath);
 }
 
 } // namespace internal

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration.h
@@ -18,6 +18,10 @@ public:
 	[[nodiscard]] QString nativeHandle(QWindow *window);
 	[[nodiscard]] bool skipTaskbarSupported();
 	void skipTaskbar(QWindow *window, bool skip);
+	void registerAppMenu(
+		QWindow *window,
+		const QString &serviceName,
+		const QString &objectPath);
 
 private:
 	WaylandIntegration();

--- a/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_wayland_integration_dummy.cpp
@@ -44,5 +44,11 @@ bool WaylandIntegration::skipTaskbarSupported() {
 void WaylandIntegration::skipTaskbar(QWindow *window, bool skip) {
 }
 
+void WaylandIntegration::registerAppMenu(
+		QWindow *window,
+		const QString &serviceName,
+		const QString &objectPath) {
+}
+
 } // namespace internal
 } // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.h
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.h
@@ -10,8 +10,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "platform/platform_main_window.h"
 #include "base/unique_qptr.h"
 
-class QMenuBar;
-
 namespace Ui {
 class PopupMenu;
 } // namespace Ui
@@ -72,7 +70,7 @@ private:
 	bool _sniAvailable = false;
 	base::unique_qptr<Ui::PopupMenu> _trayIconMenuXEmbed;
 
-	QMenuBar *psMainMenu = nullptr;
+	QMenu *psMainMenu = nullptr;
 	QAction *psLogout = nullptr;
 	QAction *psUndo = nullptr;
 	QAction *psRedo = nullptr;


### PR DESCRIPTION
This reverts commit 79f96480c2e8265d591818173015690f7de4bc5a.

Fixes #16563