### PR TITLE
Fix song volume controls, closes #16276 #16905

### DIFF
--- a/Telegram/SourceFiles/media/player/media_player_volume_controller.cpp
+++ b/Telegram/SourceFiles/media/player/media_player_volume_controller.cpp
@@ -72,8 +72,8 @@ void VolumeController::setVolume(float64 volume) {
 
 void VolumeController::applyVolumeChange(float64 volume) {
 	if (volume != Core::App().settings().songVolume()) {
+		mixer()->setSongVolume(volume);
 		Core::App().settings().setSongVolume(volume);
-		mixer()->setSongVolume(Core::App().settings().songVolume());
 	}
 }
 

--- a/Telegram/SourceFiles/media/system_media_controls_manager.cpp
+++ b/Telegram/SourceFiles/media/system_media_controls_manager.cpp
@@ -248,6 +248,9 @@ SystemMediaControlsManager::SystemMediaControlsManager(
 		_controls->volumeChangeRequests(
 		) | rpl::start_with_next([](float64 volume) {
 			Player::mixer()->setSongVolume(volume);
+			if (volume > 0) {
+				Core::App().settings().setRememberedSongVolume(volume);
+			}
 			Core::App().settings().setSongVolume(volume);
 		}, _lifetime);
 	}

--- a/Telegram/SourceFiles/media/system_media_controls_manager.cpp
+++ b/Telegram/SourceFiles/media/system_media_controls_manager.cpp
@@ -7,6 +7,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "media/system_media_controls_manager.h"
 
+#include "media/audio/media_audio.h"
 #include "base/observer.h"
 #include "base/platform/base_platform_system_media_controls.h"
 #include "core/application.h"
@@ -246,6 +247,7 @@ SystemMediaControlsManager::SystemMediaControlsManager(
 
 		_controls->volumeChangeRequests(
 		) | rpl::start_with_next([](float64 volume) {
+			Player::mixer()->setSongVolume(volume);
 			Core::App().settings().setSongVolume(volume);
 		}, _lifetime);
 	}


### PR DESCRIPTION
The audio mixer tracks changes to the volume using the settings:
https://github.com/telegramdesktop/tdesktop/blob/5000902d61d556960c4afe20f7624933fd914499/Telegram/SourceFiles/media/audio/media_audio.cpp#L588-L596
However it uses the internal value `_volumeSong` to set the volume, so if the setting is updated before the mixer value, the previous value is used.

When the slider value changes, the value in settings gets updated before the mixer value, causing the previous value to be used in the mixer, which causes #16276

Additionally, setting the volume with media controls only updates the setting, causing the playback volume to not change, which causes #16905