### PR TITLE
window title for call window

### DIFF
--- a/Telegram/SourceFiles/calls/calls_panel.cpp
+++ b/Telegram/SourceFiles/calls/calls_panel.cpp
@@ -118,7 +118,7 @@ void Panel::initWindow() {
 	window()->setAttribute(Qt::WA_NoSystemBackground);
 	window()->setWindowIcon(
 		QIcon(QPixmap::fromImage(Image::Empty()->original(), Qt::ColorOnly)));
-	window()->setTitle(u" "_q);
+	window()->setTitle(_user->name);
 	window()->setTitleStyle(st::callTitle);
 
 	window()->events(


### PR DESCRIPTION
Having an empty window title brings different issues, for example:

* invisible on task bar
* invisible in task switcher
* apply properties by match
* ...

So let's use the contact user name for window title.

Fixes #10243