### PR TITLE
Close a race between Gio threads and Qt application init.

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -659,6 +659,9 @@ void start() {
 	auto backgroundThread = true;
 	mallctl("background_thread", nullptr, nullptr, &backgroundThread, sizeof(bool));
 
+	// Prevent any later calls into setlocale() by Qt
+	QCoreApplicationPrivate::initLocale();
+
 	LOG(("Launcher filename: %1").arg(QGuiApplication::desktopFileName()));
 
 #ifndef DESKTOP_APP_DISABLE_WAYLAND_INTEGRATION


### PR DESCRIPTION
QApplication has a historical feature[1] of calling setlocale(3) at init,
which today cause more harm than good.  Such call isn't thread safe neither
per C standard, not per any known libc implementation.  The Gio threads
would call into locale reading functions all the time, so early access to
locale by Gio may race with setlocale() by Qt leading to undefined behavior.

Platform specific start before the Sandbox (aka QApplication) is at core
design of tdesktop and that order can't be changed. There is no way to pause
Gio until QApplication instantiates.

Fortunately, Qt library itself has a static global flag that prevents it
from calling setlocale() twice. We don't even need to instantiate a
temporary QCoreApplication, we can just call into the method.  So call
it form Platform::start before any existing or future calls to Gio.

Fixes #16922

[1] https://chat.stackoverflow.com/rooms/63812/discussion-between-phil-armstrong-and-matteo-italia