### PR TITLE
Fix media viewer on Unity

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -537,8 +537,6 @@ void OverlayWidget::updateGeometry(bool inMove) {
 		.arg(use.width())
 		.arg(use.height()));
 	_widget->setGeometry(use);
-	_widget->setMinimumSize(use.size());
-	_widget->setMaximumSize(use.size());
 	if (possibleSizeHack) {
 		_widget->setMask(mask);
 	}


### PR DESCRIPTION
This could be a regression for tiling WMs, though...

Fixes #24416