### PR TITLE
Get media viewer screen by checking the screen by active window position

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -481,7 +481,16 @@ void OverlayWidget::refreshLang() {
 
 void OverlayWidget::moveToScreen(bool inMove) {
 	const auto widgetScreen = [&](auto &&widget) -> QScreen* {
-		if (auto handle = widget ? widget->windowHandle() : nullptr) {
+		if (!widget) {
+			return nullptr;
+		}
+		if (!Platform::IsWayland()) {
+			if (const auto screen = QGuiApplication::screenAt(
+				widget->geometry().center())) {
+				return screen;
+			}
+		}
+		if (const auto handle = widget->windowHandle()) {
 			return handle->screen();
 		}
 		return nullptr;


### PR DESCRIPTION
QWindow::screen seem to be buggy on Windows and doesn't always follow window moves