### PR TITLE
Do not capture buttons in AccountsList that belong to inner VerticalLayout widget

### DIFF
--- a/Telegram/SourceFiles/settings/settings_information.cpp
+++ b/Telegram/SourceFiles/settings/settings_information.cpp
@@ -78,9 +78,7 @@ private:
 	int _outerIndex = 0;
 
 	Ui::SlideWrap<Ui::SettingsButton> *_addAccount = nullptr;
-	base::flat_map<
-		not_null<Main::Account*>,
-		base::unique_qptr<Ui::SettingsButton>> _watched;
+	base::flat_map<not_null<Main::Account*>, Ui::SettingsButton*> _watched;
 
 	base::unique_qptr<Ui::PopupMenu> _contextMenu;
 	std::unique_ptr<Ui::VerticalLayoutReorder> _reorder;
@@ -730,7 +728,7 @@ void AccountsList::rebuild() {
 				order.reserve(inner->count());
 				for (auto i = 0; i < inner->count(); i++) {
 					for (const auto &[account, button] : _watched) {
-						if (button.get() == inner->widgetAt(i)) {
+						if (button == inner->widgetAt(i)) {
 							order.push_back(account->session().uniqueId());
 						}
 					}
@@ -769,11 +767,11 @@ void AccountsList::rebuild() {
 					account,
 					std::move(activate));
 			};
-			button.reset(inner->add(MakeAccountButton(
+			button = inner->add(MakeAccountButton(
 				inner,
 				_controller,
 				account,
-				std::move(callback))));
+				std::move(callback)));
 		}
 	}
 	inner->resizeToWidth(_outer->width());

--- a/Telegram/SourceFiles/settings/settings_information.cpp
+++ b/Telegram/SourceFiles/settings/settings_information.cpp
@@ -78,7 +78,9 @@ private:
 	int _outerIndex = 0;
 
 	Ui::SlideWrap<Ui::SettingsButton> *_addAccount = nullptr;
-	base::flat_map<not_null<Main::Account*>, Ui::SettingsButton*> _watched;
+	base::flat_map<
+		not_null<Main::Account*>,
+		QPointer<Ui::SettingsButton>> _watched;
 
 	base::unique_qptr<Ui::PopupMenu> _contextMenu;
 	std::unique_ptr<Ui::VerticalLayoutReorder> _reorder;
@@ -728,7 +730,7 @@ void AccountsList::rebuild() {
 				order.reserve(inner->count());
 				for (auto i = 0; i < inner->count(); i++) {
 					for (const auto &[account, button] : _watched) {
-						if (button == inner->widgetAt(i)) {
+						if (button.data() == inner->widgetAt(i)) {
 							order.push_back(account->session().uniqueId());
 						}
 					}


### PR DESCRIPTION
This fixes a use-after-free error (double destruction) in the main menu right after account switching. The Ui::VerticalLayout::add method seems to return a weak pointer that should not be given to base::unique_qptr or anything.

The regression was introduced in commit f31be7784b9ef0790408a353e3d53e6022553d1f.

```
==121545== Invalid read of size 8
==121545==    at 0x603F7D: QWeakPointer<QObject>::internalData() const (qsharedpointer_impl.h:698)
==121545==    by 0x603FE8: QPointer<QObject>::data() const (qpointer.h:77)
==121545==    by 0xA2DCC6: object_ptr<Ui::RpWidget>::data() const (object_ptr.h:68)
==121545==    by 0xA3284A: object_ptr<Ui::RpWidget>::operator Ui::RpWidget*() const (object_ptr.h:71)
==121545==    by 0x6B70AEC: Ui::VerticalLayout::childHeightUpdated(Ui::RpWidget*)::{lambda(Ui::VerticalLayout::Row const&)#1}::operator()(Ui::VerticalLayout::Row const&) const (vertical_layout.cpp:144)
...
```

I'm attaching the full Valgrind log. You can see there errors about uninitialized values. I've fixed some of them in other pull requests, desktop-app/lib_rpl#2, desktop-app/lib_ui#86, [tdesktop.log](https://github.com/telegramdesktop/tdesktop/files/8454352/tdesktop.log).
