### PR TITLE
[Linux] Clear read message notifications from history

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -2570,7 +2570,7 @@ void HistoryInner::checkHistoryActivation() {
 	}
 	adjustCurrent(_visibleAreaBottom);
 	if (_history->loadedAtBottom() && _visibleAreaBottom >= height()) {
-		// Clear possible scheduled messages notifications.
+		// Clear possible message notifications.
 		Core::App().notifications().clearFromHistory(_history);
 	}
 	if (_curHistory != _history || _history->isEmpty()) {

--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -695,7 +695,21 @@ void NotificationData::setImage(const QString &imagePath) {
 }
 
 void NotificationData::notificationClosed(uint id, uint reason) {
-	if (id == _notificationId) {
+	/*
+	 * From: https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html
+	 * The reason the notification was closed
+	 * 1 - The notification expired.
+	 * 2 - The notification was dismissed by the user.
+	 * 3 - The notification was closed by a call to CloseNotification.
+	 * 4 - Undefined/reserved reasons.
+	 *
+	 * If the notification was dismissed by the user (reason == 2), the notification is not kept in notification history.
+	 * We do not need to send a "CloseNotification" call later to clear it from history.
+	 * Therefore we can drop the notification reference now.
+	 * In all other cases we keep the notification reference so that we may clear the notification later from history,
+	 * if the message for that notification is read (e.g. chat is opened or read from another device).
+	*/
+	if (id == _notificationId && reason == 2) {
 		_manager->clearNotification(_id);
 	}
 }

--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -74,6 +74,9 @@ std::unique_ptr<base::Platform::DBus::ServiceWatcher> CreateServiceWatcher() {
 				const Glib::ustring &oldOwner,
 				const Glib::ustring &newOwner) {
 				if (activatable && newOwner.empty()) {
+					crl::on_main([] {
+						Core::App().notifications().clearAll();
+					});
 					return;
 				}
 
@@ -665,7 +668,9 @@ void NotificationData::close() {
 			_notificationId,
 		}),
 		{},
-		std::string(kService));
+		std::string(kService),
+		-1,
+		Gio::DBus::CALL_FLAGS_NO_AUTO_START);
 	_manager->clearNotification(_id);
 }
 


### PR DESCRIPTION
This fixes notifications not being cleared from history on Linux, once the chat with that person (whom the notifications originated from) is opened.
The notification reference must only be removed when the notification is really cleared - and not already when the notification has timed out.
See commit message for more details.