### PR TITLE
Partially revert "Use QWidget::screen/QWidget::mask instead of QWindow ones"

### DIFF
--- a/Telegram/SourceFiles/calls/group/ui/desktop_capture_choose_source.cpp
+++ b/Telegram/SourceFiles/calls/group/ui/desktop_capture_choose_source.cpp
@@ -574,6 +574,7 @@ void ChooseSourceProcess::setupSourcesGeometry() {
 
 void ChooseSourceProcess::setupGeometryWithParent(
 		not_null<QWidget*> parent) {
+	_window->createWinId();
 	const auto parentScreen = [&] {
 		if (!::Platform::IsWayland()) {
 			if (const auto screen = QGuiApplication::screenAt(
@@ -585,7 +586,7 @@ void ChooseSourceProcess::setupGeometryWithParent(
 	}();
 	const auto myScreen = _window->screen();
 	if (parentScreen && myScreen != parentScreen) {
-		_window->setScreen(parentScreen);
+		_window->windowHandle()->setScreen(parentScreen);
 	}
 	_window->move(
 		parent->x() + (parent->width() - _window->width()) / 2,

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -501,7 +501,7 @@ void OverlayWidget::moveToScreen(bool inMove) {
 		DEBUG_LOG(("Viewer Pos: Currently on screen %1, moving to screen %2")
 			.arg(screenList.indexOf(myScreen))
 			.arg(screenList.indexOf(activeWindowScreen)));
-		_widget->setScreen(activeWindowScreen);
+		window()->setScreen(activeWindowScreen);
 		DEBUG_LOG(("Viewer Pos: New actual screen: %1")
 			.arg(screenList.indexOf(_widget->screen())));
 	}


### PR DESCRIPTION
This partially reverts commit e5d8a1aa3c9457c0c0ceb560190a19d7b5349d9d to use QWindow::setScreen.