### PR TITLE
Use quasi-logarithmic volume controls

### DIFF
--- a/Telegram/SourceFiles/media/audio/media_audio.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio.cpp
@@ -315,12 +315,15 @@ base::Observable<AudioMsgId> &Updated() {
 
 // Thread: Any. Must be locked: AudioMutex.
 float64 ComputeVolume(AudioMsgId::Type type) {
-	switch (type) {
-	case AudioMsgId::Type::Voice: return VolumeMultiplierAll;
-	case AudioMsgId::Type::Song: return VolumeMultiplierSong * mixer()->getSongVolume();
-	case AudioMsgId::Type::Video: return mixer()->getVideoVolume();
-	}
-	return 1.;
+	const auto gain = [&] {
+		switch (type) {
+		case AudioMsgId::Type::Voice: return VolumeMultiplierAll;
+		case AudioMsgId::Type::Song: return VolumeMultiplierSong * mixer()->getSongVolume();
+		case AudioMsgId::Type::Video: return mixer()->getVideoVolume();
+		}
+		return 1.;
+	}();
+	return gain * gain * gain;
 }
 
 Mixer *mixer() {


### PR DESCRIPTION
This commit significantly improves the usability of the volume controls
for controlling volume in a way that matches intuitively onto human
needs and loudness perception.

Using the third power of the volume is a good approximation of the
quasi-logarithmic psychoacoustic system, while being defined everywhere
and preserving the useful quality of 0% volume mapping onto gain 0.0.
The use of this exact mapping function is a prior art established by
e.g. PulseAudio, among many other programs.

Fixes #24488