### PR TITLE
Export CSS: per-line automatic bidi direction

### DIFF
--- a/Telegram/Resources/export_html/css/style.css
+++ b/Telegram/Resources/export_html/css/style.css
@@ -291,6 +291,8 @@ div.selected {
 .default .text {
     word-wrap: break-word;
     line-height: 150%;
+    unicode-bidi: plaintext;
+    text-align: start;
 }
 .default .reply_to,
 .default .media_wrap {


### PR DESCRIPTION
Fixes #16120.
`unicode-bidi: plaintext` makes browser auto-detect base bidi direction according to bidi algorithm heuristics, on each line separately.
https://drafts.csswg.org/css-writing-modes/#bidi-algo
AFAICT this matches both Android and Desktop behaviors, and is the friendly behavior for mixed-direction users.
Purely LTR users should not be affected — the heuristics return LTR even on "neutral" lines that contain no letters, only punctuation/emojis/digits.
(http://www.unicode.org/reports/tr9/#P2 — rule P3 defaults to level 0, which is LTR.)
Whereas all RTL language users in practice need to deal with mixed-direction texts, and the ability to split lines to prevent LTR/RTL mixups is extremely handy...

The `text-align: start` ensures LTR-detected lines are displayed left-aligned, and RTL-detected lines right-aligned.
Which again matches both Android and Desktop behaviors.
This is redundant — it seems already the default with current CSS — but is important for mixed-language users, so I wanted to ensure it in case somebody sets alignment on bigger parts of the document in the future.

## before
![Ekrankopio de 2021-09-03 13-25-15](https://user-images.githubusercontent.com/273688/131990974-5321cc3a-c5bd-4ccc-adef-ed03f7629368.png)

## after
![Ekrankopio de 2021-09-03 13-34-18](https://user-images.githubusercontent.com/273688/131992500-3c06496d-e83e-4bc2-8519-c054f855c29f.png)

Tested by editing exported CSS from Telegram 2.7.1 on Linux, viewed with Chrome 92.