### PR TITLE
Correct FFmpeg API usage

### DIFF
--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_frame_generator.cpp
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_frame_generator.cpp
@@ -47,11 +47,11 @@ private:
 		return (_rotation == 90) || (_rotation == 270);
 	}
 
-	[[nodiscard]] static int Read(
+	[[nodiscard]] static int _read(
 		void *opaque,
 		uint8_t *buf,
 		int buf_size);
-	[[nodiscard]] static int64_t Seek(
+	[[nodiscard]] static int64_t _seek(
 		void *opaque,
 		int64_t offset,
 		int whence);
@@ -113,7 +113,7 @@ int FrameGenerator::Impl::Read(void *opaque, uint8_t *buf, int buf_size) {
 int FrameGenerator::Impl::read(uint8_t *buf, int buf_size) {
 	const auto available = _bytes.size() - _deviceOffset;
 	if (available <= 0) {
-		return -1;
+		return AVERROR_EOF;
 	}
 	const auto fill = std::min(int(available), buf_size);
 	memcpy(buf, _bytes.data() + _deviceOffset, fill);

--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_frame_generator.cpp
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_frame_generator.cpp
@@ -47,11 +47,11 @@ private:
 		return (_rotation == 90) || (_rotation == 270);
 	}
 
-	[[nodiscard]] static int _read(
+	[[nodiscard]] static int Read(
 		void *opaque,
 		uint8_t *buf,
 		int buf_size);
-	[[nodiscard]] static int64_t _seek(
+	[[nodiscard]] static int64_t Seek(
 		void *opaque,
 		int64_t offset,
 		int whence);

--- a/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
@@ -176,7 +176,7 @@ struct Instance::Inner::Private {
 	uint16 waveformPeak = 0;
 	QVector<uchar> waveform;
 
-	static int _read_data(void *opaque, uint8_t *buf, int buf_size) {
+	static int ReadData(void *opaque, uint8_t *buf, int buf_size) {
 		auto l = reinterpret_cast<Private*>(opaque);
 
 		int32 nbytes = qMin(l->data.size() - l->dataPos, int32(buf_size));
@@ -189,7 +189,7 @@ struct Instance::Inner::Private {
 		return nbytes;
 	}
 
-	static int _write_data(void *opaque, uint8_t *buf, int buf_size) {
+	static int WriteData(void *opaque, uint8_t *buf, int buf_size) {
 		auto l = reinterpret_cast<Private*>(opaque);
 
 		if (buf_size <= 0) return 0;
@@ -199,7 +199,7 @@ struct Instance::Inner::Private {
 		return buf_size;
 	}
 
-	static int64_t _seek_data(void *opaque, int64_t offset, int whence) {
+	static int64_t SeekData(void *opaque, int64_t offset, int whence) {
 		auto l = reinterpret_cast<Private*>(opaque);
 
 		int32 newPos = -1;
@@ -260,7 +260,7 @@ void Instance::Inner::start(Fn<void(Update)> updated, Fn<void()> error) {
 
 	d->ioBuffer = (uchar*)av_malloc(FFmpeg::kAVBlockSize);
 
-	d->ioContext = avio_alloc_context(d->ioBuffer, FFmpeg::kAVBlockSize, 1, static_cast<void*>(d.get()), &Private::_read_data, &Private::_write_data, &Private::_seek_data);
+	d->ioContext = avio_alloc_context(d->ioBuffer, FFmpeg::kAVBlockSize, 1, static_cast<void*>(d.get()), &Private::ReadData, &Private::WriteData, &Private::SeekData);
 	int res = 0;
 	char err[AV_ERROR_MAX_STRING_SIZE] = { 0 };
 	const AVOutputFormat *fmt = nullptr;

--- a/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
@@ -181,7 +181,7 @@ struct Instance::Inner::Private {
 
 		int32 nbytes = qMin(l->data.size() - l->dataPos, int32(buf_size));
 		if (nbytes <= 0) {
-			return 0;
+			return AVERROR_EOF;
 		}
 
 		memcpy(buf, l->data.constData() + l->dataPos, nbytes);

--- a/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.cpp
@@ -38,11 +38,11 @@ bool AbstractFFMpegLoader::open(crl::time positionMs) {
 
 	ioBuffer = (uchar *)av_malloc(FFmpeg::kAVBlockSize);
 	if (!_data.isEmpty()) {
-		ioContext = avio_alloc_context(ioBuffer, FFmpeg::kAVBlockSize, 0, reinterpret_cast<void *>(this), &AbstractFFMpegLoader::_read_data, 0, &AbstractFFMpegLoader::_seek_data);
+		ioContext = avio_alloc_context(ioBuffer, FFmpeg::kAVBlockSize, 0, reinterpret_cast<void *>(this), &AbstractFFMpegLoader::ReadData, 0, &AbstractFFMpegLoader::SeekData);
 	} else if (!_bytes.empty()) {
-		ioContext = avio_alloc_context(ioBuffer, FFmpeg::kAVBlockSize, 0, reinterpret_cast<void *>(this), &AbstractFFMpegLoader::_read_bytes, 0, &AbstractFFMpegLoader::_seek_bytes);
+		ioContext = avio_alloc_context(ioBuffer, FFmpeg::kAVBlockSize, 0, reinterpret_cast<void *>(this), &AbstractFFMpegLoader::ReadBytes, 0, &AbstractFFMpegLoader::SeekBytes);
 	} else {
-		ioContext = avio_alloc_context(ioBuffer, FFmpeg::kAVBlockSize, 0, reinterpret_cast<void *>(this), &AbstractFFMpegLoader::_read_file, 0, &AbstractFFMpegLoader::_seek_file);
+		ioContext = avio_alloc_context(ioBuffer, FFmpeg::kAVBlockSize, 0, reinterpret_cast<void *>(this), &AbstractFFMpegLoader::ReadFile, 0, &AbstractFFMpegLoader::SeekFile);
 	}
 	fmtContext = avformat_alloc_context();
 	if (!fmtContext) {
@@ -100,7 +100,7 @@ AbstractFFMpegLoader::~AbstractFFMpegLoader() {
 	if (fmtContext) avformat_free_context(fmtContext);
 }
 
-int AbstractFFMpegLoader::_read_data(void *opaque, uint8_t *buf, int buf_size) {
+int AbstractFFMpegLoader::ReadData(void *opaque, uint8_t *buf, int buf_size) {
 	auto l = reinterpret_cast<AbstractFFMpegLoader *>(opaque);
 
 	auto nbytes = qMin(l->_data.size() - l->_dataPos, int32(buf_size));
@@ -113,7 +113,7 @@ int AbstractFFMpegLoader::_read_data(void *opaque, uint8_t *buf, int buf_size) {
 	return nbytes;
 }
 
-int64_t AbstractFFMpegLoader::_seek_data(void *opaque, int64_t offset, int whence) {
+int64_t AbstractFFMpegLoader::SeekData(void *opaque, int64_t offset, int whence) {
 	auto l = reinterpret_cast<AbstractFFMpegLoader *>(opaque);
 
 	int32 newPos = -1;
@@ -133,7 +133,7 @@ int64_t AbstractFFMpegLoader::_seek_data(void *opaque, int64_t offset, int whenc
 	return l->_dataPos;
 }
 
-int AbstractFFMpegLoader::_read_bytes(void *opaque, uint8_t *buf, int buf_size) {
+int AbstractFFMpegLoader::ReadBytes(void *opaque, uint8_t *buf, int buf_size) {
 	auto l = reinterpret_cast<AbstractFFMpegLoader *>(opaque);
 
 	auto nbytes = qMin(static_cast<int>(l->_bytes.size()) - l->_dataPos, buf_size);
@@ -146,7 +146,7 @@ int AbstractFFMpegLoader::_read_bytes(void *opaque, uint8_t *buf, int buf_size) 
 	return nbytes;
 }
 
-int64_t AbstractFFMpegLoader::_seek_bytes(void *opaque, int64_t offset, int whence) {
+int64_t AbstractFFMpegLoader::SeekBytes(void *opaque, int64_t offset, int whence) {
 	auto l = reinterpret_cast<AbstractFFMpegLoader *>(opaque);
 
 	int32 newPos = -1;
@@ -167,7 +167,7 @@ int64_t AbstractFFMpegLoader::_seek_bytes(void *opaque, int64_t offset, int when
 	return l->_dataPos;
 }
 
-int AbstractFFMpegLoader::_read_file(void *opaque, uint8_t *buf, int buf_size) {
+int AbstractFFMpegLoader::ReadFile(void *opaque, uint8_t *buf, int buf_size) {
 	auto l = reinterpret_cast<AbstractFFMpegLoader *>(opaque);
 	int ret = l->_f.read((char *)(buf), buf_size);
 	switch (ret) {
@@ -177,7 +177,7 @@ int AbstractFFMpegLoader::_read_file(void *opaque, uint8_t *buf, int buf_size) {
 	}
 }
 
-int64_t AbstractFFMpegLoader::_seek_file(void *opaque, int64_t offset, int whence) {
+int64_t AbstractFFMpegLoader::SeekFile(void *opaque, int64_t offset, int whence) {
 	auto l = reinterpret_cast<AbstractFFMpegLoader *>(opaque);
 
 	switch (whence) {

--- a/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.h
+++ b/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.h
@@ -70,12 +70,12 @@ protected:
 	bool _opened = false;
 
 private:
-	static int _read_data(void *opaque, uint8_t *buf, int buf_size);
-	static int64_t _seek_data(void *opaque, int64_t offset, int whence);
-	static int _read_bytes(void *opaque, uint8_t *buf, int buf_size);
-	static int64_t _seek_bytes(void *opaque, int64_t offset, int whence);
-	static int _read_file(void *opaque, uint8_t *buf, int buf_size);
-	static int64_t _seek_file(void *opaque, int64_t offset, int whence);
+	static int ReadData(void *opaque, uint8_t *buf, int buf_size);
+	static int64_t SeekData(void *opaque, int64_t offset, int whence);
+	static int ReadBytes(void *opaque, uint8_t *buf, int buf_size);
+	static int64_t SeekBytes(void *opaque, int64_t offset, int whence);
+	static int ReadFile(void *opaque, uint8_t *buf, int buf_size);
+	static int64_t SeekFile(void *opaque, int64_t offset, int whence);
 
 };
 

--- a/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
+++ b/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
@@ -283,7 +283,7 @@ bool FFMpegReaderImplementation::start(Mode mode, crl::time &positionMs) {
 		return false;
 	}
 	_ioBuffer = (uchar*)av_malloc(FFmpeg::kAVBlockSize);
-	_ioContext = avio_alloc_context(_ioBuffer, FFmpeg::kAVBlockSize, 0, static_cast<void*>(this), &FFMpegReaderImplementation::_read, nullptr, &FFMpegReaderImplementation::_seek);
+	_ioContext = avio_alloc_context(_ioBuffer, FFmpeg::kAVBlockSize, 0, static_cast<void*>(this), &FFMpegReaderImplementation::Read, nullptr, &FFMpegReaderImplementation::Seek);
 	_fmtContext = avformat_alloc_context();
 	if (!_fmtContext) {
 		LOG(("Gif Error: Unable to avformat_alloc_context %1").arg(logData()));
@@ -480,7 +480,7 @@ FFMpegReaderImplementation::PacketResult FFMpegReaderImplementation::readAndProc
 	return result;
 }
 
-int FFMpegReaderImplementation::_read(void *opaque, uint8_t *buf, int buf_size) {
+int FFMpegReaderImplementation::Read(void *opaque, uint8_t *buf, int buf_size) {
 	FFMpegReaderImplementation *l = reinterpret_cast<FFMpegReaderImplementation*>(opaque);
 	int ret = l->_device->read((char*)(buf), buf_size);
 	switch (ret) {
@@ -490,7 +490,7 @@ int FFMpegReaderImplementation::_read(void *opaque, uint8_t *buf, int buf_size) 
 	}
 }
 
-int64_t FFMpegReaderImplementation::_seek(void *opaque, int64_t offset, int whence) {
+int64_t FFMpegReaderImplementation::Seek(void *opaque, int64_t offset, int whence) {
 	FFMpegReaderImplementation *l = reinterpret_cast<FFMpegReaderImplementation*>(opaque);
 
 	switch (whence) {

--- a/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
+++ b/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
@@ -482,7 +482,13 @@ FFMpegReaderImplementation::PacketResult FFMpegReaderImplementation::readAndProc
 
 int FFMpegReaderImplementation::_read(void *opaque, uint8_t *buf, int buf_size) {
 	FFMpegReaderImplementation *l = reinterpret_cast<FFMpegReaderImplementation*>(opaque);
-	return int(l->_device->read((char*)(buf), buf_size));
+	FFMpegReaderImplementation *l = reinterpret_cast<FFMpegReaderImplementation*>(opaque);
+	int ret = l->_device->read((char*)(buf), buf_size);
+	switch (ret) {
+	case -1: return AVERROR_EXTERNAL;
+	case 0: return AVERROR_EOF;
+	default: return ret;
+	}
 }
 
 int64_t FFMpegReaderImplementation::_seek(void *opaque, int64_t offset, int whence) {

--- a/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
+++ b/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
@@ -482,7 +482,6 @@ FFMpegReaderImplementation::PacketResult FFMpegReaderImplementation::readAndProc
 
 int FFMpegReaderImplementation::_read(void *opaque, uint8_t *buf, int buf_size) {
 	FFMpegReaderImplementation *l = reinterpret_cast<FFMpegReaderImplementation*>(opaque);
-	FFMpegReaderImplementation *l = reinterpret_cast<FFMpegReaderImplementation*>(opaque);
 	int ret = l->_device->read((char*)(buf), buf_size);
 	switch (ret) {
 	case -1: return AVERROR_EXTERNAL;

--- a/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.h
+++ b/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.h
@@ -76,8 +76,8 @@ private:
 		return (_rotation == Rotation::Degrees90) || (_rotation == Rotation::Degrees270);
 	}
 
-	static int _read(void *opaque, uint8_t *buf, int buf_size);
-	static int64_t _seek(void *opaque, int64_t offset, int whence);
+	static int Read(void *opaque, uint8_t *buf, int buf_size);
+	static int64_t Seek(void *opaque, int64_t offset, int whence);
 
 	Mode _mode = Mode::Silent;
 

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
@@ -44,12 +44,12 @@ File::Context::Context(
 
 File::Context::~Context() = default;
 
-int File::Context::_read(void *opaque, uint8_t *buffer, int bufferSize) {
+int File::Context::Read(void *opaque, uint8_t *buffer, int bufferSize) {
 	return static_cast<Context*>(opaque)->read(
 		bytes::make_span(buffer, bufferSize));
 }
 
-int64_t File::Context::_seek(void *opaque, int64_t offset, int whence) {
+int64_t File::Context::Seek(void *opaque, int64_t offset, int whence) {
 	return static_cast<Context*>(opaque)->seek(offset, whence);
 }
 
@@ -276,9 +276,9 @@ void File::Context::start(crl::time position, bool hwAllow) {
 	}
 	auto format = FFmpeg::MakeFormatPointer(
 		static_cast<void *>(this),
-		&Context::_read,
+		&Context::Read,
 		nullptr,
-		&Context::_seek);
+		&Context::Seek);
 	if (!format) {
 		return fail(Error::OpenFailed);
 	}

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.h
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.h
@@ -62,8 +62,8 @@ private:
 			Allowed,
 			Disallowed,
 		};
-		static int _read(void *opaque, uint8_t *buffer, int bufferSize);
-		static int64_t _seek(void *opaque, int64_t offset, int whence);
+		static int Read(void *opaque, uint8_t *buffer, int bufferSize);
+		static int64_t Seek(void *opaque, int64_t offset, int whence);
 
 		[[nodiscard]] int read(bytes::span buffer);
 		[[nodiscard]] int64_t seek(int64_t offset, int whence);

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.h
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.h
@@ -62,8 +62,8 @@ private:
 			Allowed,
 			Disallowed,
 		};
-		static int Read(void *opaque, uint8_t *buffer, int bufferSize);
-		static int64_t Seek(void *opaque, int64_t offset, int whence);
+		static int _read(void *opaque, uint8_t *buffer, int bufferSize);
+		static int64_t _seek(void *opaque, int64_t offset, int whence);
 
 		[[nodiscard]] int read(bytes::span buffer);
 		[[nodiscard]] int64_t seek(int64_t offset, int whence);


### PR DESCRIPTION
FFmpeg docs say that you must return `AVERROR_EOF` from the read callback, not zero. Still, Telegram just propagates the return value from `IODevice::read()` call, which returns zero in case of EOF.

I don't know whether this commit has any effect on the upstream build, but it fixes a bug in Debian build of Telegram, which is using FFmpeg 5.1 instead of 4.4. Still, it's also useful in the upstream, as it makes work with FFmpeg more correct.