### PR TITLE
Update media viewer window flags

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -407,17 +407,12 @@ OverlayWidget::OverlayWidget()
 		return base::EventFilterResult::Continue;
 	});
 
-	if (Platform::IsLinux()) {
-		_widget->setWindowFlags(Qt::FramelessWindowHint
-			| Qt::MaximizeUsingFullscreenGeometryHint);
-	} else if (Platform::IsMac()) {
+	if constexpr (Platform::IsMac()) {
 		// Without Qt::Tool starting with Qt 5.15.1 this widget
 		// when being opened from a fullscreen main window was
 		// opening not as overlay over the main window, but as
 		// a separate fullscreen window with a separate space.
 		_widget->setWindowFlags(Qt::FramelessWindowHint | Qt::Tool);
-	} else {
-		_widget->setWindowFlags(Qt::FramelessWindowHint);
 	}
 	_widget->setAttribute(Qt::WA_NoSystemBackground, true);
 	_widget->setAttribute(Qt::WA_TranslucentBackground, true);
@@ -425,13 +420,6 @@ OverlayWidget::OverlayWidget()
 
 	hide();
 	_widget->createWinId();
-	if (Platform::IsLinux()) {
-		window()->setTransientParent(App::wnd()->windowHandle());
-		_widget->setWindowModality(Qt::WindowModal);
-	}
-	if (!Platform::IsMac()) {
-		_widget->setWindowState(Qt::WindowFullScreen);
-	}
 
 	QObject::connect(
 		window(),
@@ -548,6 +536,8 @@ void OverlayWidget::updateGeometry(bool inMove) {
 		.arg(use.width())
 		.arg(use.height()));
 	_widget->setGeometry(use);
+	_widget->setMinimumSize(use.size());
+	_widget->setMaximumSize(use.size());
 	if (useSizeHack) {
 		_widget->setMask(mask);
 	}
@@ -2628,7 +2618,7 @@ void OverlayWidget::displayFinished() {
 		//OverlayParent::setVisibleHook(false);
 		//setAttribute(Qt::WA_DontShowOnScreen, false);
 		Ui::Platform::UpdateOverlayed(_widget);
-		if (Platform::IsLinux()) {
+		if constexpr (!Platform::IsMac()) {
 			_widget->showFullScreen();
 		} else {
 			_widget->show();


### PR DESCRIPTION
1. FramelessWindowHint seem to be a redudant leftover of BypassWindowManagerHint, media viewer uses fullscreen state now that implies lack of the frame
2. MaximizeUsingFullscreenGeometryHint is useless since media viewer doesn't use maximize
3. Transient parent/window modality dance is replaced with minimum/maximum size just like in other places where tiling shouldn't be done
4. setWindowState(WindowFullScreen) is replaced with showFullScreen that ensures the flag is set on each show