### PR TITLE
Couple small fixes to compile on FreeBSD

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -46,7 +46,12 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtGui/QWindow>
 
 #include <private/qguiapplication_p.h>
+
+#ifdef Q_OS_FREEBSD
+#include <malloc_np.h>
+#else // Q_OS_FREEBSD
 #include <jemalloc/jemalloc.h>
+#endif // Q_OS_FREEBSD
 
 #ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 #include <glibmm.h>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -454,7 +454,7 @@ parts:
   webrtc:
     source: https://github.com/desktop-app/tg_owt.git
     source-depth: 1
-    source-commit: 91d836dc84a16584c6ac52b36c04c0de504d9c34
+    source-commit: 575fb17d2853c43329e45f6693370f5e41668055
     plugin: cmake
     build-packages:
       - yasm


### PR DESCRIPTION
Together with pull requests to other components, tdesktop/dev compiles and works perfectly on FreeBSD.

https://github.com/telegramdesktop/libtgvoip/pull/35
https://github.com/desktop-app/tg_owt/pull/69
https://github.com/desktop-app/cmake_helpers/pull/123

Note: the zip.h problem, I believe, can show up on a certain Linux distributions as well. And of course won't show up on FreeBSD if zlib package isn't installed. In other words, it isn't actually related to the topic.