### PR TITLE
Fix incorrect admin log

### DIFF
--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
+++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
@@ -483,7 +483,10 @@ auto GenerateParticipantChangeText(
 				user,
 				ChatRestrictionsInfo(),
 				oldRestrictions);
-		} else if (oldParticipant && oldParticipant->type() == Type::Restricted && participant.type() == Type::Member) {
+		} else if (oldParticipant
+				&& oldParticipant->type() == Type::Restricted
+				&& (participant.type() == Type::Member
+						|| participant.type() == Type::Left)) {
 			return GeneratePermissionsChangeText(
 				participantId,
 				user,


### PR DESCRIPTION
One more case of #23944: `Restricted` to `Left`

Before:
![{8D9CEEC0-3B35-4E51-BD7E-CE7D90EF9D58}](https://user-images.githubusercontent.com/5726473/157752014-66f3705f-c8a6-45e6-99f6-b0e5fe123aae.png)

After:
![{4453F818-BC6C-4879-A5F0-94BE72751A1E}](https://user-images.githubusercontent.com/5726473/157752042-4d59c587-4d26-4670-83f4-147d46b238ff.png)

