### PR TITLE
Rework DE detection

### DIFF
--- a/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
+++ b/Telegram/SourceFiles/platform/linux/linux_desktop_environment.h
@@ -11,67 +11,33 @@ namespace Platform {
 namespace DesktopEnvironment {
 
 enum class Type {
-	Other,
 	Gnome,
 	Cinnamon,
-	KDE3,
-	KDE4,
-	KDE5,
+	KDE,
 	Unity,
-	XFCE,
 	MATE,
-	LXDE,
 };
 
-Type Get();
+std::vector<Type> Get();
 
 inline bool IsGnome() {
-	return Get() == Type::Gnome;
+	return ranges::contains(Get(), Type::Gnome);
 }
 
 inline bool IsCinnamon() {
-	return Get() == Type::Cinnamon;
-}
-
-inline bool IsKDE3() {
-	return Get() == Type::KDE3;
-}
-
-inline bool IsKDE4() {
-	return Get() == Type::KDE4;
-}
-
-inline bool IsKDE5() {
-	return Get() == Type::KDE5;
+	return ranges::contains(Get(), Type::Cinnamon);
 }
 
 inline bool IsKDE() {
-	return IsKDE3() || IsKDE4() || IsKDE5();
+	return ranges::contains(Get(), Type::KDE);
 }
 
 inline bool IsUnity() {
-	return Get() == Type::Unity;
-}
-
-inline bool IsXFCE() {
-	return Get() == Type::XFCE;
+	return ranges::contains(Get(), Type::Unity);
 }
 
 inline bool IsMATE() {
-	return Get() == Type::MATE;
-}
-
-inline bool IsLXDE() {
-	return Get() == Type::LXDE;
-}
-
-inline bool IsGtkBased() {
-	return IsGnome()
-		|| IsCinnamon()
-		|| IsUnity()
-		|| IsMATE()
-		|| IsXFCE()
-		|| IsLXDE();
+	return ranges::contains(Get(), Type::MATE);
 }
 
 } // namespace DesktopEnvironment

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -816,17 +816,20 @@ bool OpenSystemSettings(SystemSettingsType type) {
 			}
 			options.push_back(std::move(command));
 		};
-		if (DesktopEnvironment::IsUnity()) {
-			add("unity-control-center", "sound");
-		} else if (DesktopEnvironment::IsKDE()) {
-			add("kcmshell5", "kcm_pulseaudio");
-			add("kcmshell4", "phonon");
-		} else if (DesktopEnvironment::IsGnome()) {
-			add("gnome-control-center", "sound");
-		} else if (DesktopEnvironment::IsCinnamon()) {
-			add("cinnamon-settings", "sound");
-		} else if (DesktopEnvironment::IsMATE()) {
-			add("mate-volume-control");
+		for (const auto &type : DesktopEnvironment::Get()) {
+			using DesktopEnvironment::Type;
+			if (type == Type::Unity) {
+				add("unity-control-center", "sound");
+			} else if (type == Type::KDE) {
+				add("kcmshell5", "kcm_pulseaudio");
+				add("kcmshell4", "phonon");
+			} else if (type == Type::Gnome) {
+				add("gnome-control-center", "sound");
+			} else if (type == Type::Cinnamon) {
+				add("cinnamon-settings", "sound");
+			} else if (type == Type::MATE) {
+				add("mate-volume-control");
+			}
 		}
 #ifdef __HAIKU__
 		add("Media");


### PR DESCRIPTION
Variables can point to a mixed environment, make DE detection non-exclusive.
Remove unused methods.