### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,6 +40,9 @@ on:
       - 'Telegram/configure.bat'
       - 'Telegram/Telegram.plist'
 
+permissions:
+  contents: read
+
 jobs:
 
   linux:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,8 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
+      pull-requests: write  # for dessant/lock-threads to lock PRs
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,6 +38,9 @@ on:
       - 'Telegram/SourceFiles/platform/linux/**'
       - 'Telegram/configure.bat'
 
+permissions:
+  contents: read
+
 jobs:
 
   macos:

--- a/.github/workflows/master_updater.yml
+++ b/.github/workflows/master_updater.yml
@@ -4,8 +4,13 @@ on:
   release:
     types: released
 
+permissions:
+  contents: read
+
 jobs:
   updater:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     env:
       SKIP: "0"

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -36,6 +36,9 @@ on:
       - 'Telegram/configure.bat'
       - 'Telegram/Telegram.plist'
 
+permissions:
+  contents: read
+
 jobs:
 
   linux:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
