### PR TITLE
Option "also delete for contact" being checked by default

### DIFF
--- a/Telegram/SourceFiles/boxes/delete_messages_box.cpp
+++ b/Telegram/SourceFiles/boxes/delete_messages_box.cpp
@@ -158,7 +158,7 @@ void DeleteMessagesBox::prepare() {
 				_revoke.create(
 					this,
 					revoke->checkbox,
-					false,
+					true,
 					st::defaultBoxCheckbox);
 				appendDetails(std::move(revoke->description));
 			} else if (peer->isChannel()) {


### PR DESCRIPTION
I think the checkbox should be checked by default. Because when you send something wrong, you want to delete it as fast as possible. In this situation, you may forget to check the checkbox, and if you delete it only for yourself, there is no way to delete the message for the other side. Also, we usually want to delete messages for both sides. 