### PR TITLE
Build Qt without egl-extension-platform-wayland

### DIFF
--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -694,6 +694,7 @@ RUN echo './configure -prefix '$'\"''$QT_PREFIX'$'\"'' \
 	-no-icu \
 	-no-feature-xcb-sm \
 	-no-feature-wayland-server \
+	-no-feature-egl-extension-platform-wayland \
 	-static \
 	-dbus-runtime \
 	-openssl-linked \


### PR DESCRIPTION
Fixes #16947