### PR TITLE
Revert "Use gtk clipboard when available to avoid https://bugreports.qt.io/browse/QTBUG-56595"

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -1298,8 +1298,6 @@ else()
         if (NOT DESKTOP_APP_DISABLE_X11_INTEGRATION)
             target_link_libraries(Telegram PRIVATE X11)
         endif()
-
-        target_link_libraries(Telegram PRIVATE rt)
     endif()
 endif()
 

--- a/Telegram/SourceFiles/boxes/edit_caption_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_caption_box.cpp
@@ -67,10 +67,7 @@ auto ListFromMimeData(not_null<const QMimeData*> data) {
 	if (result.error == Error::None) {
 		return result;
 	} else if (data->hasImage()) {
-		auto image = Platform::GetImageFromClipboard();
-		if (image.isNull()) {
-			image = qvariant_cast<QImage>(data->imageData());
-		}
+		auto image = qvariant_cast<QImage>(data->imageData());
 		if (!image.isNull()) {
 			return Storage::PrepareMediaFromImage(
 				std::move(image),

--- a/Telegram/SourceFiles/boxes/send_files_box.cpp
+++ b/Telegram/SourceFiles/boxes/send_files_box.cpp
@@ -7,7 +7,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "boxes/send_files_box.h"
 
-#include "platform/platform_specific.h"
 #include "lang/lang_keys.h"
 #include "storage/localstorage.h"
 #include "storage/storage_media_prepare.h"
@@ -800,10 +799,7 @@ bool SendFilesBox::addFiles(not_null<const QMimeData*> data) {
 		if (result.error == Ui::PreparedList::Error::None) {
 			return result;
 		} else if (data->hasImage()) {
-			auto image = Platform::GetImageFromClipboard();
-			if (image.isNull()) {
-				image = qvariant_cast<QImage>(data->imageData());
-			}
+			auto image = qvariant_cast<QImage>(data->imageData());
 			if (!image.isNull()) {
 				return Storage::PrepareMediaFromImage(
 					std::move(image),

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -88,7 +88,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "chat_helpers/bot_keyboard.h"
 #include "chat_helpers/message_field.h"
 #include "chat_helpers/send_context_menu.h"
-#include "platform/platform_specific.h"
 #include "mtproto/mtproto_config.h"
 #include "lang/lang_keys.h"
 #include "mainwidget.h"
@@ -4494,10 +4493,7 @@ bool HistoryWidget::confirmSendingFiles(
 	}
 
 	if (hasImage) {
-		auto image = Platform::GetImageFromClipboard();
-		if (image.isNull()) {
-			image = qvariant_cast<QImage>(data->imageData());
-		}
+		auto image = qvariant_cast<QImage>(data->imageData());
 		if (!image.isNull()) {
 			confirmSendingFiles(
 				std::move(image),

--- a/Telegram/SourceFiles/history/view/history_view_replies_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_replies_section.cpp
@@ -55,7 +55,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "storage/storage_media_prepare.h"
 #include "storage/storage_account.h"
 #include "inline_bots/inline_bot_result.h"
-#include "platform/platform_specific.h"
 #include "lang/lang_keys.h"
 #include "facades.h"
 #include "app.h"
@@ -602,10 +601,7 @@ bool RepliesWidget::confirmSendingFiles(
 	}
 
 	if (hasImage) {
-		auto image = Platform::GetImageFromClipboard();
-		if (image.isNull()) {
-			image = qvariant_cast<QImage>(data->imageData());
-		}
+		auto image = qvariant_cast<QImage>(data->imageData());
 		if (!image.isNull()) {
 			confirmSendingFiles(
 				std::move(image),

--- a/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
@@ -48,7 +48,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "storage/storage_media_prepare.h"
 #include "storage/storage_account.h"
 #include "inline_bots/inline_bot_result.h"
-#include "platform/platform_specific.h"
 #include "lang/lang_keys.h"
 #include "facades.h"
 #include "app.h"
@@ -342,10 +341,7 @@ bool ScheduledWidget::confirmSendingFiles(
 	}
 
 	if (hasImage) {
-		auto image = Platform::GetImageFromClipboard();
-		if (image.isNull()) {
-			image = qvariant_cast<QImage>(data->imageData());
-		}
+		auto image = qvariant_cast<QImage>(data->imageData());
 		if (!image.isNull()) {
 			confirmSendingFiles(
 				std::move(image),

--- a/Telegram/SourceFiles/platform/linux/linux_gtk_integration.h
+++ b/Telegram/SourceFiles/platform/linux/linux_gtk_integration.h
@@ -25,8 +25,6 @@ public:
 
 	[[nodiscard]] bool showOpenWithDialog(const QString &filepath) const;
 
-	[[nodiscard]] QImage getImageFromClipboard() const;
-
 	static QString AllowedBackends();
 
 	static int Exec(

--- a/Telegram/SourceFiles/platform/linux/linux_gtk_integration_dummy.cpp
+++ b/Telegram/SourceFiles/platform/linux/linux_gtk_integration_dummy.cpp
@@ -33,10 +33,6 @@ bool GtkIntegration::showOpenWithDialog(const QString &filepath) const {
 	return false;
 }
 
-QImage GtkIntegration::getImageFromClipboard() const {
-	return {};
-}
-
 QString GtkIntegration::AllowedBackends() {
 	return {};
 }

--- a/Telegram/SourceFiles/platform/linux/linux_gtk_integration_p.h
+++ b/Telegram/SourceFiles/platform/linux/linux_gtk_integration_p.h
@@ -19,15 +19,9 @@ inline void (*gtk_widget_show)(GtkWidget *widget) = nullptr;
 inline GdkWindow* (*gtk_widget_get_window)(GtkWidget *widget) = nullptr;
 inline void (*gtk_widget_realize)(GtkWidget *widget) = nullptr;
 inline void (*gtk_widget_destroy)(GtkWidget *widget) = nullptr;
-inline GtkClipboard* (*gtk_clipboard_get)(GdkAtom selection) = nullptr;
-inline GtkSelectionData* (*gtk_clipboard_wait_for_contents)(GtkClipboard *clipboard, GdkAtom target) = nullptr;
-inline const guchar* (*gtk_selection_data_get_data)(const GtkSelectionData *selection_data) = nullptr;
-inline gint (*gtk_selection_data_get_length)(const GtkSelectionData *selection_data) = nullptr;
-inline void (*gtk_selection_data_free)(GtkSelectionData *data) = nullptr;
 inline GType (*gtk_app_chooser_get_type)(void) G_GNUC_CONST = nullptr;
 inline GtkWidget* (*gtk_app_chooser_dialog_new)(GtkWindow *parent, GtkDialogFlags flags, GFile *file) = nullptr;
 inline GAppInfo* (*gtk_app_chooser_get_app_info)(GtkAppChooser *self) = nullptr;
-inline GdkAtom (*gdk_atom_intern)(const gchar *atom_name, gboolean only_if_exists) = nullptr;
 
 } // namespace Gtk
 } // namespace Platform

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -513,14 +513,6 @@ QString GetIconName() {
 	return Result;
 }
 
-QImage GetImageFromClipboard() {
-	if (const auto integration = GtkIntegration::Instance()) {
-		return integration->getImageFromClipboard();
-	}
-
-	return {};
-}
-
 std::optional<bool> IsDarkMode() {
 	return Core::App().settings().systemDarkMode();
 }

--- a/Telegram/SourceFiles/platform/mac/specific_mac.h
+++ b/Telegram/SourceFiles/platform/mac/specific_mac.h
@@ -18,10 +18,6 @@ namespace Platform {
 
 [[nodiscard]] bool IsDarkMenuBar();
 
-inline QImage GetImageFromClipboard() {
-	return {};
-}
-
 inline bool AutostartSupported() {
 	return false;
 }

--- a/Telegram/SourceFiles/platform/platform_specific.h
+++ b/Telegram/SourceFiles/platform/platform_specific.h
@@ -37,7 +37,6 @@ void IgnoreApplicationActivationRightNow();
 bool AutostartSupported();
 bool TrayIconSupported();
 bool SkipTaskbarSupported();
-[[nodiscard]] QImage GetImageFromClipboard();
 void WriteCrashDumpDetails();
 
 [[nodiscard]] std::optional<bool> IsDarkMode();

--- a/Telegram/SourceFiles/platform/win/specific_win.h
+++ b/Telegram/SourceFiles/platform/win/specific_win.h
@@ -19,10 +19,6 @@ namespace Platform {
 inline void IgnoreApplicationActivationRightNow() {
 }
 
-inline QImage GetImageFromClipboard() {
-	return {};
-}
-
 inline bool TrayIconSupported() {
 	return true;
 }


### PR DESCRIPTION
Fixed in Qt by https://codereview.qt-project.org/c/qt/qtbase/+/306771

This reverts commit 3a91003eeacb038032499d60f3a47e3ef6e4c14f.