### PR TITLE
Fix -Wunused-const-variable variables

### DIFF
--- a/Telegram/SourceFiles/app.cpp
+++ b/Telegram/SourceFiles/app.cpp
@@ -18,8 +18,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace {
 
-constexpr auto kImageAreaLimit = 12'032 * 9'024;
-
 App::LaunchState _launchState = App::Launched;
 
 HistoryView::Element *hoveredItem = nullptr,

--- a/Telegram/SourceFiles/calls/group/calls_group_members.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_members.cpp
@@ -44,8 +44,6 @@ namespace Calls::Group {
 namespace {
 
 constexpr auto kKeepRaisedHandStatusDuration = 3 * crl::time(1000);
-constexpr auto kUserpicSizeForBlur = 40;
-constexpr auto kUserpicBlurRadius = 8;
 
 using Row = MembersRow;
 

--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -68,6 +68,7 @@ constexpr auto kPanelTrayIconName = "telegram-panel"_cs;
 constexpr auto kMutePanelTrayIconName = "telegram-mute-panel"_cs;
 constexpr auto kAttentionPanelTrayIconName = "telegram-attention-panel"_cs;
 
+#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties"_cs;
 constexpr auto kTrayIconFilename = "tdesktop-trayicon-XXXXXX.png"_cs;
 
@@ -80,6 +81,7 @@ constexpr auto kAppMenuObjectPath = "/com/canonical/AppMenu/Registrar"_cs;
 constexpr auto kAppMenuInterface = kAppMenuService;
 
 constexpr auto kMainMenuObjectPath = "/MenuBar"_cs;
+#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 
 bool TrayIconMuted = true;
 int32 TrayIconCount = 0;


### PR DESCRIPTION
A few warnings found when building tdesktop 3.3.0 on OpenBSD.