### PR TITLE
Fix compilation in presence of libzip installed.

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -52,6 +52,14 @@ PRIVATE
     tdesktop::lib_tgcalls_legacy
     tdesktop::lib_tgcalls
     tdesktop::lib_tgvoip
+
+    # Order in this list defines the order of include paths in command line.
+    # We need to place desktop-app::external_minizip this early to have its
+    # include paths (usually ${PREFIX}/include/minizip) before any depend that
+    # would add ${PREFIX}/include. This path may have a different <zip.h>,
+    # for example installed by libzip (https://libzip.org).
+    desktop-app::external_minizip
+
     tdesktop::td_export
     tdesktop::td_mtproto
     tdesktop::td_lang
@@ -71,7 +79,6 @@ PRIVATE
     desktop-app::external_lz4
     desktop-app::external_rlottie
     desktop-app::external_zlib
-    desktop-app::external_minizip
     desktop-app::external_qt_static_plugins
     desktop-app::external_qt
     desktop-app::external_qr_code_generator


### PR DESCRIPTION
When both minizip [1] and libzip [2] are present in the build
environment we have two <zip.h> includes. We are interested in
the minizip. Unfortunately, libzip usually installs its zip.h
straight into ${PREFIX}/include where lots of other headers reside.
We pick up ${PREFIX}/include into the include path with the
desktop-app::lib_base target, which is also dependency of
of tdesktop::td_* targets. To fix compilation in presence of
conflicting zip.h we need to put minizip's include directory
before ${PREFIX}/include, thus record its dependency before
all other dependencies that can bring desktop-app::lib_base.

[1] http://www.winimage.com/zLibDll/minizip.html
[2] https://libzip.org