### PR TITLE
Explicitly specify `signed` modifier for `char` type

### DIFF
--- a/Telegram/SourceFiles/data/data_types.h
+++ b/Telegram/SourceFiles/data/data_types.h
@@ -148,7 +148,7 @@ enum LocationType {
 	SecureFileLocation = 0xcbc7ee28, // mtpc_inputSecureFileLocation
 };
 
-enum FileStatus : char {
+enum FileStatus : signed char {
 	FileDownloadFailed = -2,
 	FileUploadFailed = -1,
 	FileReady = 1,


### PR DESCRIPTION
Build for RISC-V architecture using v4.0 release will fail with errors:

```
/build/telegram-desktop/src/tdesktop-4.0.0-full/Telegram/SourceFiles/data/data_types.h:152:31: error: enumerator value ‘-2’ is outside the range of underlying type ‘char’
  152 |         FileDownloadFailed = -2,
      |                               ^
/build/telegram-desktop/src/tdesktop-4.0.0-full/Telegram/SourceFiles/data/data_types.h:153:29: error: enumerator value ‘-1’ is outside the range of underlying type ‘char’
  153 |         FileUploadFailed = -1,
      |                             ^
ninja: build stopped: subcommand failed.
```

Reference to C++ standard ([cppref](https://en.cppreference.com/w/cpp/language/types#Character_types)):

> `char` - type for character representation which can be most efficiently processed on the target system (has the same representation and alignment as either `signed char` or `unsigned char`, but is always a distinct type). [Multibyte characters strings](https://en.cppreference.com/w/cpp/string/multibyte) use this type to represent code units. For every value of type `unsigned char` in range [0, 255], converting the value to `char` and then back to `unsigned char` produces the original value. (since C++11) **The signedness of `char` depends on the compiler and the target platform**: the defaults for ARM and PowerPC are typically unsigned, the defaults for x86 and x64 are typically signed.

Reference to [RISC-V Calling Convention Specification](https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf) [18.1] C Datatypes and Alignment:

> The C types char and unsigned char are 8-bit unsigned integers and are zero-extended when stored in a RISC-V integer register.

For RISC-V, the `char` type without a modifier is defined as `unsigned` by the implementation. Explicitly adding a `signed` modifier to them would fix these errors.


