### PR TITLE
Hide the window instantly within autostart

### DIFF
--- a/Telegram/SourceFiles/mainwindow.cpp
+++ b/Telegram/SourceFiles/mainwindow.cpp
@@ -184,22 +184,12 @@ void MainWindow::applyInitialWorkMode() {
 		|| (cLaunchMode() == LaunchModeAutoStart
 			&& cStartMinimized()
 			&& !Core::App().passcodeLocked())) {
-		const auto minimizeAndHide = [=] {
-			DEBUG_LOG(("Window Pos: First show, setting minimized after."));
-			setWindowState(windowState() | Qt::WindowMinimized);
-			if (workMode == Core::Settings::WorkMode::TrayOnly
-				|| workMode == Core::Settings::WorkMode::WindowAndTray) {
-				hide();
-			}
-		};
-
-		if (Platform::IsLinux()) {
-			// If I call hide() synchronously here after show() then on Ubuntu 14.04
-			// it will show a window frame with transparent window body, without content.
-			// And to be able to "Show from tray" one more hide() will be required.
-			crl::on_main(this, minimizeAndHide);
+		DEBUG_LOG(("Window Pos: First show, setting minimized after."));
+		if (workMode == Core::Settings::WorkMode::TrayOnly
+			|| workMode == Core::Settings::WorkMode::WindowAndTray) {
+			hide();
 		} else {
-			minimizeAndHide();
+			setWindowState(windowState() | Qt::WindowMinimized);
 		}
 	}
 	setPositionInited();


### PR DESCRIPTION
Unnecessary minimize triggers animation that provides a sign there were a window. There's also seem to be queuing of hide on Linux that makes the effect even more noticable and it seems the bug this workaround was made for no longer reproduces.