### PR TITLE
Introduce TDESKTOP_DISABLE_LEGACY_TGVOIP

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -31,7 +31,9 @@ get_filename_component(res_loc Resources REALPATH)
 include(cmake/telegram_options.cmake)
 include(cmake/lib_ffmpeg.cmake)
 include(cmake/lib_stripe.cmake)
-include(cmake/lib_tgvoip.cmake)
+if (NOT TDESKTOP_DISABLE_LEGACY_TGVOIP)
+    include(cmake/lib_tgvoip.cmake)
+endif()
 include(cmake/lib_tgcalls.cmake)
 include(cmake/td_export.cmake)
 include(cmake/td_mtproto.cmake)
@@ -55,9 +57,7 @@ target_prepare_qrc(Telegram)
 
 target_link_libraries(Telegram
 PRIVATE
-    tdesktop::lib_tgcalls_legacy
     tdesktop::lib_tgcalls
-    tdesktop::lib_tgvoip
 
     # Order in this list defines the order of include paths in command line.
     # We need to place desktop-app::external_minizip this early to have its

--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++ b/Telegram/SourceFiles/calls/calls_call.cpp
@@ -37,8 +37,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace tgcalls {
 class InstanceImpl;
 class InstanceV2Impl;
+#ifndef TDESKTOP_DISABLE_LEGACY_TGVOIP
 class InstanceImplLegacy;
 void SetLegacyGlobalServerConfig(const std::string &serverConfig);
+#endif
 } // namespace tgcalls
 
 namespace Calls {
@@ -52,7 +54,9 @@ const auto kDefaultVersion = "2.4.4"_q;
 
 const auto Register = tgcalls::Register<tgcalls::InstanceImpl>();
 const auto RegisterV2 = tgcalls::Register<tgcalls::InstanceV2Impl>();
+#ifndef TDESKTOP_DISABLE_LEGACY_TGVOIP
 const auto RegisterLegacy = tgcalls::Register<tgcalls::InstanceImplLegacy>();
+#endif
 
 void AppendEndpoint(
 		std::vector<tgcalls::Endpoint> &list,
@@ -1268,7 +1272,9 @@ Call::~Call() {
 }
 
 void UpdateConfig(const std::string &data) {
+#ifndef TDESKTOP_DISABLE_LEGACY_TGVOIP
 	tgcalls::SetLegacyGlobalServerConfig(data);
+#endif
 }
 
 } // namespace Calls

--- a/Telegram/cmake/lib_tgcalls.cmake
+++ b/Telegram/cmake/lib_tgcalls.cmake
@@ -243,6 +243,10 @@ PRIVATE
     ${tgcalls_loc}
 )
 
+if (TDESKTOP_DISABLE_LEGACY_TGVOIP)
+    return()
+endif()
+
 add_library(lib_tgcalls_legacy STATIC)
 init_target(lib_tgcalls_legacy)
 

--- a/Telegram/cmake/telegram_options.cmake
+++ b/Telegram/cmake/telegram_options.cmake
@@ -4,7 +4,9 @@
 # For license and copyright information please follow this link:
 # https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
+option(TDESKTOP_DISABLE_LEGACY_TGVOIP "Disable legacy tgvoip support." OFF)
 option(TDESKTOP_API_TEST "Use test API credentials." OFF)
+
 set(TDESKTOP_API_ID "0" CACHE STRING "Provide 'api_id' for the Telegram API access.")
 set(TDESKTOP_API_HASH "" CACHE STRING "Provide 'api_hash' for the Telegram API access.")
 set(TDESKTOP_LAUNCHER_BASENAME "" CACHE STRING "Desktop file base name (Linux only).")
@@ -35,6 +37,12 @@ if (TDESKTOP_API_ID STREQUAL "0" OR TDESKTOP_API_HASH STREQUAL "")
     " > Your users will start getting internal server errors on login\n"
     " > if you deploy an app using those 'api_id' and 'api_hash'.\n"
     " ")
+endif()
+
+if (TDESKTOP_DISABLE_LEGACY_TGVOIP)
+    target_compile_definitions(Telegram PRIVATE TDESKTOP_DISABLE_LEGACY_TGVOIP)
+else()
+    target_link_libraries(Telegram PRIVATE tdesktop::lib_tgcalls_legacy tdesktop::lib_tgvoip)
 endif()
 
 if (DESKTOP_APP_DISABLE_SPELLCHECK)


### PR DESCRIPTION
Originally from Alt Linux[0], OpenBSD has so far adapted the removal of
tgvoip in the official net/tdesktop build.

tgcalls provides everything needed for calls;  audio/video/desktop
sharing calls have been working fine across different operating systems
and telegram desktop/mobile versions without problems.

0: http://www.sisyphus.ru/cgi-bin/srpm.pl/Sisyphus/telegram-desktop/getpatch/1
