### PR TITLE
Adjust snap permissions

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,11 +30,10 @@ apps:
       - camera
       - desktop
       - desktop-legacy
+      - hardware-observe
       - home
       - network
-      - network-manager-observe
       - opengl
-      - pulseaudio
       - removable-media
       - unity7
       - wayland
@@ -121,6 +120,7 @@ parts:
       - libxcb-record0
       - libxcb-screensaver0
       - zlib1g
+      - systemd
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
Due to the removal of beariers, network-manager-observe shouldn't be needed anymore.
hardware-observe is needed for DeviceModelPretty, though.
Added systemd to stage-packages for calling systemd-detect-virt.