### PR TITLE
Explicitly specify QVector element type to fix build with clang13+qt6

### DIFF
--- a/Telegram/SourceFiles/api/api_media.cpp
+++ b/Telegram/SourceFiles/api/api_media.cpp
@@ -83,7 +83,7 @@ MTPInputMedia PrepareUploadedPhoto(RemoteFileInfo info) {
 		MTP_flags(flags),
 		info.file,
 		MTP_vector<MTPInputDocument>(
-			ranges::to<QVector>(info.attachedStickers)),
+			ranges::to<QVector<MTPInputDocument>>(info.attachedStickers)),
 		MTP_int(0));
 }
 
@@ -107,7 +107,7 @@ MTPInputMedia PrepareUploadedDocument(
 		MTP_string(document->mimeString()),
 		ComposeSendingDocumentAttributes(document),
 		MTP_vector<MTPInputDocument>(
-			ranges::to<QVector>(info.attachedStickers)),
+			ranges::to<QVector<MTPInputDocument>>(info.attachedStickers)),
 		MTP_int(0));
 }
 

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_reactions.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_reactions.cpp
@@ -138,7 +138,7 @@ void SaveAllowedReactions(
 		const std::vector<QString> &allowed) {
 	auto ids = allowed | ranges::views::transform([=](QString value) {
 		return MTP_string(value);
-	}) | ranges::to<QVector>;
+	}) | ranges::to<QVector<MTPstring>>;
 
 	peer->session().api().request(MTPmessages_SetChatAvailableReactions(
 		peer->input,


### PR DESCRIPTION
More info:
https://github.com/telegramdesktop/tdesktop/issues/24385
fixes #24014
https://github.com/ericniebler/range-v3/issues/1691