### PR TITLE
Add glib-networking to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,6 +121,7 @@ parts:
       - libxcb-record0
       - libxcb-screensaver0
       - zlib1g
+      - glib-networking
       - systemd
     cmake-parameters:
       - -GNinja


### PR DESCRIPTION
It's required by webkit2gtk for correct operation