### PR TITLE
Fix drag and drop on Linux

### DIFF
--- a/Telegram/SourceFiles/window/main_window.cpp
+++ b/Telegram/SourceFiles/window/main_window.cpp
@@ -964,7 +964,9 @@ int MainWindow::tryToExtendWidthBy(int addToWidth) {
 void MainWindow::launchDrag(
 		std::unique_ptr<QMimeData> data,
 		Fn<void()> &&callback) {
-	auto drag = std::make_unique<QDrag>(this);
+	// Qt destroys this QDrag automatically after the drag is finished
+	// We must not delete this at the end of this function, as this breaks DnD on Linux
+	auto drag = new QDrag(this);
 	drag->setMimeData(data.release());
 	drag->exec(Qt::CopyAction);
 


### PR DESCRIPTION
If the `QDrag` object is destroyed too early, drag and drop will not work on Linux, because communication will still have to happen later between source and target, see: https://freedesktop.org/wiki/Specifications/XDND/

This patch increases the lifetime of `drag`, by changing the type to a raw pointer. This does not create a memory leak, as parent is specified in the `QDrag` constructor, which will free it later.

If you know a better way to increase the lifetime of the `drag` and don't like this "Qt way" of memory management, let me know. :)

In any case this finally fixes Drag and drop on Linux.