### PR TITLE
Don't trigger actions on build documentation change

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '!docs/building-linux.md'
       - 'changelog.txt'
       - 'LEGAL'
       - 'LICENSE'
@@ -24,7 +23,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '!docs/building-linux.md'
       - 'changelog.txt'
       - 'LEGAL'
       - 'LICENSE'

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -5,7 +5,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '!docs/building-mac.md'
       - 'changelog.txt'
       - 'LEGAL'
       - 'LICENSE'
@@ -23,7 +22,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '!docs/building-mac.md'
       - 'changelog.txt'
       - 'LEGAL'
       - 'LICENSE'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -5,7 +5,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '!docs/building-win.md'
       - 'changelog.txt'
       - 'LEGAL'
       - 'LICENSE'
@@ -24,7 +23,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '!docs/building-win.md'
       - 'changelog.txt'
       - 'LEGAL'
       - 'LICENSE'


### PR DESCRIPTION
Documentation is not sourced in actions since prepare.py invention