### PR TITLE
Allow users to filter message searches by channel sender in groups

### DIFF
--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -1132,7 +1132,7 @@ void AddSpecialBoxSearchController::searchGlobalDone(
 		} else {
 			return;
 		}
-		for (const auto& mtpChat : list.v) {
+		for (const auto &mtpChat : list.v) {
 			const auto peerId = mtpChat.match([](const MTPDchannel& data) {
 					return peerFromChannel(data.vid().v);
 				}, [](const MTPDchat& data) {

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -415,8 +415,13 @@ std::unique_ptr<PeerListRow> AddSpecialBoxController::createSearchRow(
 	if (_excludeSelf && peer->isSelf()) {
 		return nullptr;
 	}
-	if (const auto user = peer->asUser()) {
-		return createRow(user);
+	if (_excludeBroadcasts && peer->isBroadcast())
+	{
+		return nullptr;
+	}
+
+	if (peer->asUser() || peer->asBroadcast()) {
+		return createRow(peer);
 	}
 	return nullptr;
 }
@@ -1118,9 +1123,48 @@ void AddSpecialBoxSearchController::searchGlobalDone(
 			}
 		}
 	};
+
+	const auto feedListChannels = [&](const MTPVector<MTPChat>& list) {
+		// skip this step in groups which are not eligible for masquerading.
+		if (const auto megagroup = _peer->asMegagroup()) {
+			if (!megagroup->hasUsername() && !megagroup->linkedChat()) {
+				return;
+			}
+		} else {
+			return;
+		}
+		for (const auto& mtpChat : list.v) {
+			const auto peerId = mtpChat.match([](const MTPDchannel& data) {
+					return peerFromChannel(data.vid().v);
+				}, [](const MTPDchat& data) {
+					return peerFromChat(data.vid().v);
+				}, [](auto&&) {
+					return PeerId();
+				});
+			if (const auto peer = _peer->owner().peerLoaded(peerId)) {
+				bool isBroadcastMasqueradable = false;
+				if (const auto broadcast = peer->asBroadcast()) {
+					// to reduce clutter, only allow exact username matches.
+					if (broadcast->hasUsername() &&
+						broadcast->username.compare(_query.startsWith('@') ?
+							QString(_query).remove('@') :
+							_query, Qt::CaseInsensitive) == 0) {
+						isBroadcastMasqueradable = true;
+					}
+				}
+
+				if (isBroadcastMasqueradable) {
+					_additional->checkForLoaded(peer);
+					delegate()->peerListSearchAddRow(peer);
+				}
+			}
+		}
+	};
+
 	if (_requestId == requestId) {
 		_requestId = 0;
 		_globalLoaded = true;
+		feedListChannels(found.vchats());
 		feedList(found.vmy_results());
 		feedList(found.vresults());
 		delegate()->peerListSearchRefreshRows();

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -1135,7 +1135,7 @@ void AddSpecialBoxSearchController::searchGlobalDone(
 		for (const auto &mtpChat : list.v) {
 			const auto peerId = mtpChat.match([](const MTPDchannel &data) {
 					return peerFromChannel(data.vid().v);
-				}, [](const MTPDchat& data) {
+				}, [](const MTPDchat &data) {
 					return peerFromChat(data.vid().v);
 				}, [](auto&&) {
 					return PeerId();

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -1141,7 +1141,7 @@ void AddSpecialBoxSearchController::searchGlobalDone(
 					return PeerId();
 				});
 			if (const auto peer = _peer->owner().peerLoaded(peerId)) {
-				bool isBroadcastMasqueradable = false;
+				auto isBroadcastMasqueradable = false;
 				if (const auto broadcast = peer->asBroadcast()) {
 					// to reduce clutter, only allow exact username matches.
 					if (broadcast->hasUsername() &&

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -1133,7 +1133,7 @@ void AddSpecialBoxSearchController::searchGlobalDone(
 			return;
 		}
 		for (const auto &mtpChat : list.v) {
-			const auto peerId = mtpChat.match([](const MTPDchannel& data) {
+			const auto peerId = mtpChat.match([](const MTPDchannel &data) {
 					return peerFromChannel(data.vid().v);
 				}, [](const MTPDchat& data) {
 					return peerFromChat(data.vid().v);

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
@@ -415,8 +415,7 @@ std::unique_ptr<PeerListRow> AddSpecialBoxController::createSearchRow(
 	if (_excludeSelf && peer->isSelf()) {
 		return nullptr;
 	}
-	if (_excludeBroadcasts && peer->isBroadcast())
-	{
+	if (_excludeBroadcasts && peer->isBroadcast()) {
 		return nullptr;
 	}
 

--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.h
+++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.h
@@ -147,6 +147,7 @@ private:
 
 protected:
 	bool _excludeSelf = true;
+	bool _excludeBroadcasts = true;
 
 };
 

--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
@@ -59,6 +59,7 @@ SearchFromController::SearchFromController(
 	BannedDoneCallback())
 , _callback(std::move(callback)) {
 	_excludeSelf = false;
+	_excludeBroadcasts = false;
 }
 
 void SearchFromController::prepare() {


### PR DESCRIPTION
Users can send messages as channels in any supergroup which either has a public username or is linked to a channel. Previously it was not possible to filter by sender for messages sent on behalf of a channel, and now it is. In order to avoid confusion, you must search by the channel's exact username, and the group must permit sending messages as channels.

It is worth considering whether chat administrators should always be able to search for messages by any channel, regardless of group or channel settings, to ensure they can handle adversarial situations, but this pull request addresses only the simple case.

closes #25105