### PR TITLE
Updated XDG SPEC version to 1.5

### DIFF
--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version=1.5
 Name=Telegram Desktop
 Comment=Official desktop version of Telegram messaging app
 TryExec=telegram-desktop


### PR DESCRIPTION
`SingleMainWindow` is a part of XDG SPEC version 1.5 and bogus on 1.0.

Closes #23879.