### PR TITLE
Fix incorrect admin log

### DIFF
--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
+++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
@@ -219,7 +219,7 @@ TextWithEntities GenerateAdminChangeText(
 	return result;
 };
 
-QString GenerateBannedChangeText(
+QString GeneratePermissionsChangeText(
 		ChatRestrictionsInfo newRights,
 		ChatRestrictionsInfo prevRights) {
 	using Flag = ChatRestriction;
@@ -242,7 +242,7 @@ QString GenerateBannedChangeText(
 	return CollectChanges(phraseMap, prevRights.flags, newRights.flags);
 }
 
-TextWithEntities GenerateBannedChangeText(
+TextWithEntities GeneratePermissionsChangeText(
 		PeerId participantId,
 		const TextWithEntities &user,
 		ChatRestrictionsInfo newRights,
@@ -281,7 +281,7 @@ TextWithEntities GenerateBannedChangeText(
 		lt_until,
 		TextWithEntities { untilText },
 		Ui::Text::WithEntities);
-	const auto changes = GenerateBannedChangeText(newRights, prevRights);
+	const auto changes = GeneratePermissionsChangeText(newRights, prevRights);
 	if (!changes.isEmpty()) {
 		result.text.append('\n' + changes);
 	}
@@ -478,7 +478,13 @@ auto GenerateParticipantChangeText(
 				ChatAdminRightsInfo(),
 				oldRights);
 		} else if (oldParticipant && oldParticipant->type() == Type::Banned) {
-			return GenerateBannedChangeText(
+			return GeneratePermissionsChangeText(
+				participantId,
+				user,
+				ChatRestrictionsInfo(),
+				oldRestrictions);
+		} else if (oldParticipant && oldParticipant->type() == Type::Restricted && participant.type() == Type::Member) {
+			return GeneratePermissionsChangeText(
 				participantId,
 				user,
 				ChatRestrictionsInfo(),
@@ -517,7 +523,7 @@ auto GenerateParticipantChangeText(
 			const auto user = GenerateParticipantString(
 				&channel->session(),
 				peerId);
-			return GenerateBannedChangeText(
+			return GeneratePermissionsChangeText(
 				peerId,
 				user,
 				participant.restrictions(),
@@ -556,7 +562,7 @@ TextWithEntities GenerateDefaultBannedRightsChangeText(
 	auto result = TextWithEntities{
 		tr::lng_admin_log_changed_default_permissions(tr::now)
 	};
-	const auto changes = GenerateBannedChangeText(rights, oldRights);
+	const auto changes = GeneratePermissionsChangeText(rights, oldRights);
 	if (!changes.isEmpty()) {
 		result.text.append('\n' + changes);
 	}


### PR DESCRIPTION
Cause [GenerateParticipantChangeText](https://github.com/telegramdesktop/tdesktop/blob/dev/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp#L470-L492) haven't handled `Restricted` to `Member` log, so admin or bot delete(remove) a user's exception.

You will see you're invited a user:
![{8A95E9D6-3547-4537-A248-9C24A5F90265}](https://user-images.githubusercontent.com/5726473/150399617-d0337360-a319-4c0f-b4f1-7ac784bf12f4.png)

After new commit, admin log should be shown correctly.
![{203B3E02-8B4F-4C2A-A826-D1D1D6771D3E}](https://user-images.githubusercontent.com/5726473/150399641-7f238526-ff15-4516-b982-deb7b129345e.png)

I think `GenerateBannedChangeText` renamed to `GeneratePermissionsChangeText`, it would be more suitable, cause `Banned` and `Restricted >> Member` now sharing same method.