### PR TITLE
Re-add `X-GNOME-SingleWindow`

### DIFF
--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -12,8 +12,9 @@ Categories=Chat;Network;InstantMessaging;Qt;
 MimeType=x-scheme-handler/tg;
 Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;
 Actions=Quit;
-X-GNOME-UsesNotifications=true
 SingleMainWindow=true
+X-GNOME-UsesNotifications=true
+X-GNOME-SingleWindow=true
 
 [Desktop Action Quit]
 Exec=telegram-desktop -quit


### PR DESCRIPTION
`X-GNOME-SingleWindow` is best to be used for backward compatibility. Since `SingleMainWindow` was recently added, many Desktop Environments and Window Managers may not have it implemented yet.