### PR TITLE
Remove explicit setting of paths for cmake in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,8 +122,6 @@ parts:
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_LIBRARY_PATH=$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET
-      - -DCMAKE_INCLUDE_PATH=$CRAFT_STAGE/usr/include
       - -DTDESKTOP_API_ID=611335
       - -DTDESKTOP_API_HASH=d524b414d21f4d37f08684c1df41ac9c
       - -DDESKTOP_APP_USE_PACKAGED_LAZY=ON
@@ -523,8 +521,6 @@ parts:
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_LIBRARY_PATH=$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET
-      - -DCMAKE_INCLUDE_PATH=$CRAFT_STAGE/usr/include
     prime:
       - -./usr/include
       - -./usr/lib/$CRAFT_ARCH_TRIPLET/cmake


### PR DESCRIPTION
This is reported as fixed in snapcraft, thus these paths should be set automatically