### PR TITLE
Handle touch events in view replies section ScrollArea to allow scrolling from touch screen

### DIFF
--- a/Telegram/SourceFiles/history/view/history_view_replies_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_replies_section.cpp
@@ -175,7 +175,7 @@ RepliesWidget::RepliesWidget(
 , _scroll(std::make_unique<Ui::ScrollArea>(
 	this,
 	controller->chatStyle()->value(lifetime(), st::historyScroll),
-	false))
+	true))
 , _scrollDown(
 	_scroll.get(),
 	controller->chatStyle()->value(lifetime(), st::historyToDown))


### PR DESCRIPTION
This fixes https://github.com/telegramdesktop/tdesktop/issues/24880 which is reproducible on my MS Surface x Pro machine running Windows 10.

Current behavior:
- try scrolling with one finger while in the comments section
- observe that comments are selected instead

New behavior:
- scrolling with one finger works
- to select comments, do a long touch, then choose "Select"
