### PR TITLE
Allow usage of Arrow Up and Arrow Down to edit more than just the most recent message

### DIFF
--- a/Telegram/SourceFiles/history/history.cpp
+++ b/Telegram/SourceFiles/history/history.cpp
@@ -2763,6 +2763,51 @@ HistoryItem *History::lastEditableMessage() const {
 	return nullptr;
 }
 
+
+HistoryItem *History::editableMessageBefore(MsgId current) const {
+	if (!loadedAtBottom()) {
+		return nullptr;
+	}
+
+	bool found = false;
+	const auto now = base::unixtime::now();
+	for (const auto &block : ranges::views::reverse(blocks)) {
+		for (const auto &message : ranges::views::reverse(block->messages)) {
+			const auto item = message->data();
+			if (item->allowsEdit(now)) {
+				if(owner().groups().findItemToEdit(item)->id == current) {
+					found = true;
+				} else if(found) {
+					return owner().groups().findItemToEdit(item);
+				}
+			}
+		}
+	}
+	return nullptr;
+}
+
+HistoryItem *History::editableMessageAfter(MsgId current) const {
+	if (!loadedAtBottom()) {
+		return nullptr;
+	}
+
+	HistoryItem * previous = nullptr;
+	const auto now = base::unixtime::now();
+	for (const auto &block : ranges::views::reverse(blocks)) {
+		for (const auto &message : ranges::views::reverse(block->messages)) {
+			const auto item = message->data();
+			if (item->allowsEdit(now)) {
+				if(owner().groups().findItemToEdit(item)->id == current) {
+					return previous;
+				} else {
+					previous = owner().groups().findItemToEdit(item);
+				}
+			}
+		}
+	}
+	return nullptr;
+}
+
 void History::resizeToWidth(int newWidth) {
 	const auto resizeAllItems = (_width != newWidth);
 

--- a/Telegram/SourceFiles/history/history.h
+++ b/Telegram/SourceFiles/history/history.h
@@ -314,6 +314,8 @@ public:
 	MsgId maxMsgId() const;
 	MsgId msgIdForRead() const;
 	HistoryItem *lastEditableMessage() const;
+	HistoryItem *editableMessageBefore(MsgId current) const;
+	HistoryItem *editableMessageAfter(MsgId current) const;
 
 	void resizeToWidth(int newWidth);
 	void forceFullResize();

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -6101,10 +6101,8 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 					controller()->show(Ui::MakeConfirmBox({
 						.text = tr::lng_cancel_edit_post_sure(),
 						.confirmed = crl::guard(this, [this, item] {
-							if (_editMsgId) {
-								item ? editMessage(item) : cancelEdit();
-								Ui::hideLayer();
-							}
+							item ? editMessage(item) : cancelEdit();
+							Ui::hideLayer();
 						}),
 						.confirmText = tr::lng_cancel_edit_post_yes(),
 						.cancelText = tr::lng_cancel_edit_post_no(),
@@ -6134,10 +6132,8 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 					controller()->show(Ui::MakeConfirmBox({
 						.text = tr::lng_cancel_edit_post_sure(),
 						.confirmed = crl::guard(this, [this, item] {
-							if (_editMsgId) {
-								editMessage(item);
-								Ui::hideLayer();
-							}
+							editMessage(item);
+							Ui::hideLayer();
 						}),
 						.confirmText = tr::lng_cancel_edit_post_yes(),
 						.cancelText = tr::lng_cancel_edit_post_no(),

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -6093,18 +6093,36 @@ void HistoryWidget::keyPressEvent(QKeyEvent *e) {
 	} else if (e->key() == Qt::Key_PageUp) {
 		_scroll->keyPressEvent(e);
 	} else if (e->key() == Qt::Key_Down && !commonModifiers) {
-		_scroll->keyPressEvent(e);
-	} else if (e->key() == Qt::Key_Up && !commonModifiers) {
-		const auto item = _history
-			? _history->lastEditableMessage()
-			: nullptr;
-		if (item
-			&& _field->empty()
-			&& !_editMsgId
+		if (_editMsgId
 			&& !_replyToId) {
-			editMessage(item);
+				const auto item = _history ? _history->editableMessageAfter(_editMsgId) : nullptr;
+				if(item) {
+					editMessage(item);
+				}
 			return;
 		}
+
+		_scroll->keyPressEvent(e);
+	} else if (e->key() == Qt::Key_Up && !commonModifiers) {
+		if (_field->empty()
+			&& !_editMsgId
+			&& !_replyToId) {
+				const auto item = _history ? _history->lastEditableMessage() : nullptr;
+				if(item) {
+					editMessage(item);
+				}
+				return;
+		}
+
+		if (_editMsgId
+			&& !_replyToId) {
+				const auto item = _history ? _history->editableMessageBefore(_editMsgId) : nullptr;
+				if(item) {
+					editMessage(item);
+				}
+				return;
+		}
+
 		_scroll->keyPressEvent(e);
 	} else if (e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter) {
 		if (!_botStart->isHidden()) {


### PR DESCRIPTION
Pressing up currently allows you to edit the most recent message. However, there is no way to edit older messages this way.

This PR enables navigating messages to edit them by pressing the up or down key when the cursor is at the start/end of a message that is being edited.