### PR TITLE
Check and link `libatomic` for `RISC-V` architecture

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -39,6 +39,7 @@ include(cmake/td_lang.cmake)
 include(cmake/td_scheme.cmake)
 include(cmake/td_ui.cmake)
 include(cmake/generate_appdata_changelog.cmake)
+include(cmake/check_atomic.cmake)
 
 if (WIN32)
     include(cmake/generate_midl.cmake)
@@ -1377,6 +1378,20 @@ else()
             desktop-app::lib_waylandshells
             desktop-app::external_kwayland
         )
+    endif()
+
+    if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+        if (DESKTOP_APP_USE_PACKAGED)
+            target_link_libraries(Telegram
+            PRIVATE
+                atomic
+            )
+        else()
+            target_link_libraries(Telegram
+            PRIVATE
+                atomic-static
+            )
+        endif()
     endif()
 endif()
 

--- a/Telegram/cmake/check_atomic.cmake
+++ b/Telegram/cmake/check_atomic.cmake
@@ -1,0 +1,43 @@
+# Modified from https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/CheckAtomic.cmake
+
+include(CheckCXXSourceCompiles)
+include(CheckLibraryExists)
+
+# Sometimes linking against libatomic is required for atomic ops, if
+# the platform doesn't support lock-free atomics.
+
+function(check_working_cxx_atomics varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+  CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+std::atomic<int> x;
+std::atomic<short> y;
+std::atomic<char> z;
+std::atomic<uint64_t> v;
+int main() {
+  ++z;
+  ++y;
+  uint64_t i = v.load(std::memory_order_relaxed);
+  (void)i;
+  return ++x;
+}
+" ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics)
+
+# Check for (non-64-bit) atomic operations.
+if(MSVC)
+  set(HAVE_CXX_ATOMICS_WITHOUT_LIB True)
+elseif(LLVM_COMPILER_IS_GCC_COMPATIBLE OR CMAKE_CXX_COMPILER_ID MATCHES "XL")
+  # First check if atomics work without the library.
+  check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  # If not, check if the library exists, and atomics work with it.
+  if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+    check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+    if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
+      message(FATAL_ERROR "Host compiler must support std::atomic!")
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
Currently this project cannot be compiled for `RISC-V` architecture, `ld` linker raises an error:

```
/usr/bin/ld: /tmp/ccOIMCdU.ltrans23.ltrans.o: undefined reference to symbol '__atomic_compare_exchange_1@@LIBATOMIC_1.0'
/usr/bin/ld: /usr/lib/libatomic.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

This is because the `RISC-V` architecture does not support some 1-byte and 2-byte lock-free atomic operations(e.g. `fetch_add`, `exchange`...).

Explicitly linking to `libatomic` would fix this problem. Inside that library, unsupported operations for 1-byte and 2-byte `std::atomic` used in the project will fallback to the mutex implementation, which is allowed by C++ standard.