### PR TITLE
Correct year in changelog for 2022 releases

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-3.5 (31.01.21)
+3.5 (31.01.22)
 
 - Use a new type of detailed stickers with smooth animations.
 - Create new sets by sending .webm videos to @stickers.
@@ -11,31 +11,31 @@
 - The app will warn you before closing if you are uploading photos or files to a chat.
 - Enjoy better screencast quality in video chats.
 
-3.4.8 (19.01.21)
+3.4.8 (19.01.22)
 
 - Nice animations in reactions.
 - Add snap layouts support on Windows 11.
 - Bug fixes and other minor improvements.
 
-3.4.7 beta (19.01.21)
+3.4.7 beta (19.01.22)
 
 - Fix a crash on launch on Windows.
 
-3.4.6 beta (18.01.21)
+3.4.6 beta (18.01.22)
 
 - Add snap layouts support on Windows 11.
 - Fix crash in drafts after accounts switching.
 
-3.4.5 beta (16.01.21)
+3.4.5 beta (16.01.22)
 
 - Fix crash in monospace blocks processing.
 - Fix reaction animations stopping after an hour uptime.
 
-3.4.4 beta (14.01.21)
+3.4.4 beta (14.01.22)
 
 - Nice animations in reactions.
 
-3.4.3 (03.01.21)
+3.4.3 (03.01.22)
 
 - Bug fixes and other minor improvements.
 


### PR DESCRIPTION
Currently, all 2022 releases appear as 2021 ones. Since the `changelog.txt` file is used to generate `<release>` tags in metainfo.xml for Linux, and appstream sorts releases by date, they end up in a wrong order: version 2.4.2 appears as first (latest). This causes Flatpak frontends (e.g. Flathub [web page](https://flathub.org/apps/details/org.telegram.desktop)) to show the wrong version for Telegram Desktop.