### PR TITLE
Fix global menu on 64-bit systems with X11

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -577,7 +577,7 @@ void RegisterAppMenu(QWindow *window, const QString &menuPath) {
 		qsl("RegisterWindow"));
 
 	message.setArguments({
-		window->winId(),
+		uint(window->winId()),
 		QVariant::fromValue(QDBusObjectPath(menuPath))
 	});
 
@@ -598,7 +598,7 @@ void UnregisterAppMenu(QWindow *window) {
 		qsl("UnregisterWindow"));
 
 	message.setArguments({
-		window->winId()
+		uint(window->winId())
 	});
 
 	QDBusConnection::sessionBus().send(message);


### PR DESCRIPTION
When Wayland support for global menu was added (0b86feeeb58a0a5302a6811f0f51e97c562a7134), X11 support was broken since QWindow::winId returns WId what is a quintptr that expands to uint32 on 32-bit and to uint64 on 64-bit, while AppMenu d-bus service accepts only uint32.