### PR TITLE
Fix warnings by removing unused variables

### DIFF
--- a/Telegram/SourceFiles/boxes/premium_preview_box.cpp
+++ b/Telegram/SourceFiles/boxes/premium_preview_box.cpp
@@ -50,7 +50,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace {
 
 constexpr auto kPremiumShift = 21. / 240;
-constexpr auto kShiftDuration = crl::time(200);
 constexpr auto kReactionsPerRow = 5;
 constexpr auto kDisabledOpacity = 0.5;
 constexpr auto kPreviewsCount = int(PremiumPreview::kCount);

--- a/Telegram/SourceFiles/boxes/reactions_settings_box.cpp
+++ b/Telegram/SourceFiles/boxes/reactions_settings_box.cpp
@@ -43,8 +43,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace {
 
-constexpr auto kVisibleButtonsCount = 7;
-
 PeerId GenerateUser(not_null<History*> history, const QString &name) {
 	Expects(history->peer->isUser());
 

--- a/Telegram/SourceFiles/settings/settings_premium.cpp
+++ b/Telegram/SourceFiles/settings/settings_premium.cpp
@@ -52,8 +52,6 @@ namespace {
 using SectionCustomTopBarData = Info::Settings::SectionCustomTopBarData;
 
 constexpr auto kBodyAnimationPart = 0.90;
-constexpr auto kTitleAnimationPart = 0.15;
-
 constexpr auto kTitleAdditionalScale = 0.15;
 
 struct GiftRef {

--- a/Telegram/SourceFiles/ui/text/custom_emoji_instance.cpp
+++ b/Telegram/SourceFiles/ui/text/custom_emoji_instance.cpp
@@ -20,7 +20,6 @@ namespace {
 
 constexpr auto kMaxSize = 128;
 constexpr auto kMaxFrames = 180;
-constexpr auto kMaxFrameDuration = 86400 * crl::time(1000);
 constexpr auto kCacheVersion = 1;
 constexpr auto kPreloadFrames = 3;
 


### PR DESCRIPTION
Telegram/SourceFiles/ui/text/custom_emoji_instance.cpp:23:16: warning: unused variable 'kMaxFrameDuration' [-Wunused-const-variable]
Telegram/SourceFiles/boxes/reactions_settings_box.cpp:46:16: warning: unused variable 'kVisibleButtonsCount' [-Wunused-const-variable]
Telegram/SourceFiles/boxes/premium_preview_box.cpp:53:16: warning: unused variable 'kShiftDuration' [-Wunused-const-variable]

Found by:	clang