### PR TITLE
Fix Premium Maximum Connected Accounts number in Premium Preview Box

### DIFF
--- a/Telegram/SourceFiles/boxes/premium_preview_box.cpp
+++ b/Telegram/SourceFiles/boxes/premium_preview_box.cpp
@@ -1816,9 +1816,7 @@ void DoubledLimitsPreviewBox(
 		});
 	}
 	const auto now = session->domain().accounts().size();
-	const auto till = (now + 1 >= Main::Domain::kPremiumMaxAccounts)
-		? QString::number(Main::Domain::kPremiumMaxAccounts)
-		: (QString::number(now + 1) + QChar('+'));
+	const auto till = QString::number(Main::Domain::kPremiumMaxAccounts);
 	entries.push_back(Ui::Premium::ListEntry{
 		tr::lng_premium_double_limits_subtitle_accounts(),
 		tr::lng_premium_double_limits_about_accounts(

--- a/Telegram/SourceFiles/main/main_domain.h
+++ b/Telegram/SourceFiles/main/main_domain.h
@@ -31,7 +31,7 @@ public:
 	};
 
 	static constexpr auto kMaxAccounts = 3;
-	static constexpr auto kPremiumMaxAccounts = 6;
+	static constexpr auto kPremiumMaxAccounts = 4;
 
 	explicit Domain(const QString &dataName);
 	~Domain();


### PR DESCRIPTION
With one account connected

Before the edit:
![image](https://user-images.githubusercontent.com/30782292/173861987-3d2a9f1e-4f15-4a94-bc54-e7bf6cb2fa58.png)
After the edit:
![image](https://user-images.githubusercontent.com/30782292/173875030-0bd2b0de-773a-4611-855e-e7f03aabda92.png)

This puts the message and limit on par with Android and iOS limits

