### PR TITLE
Use QT_QPA_PLATFORM if provided.

### DIFF
--- a/Telegram/SourceFiles/core/launcher.cpp
+++ b/Telegram/SourceFiles/core/launcher.cpp
@@ -61,7 +61,7 @@ FilteredCommandLineArguments::FilteredCommandLineArguments(
 #endif // !Q_OS_WIN
 	}
 #elif defined Q_OS_UNIX
-	if (Platform::DesktopEnvironment::IsGnome()) {
+	if (Platform::DesktopEnvironment::IsGnome() && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
 		pushArgument("-platform");
 		pushArgument("xcb;wayland");
 	}


### PR DESCRIPTION
This PR fixes https://github.com/telegramdesktop/tdesktop/issues/23877 .

After this change it should still default to xorg, like with Qt5, while respecting `QT_QPA_PLATFORM` if it is set.