### PR TITLE
Disable crash reports entirely through macro

### DIFF
--- a/Telegram/SourceFiles/core/crash_report_window.cpp
+++ b/Telegram/SourceFiles/core/crash_report_window.cpp
@@ -220,6 +220,7 @@ void NotStartedWindow::resizeEvent(QResizeEvent *e) {
 	_close.setGeometry(width() - padding - _close.width(), height() - padding - _close.height(), _close.width(), _close.height());
 }
 
+#ifndef DESKTOP_APP_DISABLE_CRASH_REPORTS
 LastCrashedWindow::UpdaterData::UpdaterData(QWidget *buttonParent)
 : check(buttonParent)
 , skip(buttonParent, false) {
@@ -1179,3 +1180,4 @@ void NetworkSettingsWindow::updateControls() {
 		setGeometry(_parent->x() + (_parent->width() - w) / 2, _parent->y() + (_parent->height() - h) / 2, w, h);
 	}
 }
+#endif  // !DESKTOP_APP_DISABLE_CRASH_REPORTS

--- a/Telegram/SourceFiles/core/crash_report_window.h
+++ b/Telegram/SourceFiles/core/crash_report_window.h
@@ -91,6 +91,7 @@ private:
 
 };
 
+#ifndef DESKTOP_APP_DISABLE_CRASH_REPORTS
 class LastCrashedWindow : public PreLaunchWindow {
 
 public:
@@ -216,3 +217,4 @@ private:
 	rpl::event_stream<MTP::ProxyData> _saveRequests;
 
 };
+#endif  // !DESKTOP_APP_DISABLE_CRASH_REPORTS

--- a/Telegram/SourceFiles/core/sandbox.cpp
+++ b/Telegram/SourceFiles/core/sandbox.cpp
@@ -319,6 +319,8 @@ void Sandbox::singleInstanceChecked() {
 		new NotStartedWindow();
 		return;
 	}
+
+#ifndef DESKTOP_APP_DISABLE_CRASH_REPORTS
 	const auto result = CrashReports::Start();
 	v::match(result, [&](CrashReports::Status status) {
 		if (status == CrashReports::CantOpen) {
@@ -348,6 +350,9 @@ void Sandbox::singleInstanceChecked() {
 			refreshGlobalProxy();
 		}, window->lifetime());
 	});
+#else // !DESKTOP_APP_DISABLE_CRASH_REPORTS
+	launchApplication();
+#endif  // !DESKTOP_APP_DISABLE_CRASH_REPORTS
 }
 
 void Sandbox::socketDisconnected() {


### PR DESCRIPTION
This saves compile time and binary size. Guarding code by preprocessor is the only effective way to guarantee its elimination, even in most modern C++. And more importantly, one do not need to care of it for porting to old Qt.