### PR TITLE
Fix build against FFmpeg v5.0

### DIFF
--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
@@ -154,7 +154,7 @@ void FormatDeleter::operator()(AVFormatContext *value) {
 	}
 }
 
-AVCodec *FindDecoder(not_null<AVCodecContext*> context) {
+const AVCodec *FindDecoder(not_null<AVCodecContext*> context) {
 	// Force libvpx-vp9, because we need alpha channel support.
 	return (context->codec_id == AV_CODEC_ID_VP9)
 		? avcodec_find_decoder_by_name("libvpx-vp9")

--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.h
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.h
@@ -158,7 +158,7 @@ using SwscalePointer = std::unique_ptr<SwsContext, SwscaleDeleter>;
 void LogError(QLatin1String method);
 void LogError(QLatin1String method, FFmpeg::AvErrorWrap error);
 
-[[nodiscard]] AVCodec *FindDecoder(not_null<AVCodecContext*> context);
+[[nodiscard]] const AVCodec *FindDecoder(not_null<AVCodecContext*> context);
 [[nodiscard]] crl::time PtsToTime(int64_t pts, AVRational timeBase);
 // Used for full duration conversion.
 [[nodiscard]] crl::time PtsToTimeCeil(int64_t pts, AVRational timeBase);

--- a/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
@@ -147,7 +147,7 @@ struct Instance::Inner::Private {
 	AVIOContext *ioContext = nullptr;
 	AVFormatContext *fmtContext = nullptr;
 	AVStream *stream = nullptr;
-	AVCodec *codec = nullptr;
+	const AVCodec *codec = nullptr;
 	AVCodecContext *codecContext = nullptr;
 	bool opened = false;
 	bool processing = false;

--- a/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.h
+++ b/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.h
@@ -60,7 +60,11 @@ protected:
 	uchar *ioBuffer = nullptr;
 	AVIOContext *ioContext = nullptr;
 	AVFormatContext *fmtContext = nullptr;
+#if LIBAVFORMAT_VERSION_MAJOR >= 59
+	const AVCodec *codec = nullptr;
+#else
 	AVCodec *codec = nullptr;
+#endif
 	int32 streamId = 0;
 
 	bool _opened = false;

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
@@ -23,8 +23,8 @@ constexpr auto kMaxQueuedPackets = 1024;
 		not_null<AVStream*> stream,
 		Mode mode) {
 	return (mode == Mode::Video || mode == Mode::Inspection)
-		&& stream->codec
-		&& (stream->codec->codec_id == AV_CODEC_ID_VP9)
+		&& stream->codecpar
+		&& (stream->codecpar->codec_id == AV_CODEC_ID_VP9)
 		&& format->iformat
 		&& format->iformat->name
 		&& QString::fromLatin1(


### PR DESCRIPTION
It has been released on January 17th. This patch keeps source compatibility with older versions.

See also: https://github.com/TelegramMessenger/tgcalls/pull/14