### PR TITLE
Mention docker-buildx requirement in build instructions

### DIFF
--- a/docs/building-linux.md
+++ b/docs/building-linux.md
@@ -10,7 +10,7 @@ You will require **api_id** and **api_hash** to access the Telegram API servers.
 
 ### Prepare libraries
 
-Install [poetry](https://python-poetry.org), go to the `tdesktop/Telegram/build/docker/centos_env` directory and run
+Install [poetry](https://python-poetry.org), go to the `tdesktop/Telegram/build/docker/centos_env` directory and run (make sure the docker-buildx plugin is installed)
 
     poetry install
     poetry run gen_dockerfile | docker buildx build -t tdesktop:centos_env -


### PR DESCRIPTION
If you don't know that the buildx command is part of a plugin which isn't included on some distributions, the error it throws at you can be quite confusing:

```
$ poetry run gen_dockerfile | docker buildx build -t tdesktop:centos_env -
unknown shorthand flag: 't' in -t
See 'docker --help'.
```

Might save people some time.