### PR TITLE
money-purchasing and money-advertising updated

### DIFF
--- a/lib/xdg/telegramdesktop.metainfo.xml.in
+++ b/lib/xdg/telegramdesktop.metainfo.xml.in
@@ -69,8 +69,9 @@
         <content_attribute id="social-audio">intense</content_attribute>
         <content_attribute id="social-location">none</content_attribute>
         <content_attribute id="social-contacts">intense</content_attribute>
-        <content_attribute id="money-purchasing">none</content_attribute>
+        <content_attribute id="money-purchasing">intense</content_attribute>
         <content_attribute id="money-gambling">none</content_attribute>
+        <content_attribute id="money-advertising">moderate</content_attribute>
     </content_rating>
     <launchable type="desktop-id">@TDESKTOP_LAUNCHER_BASENAME@.desktop</launchable>
     <provides>


### PR DESCRIPTION
Changed money-purchasing from 'none' to 'intense' as the in-app purchase of telegram premium is available.
Added money-advertising and set it to 'moderate' as telegram ads has been introduced.