### PR TITLE
Add an experimental "small message radius" toggle

### DIFF
--- a/Telegram/SourceFiles/settings/settings_experimental.cpp
+++ b/Telegram/SourceFiles/settings/settings_experimental.cpp
@@ -13,6 +13,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/buttons.h"
 #include "ui/widgets/labels.h"
 #include "ui/gl/gl_detection.h"
+#include "ui/chat/chat_style_radius.h"
 #include "base/options.h"
 #include "core/application.h"
 #include "chat_helpers/tabbed_panel.h"
@@ -137,6 +138,7 @@ void SetupExperimental(
 	addToggle(Window::kOptionViewProfileInChatsListContextMenu);
 	addToggle(Dialogs::kOptionCtrlClickChatNewWindow);
 	addToggle(Ui::GL::kOptionAllowLinuxNvidiaOpenGL);
+	addToggle(Ui::kOptionUseSmallMsgBubbleRadius);
 	addToggle(Media::Player::kOptionDisableAutoplayNext);
 	addToggle(Settings::kOptionMonoSettingsIcons);
 	addToggle(Webview::kOptionWebviewDebugEnabled);

--- a/Telegram/SourceFiles/ui/cached_round_corners.cpp
+++ b/Telegram/SourceFiles/ui/cached_round_corners.cpp
@@ -6,7 +6,7 @@ For license and copyright information please follow this link:
 https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "ui/cached_round_corners.h"
-
+#include "ui/chat/chat_style.h"
 #include "ui/painter.h"
 #include "ui/ui_utility.h"
 #include "ui/image/image_prepare.h"
@@ -244,10 +244,10 @@ CornersPixmaps PrepareCornerPixmaps(ImageRoundRadius radius, style::color bg, co
 	using Radius = CachedCornerRadius;
 	switch (tag) {
 	case Radius::Small: return st::roundRadiusSmall;
-	case Radius::ThumbSmall: return st::msgFileThumbRadiusSmall;
-	case Radius::ThumbLarge: return st::msgFileThumbRadiusLarge;
-	case Radius::BubbleSmall: return st::bubbleRadiusSmall;
-	case Radius::BubbleLarge: return st::bubbleRadiusLarge;
+	case Radius::ThumbSmall: return MsgFileThumbRadiusSmall();
+	case Radius::ThumbLarge: return MsgFileThumbRadiusLarge();
+	case Radius::BubbleSmall: return BubbleRadiusSmall();
+	case Radius::BubbleLarge: return BubbleRadiusLarge();
 	}
 	Unexpected("Radius tag in CachedCornerRadiusValue.");
 }

--- a/Telegram/SourceFiles/ui/chat/chat_style.cpp
+++ b/Telegram/SourceFiles/ui/chat/chat_style.cpp
@@ -502,12 +502,12 @@ const MessageStyle &ChatStyle::messageStyle(bool outbg, bool selected) const {
 	auto &result = messageStyleRaw(outbg, selected);
 	EnsureCorners(
 		result.msgBgCornersSmall,
-		st::bubbleRadiusSmall,
+		BubbleRadiusSmall(),
 		result.msgBg,
 		&result.msgShadow);
 	EnsureCorners(
 		result.msgBgCornersLarge,
-		st::bubbleRadiusLarge,
+		BubbleRadiusLarge(),
 		result.msgBg,
 		&result.msgShadow);
 	return result;
@@ -521,19 +521,19 @@ const MessageImageStyle &ChatStyle::imageStyle(bool selected) const {
 		result.msgDateImgBg);
 	EnsureCorners(
 		result.msgServiceBgCornersSmall,
-		st::bubbleRadiusSmall,
+		BubbleRadiusSmall(),
 		result.msgServiceBg);
 	EnsureCorners(
 		result.msgServiceBgCornersLarge,
-		st::bubbleRadiusLarge,
+		BubbleRadiusLarge(),
 		result.msgServiceBg);
 	EnsureCorners(
 		result.msgShadowCornersSmall,
-		st::bubbleRadiusSmall,
+		BubbleRadiusSmall(),
 		result.msgShadow);
 	EnsureCorners(
 		result.msgShadowCornersLarge,
-		st::bubbleRadiusLarge,
+		BubbleRadiusLarge(),
 		result.msgShadow);
 	return result;
 }
@@ -541,7 +541,7 @@ const MessageImageStyle &ChatStyle::imageStyle(bool selected) const {
 const CornersPixmaps &ChatStyle::msgBotKbOverBgAddCornersSmall() const {
 	EnsureCorners(
 		_msgBotKbOverBgAddCornersSmall,
-		st::bubbleRadiusSmall,
+		BubbleRadiusSmall(),
 		msgBotKbOverBgAdd());
 	return _msgBotKbOverBgAddCornersSmall;
 }
@@ -549,7 +549,7 @@ const CornersPixmaps &ChatStyle::msgBotKbOverBgAddCornersSmall() const {
 const CornersPixmaps &ChatStyle::msgBotKbOverBgAddCornersLarge() const {
 	EnsureCorners(
 		_msgBotKbOverBgAddCornersLarge,
-		st::bubbleRadiusLarge,
+		BubbleRadiusLarge(),
 		msgBotKbOverBgAdd());
 	return _msgBotKbOverBgAddCornersLarge;
 }

--- a/Telegram/SourceFiles/ui/chat/chat_style.h
+++ b/Telegram/SourceFiles/ui/chat/chat_style.h
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "ui/cached_round_corners.h"
 #include "ui/chat/message_bubble.h"
+#include "ui/chat/chat_style_radius.h"
 #include "ui/style/style_core_palette.h"
 #include "layout/layout_selection.h"
 #include "styles/style_basic.h"

--- a/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
+++ b/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
@@ -20,7 +20,7 @@ namespace {
 base::options::toggle UseSmallMsgBubbleRadius({
 	.id = kOptionUseSmallMsgBubbleRadius,
 	.name = "Use small message bubble radius",
-	.description = "Makes most message bubbles square-ish again.",
+	.description = "Makes most message bubbles square-ish.",
 	.restartRequired = true,
 });
 

--- a/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
+++ b/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
@@ -1,0 +1,61 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "ui/chat/chat_style_radius.h"
+#include "ui/chat/chat_style.h"
+#include "base/options.h"
+
+#include "ui/chat/chat_theme.h"
+#include "ui/painter.h"
+#include "ui/ui_utility.h"
+#include "styles/style_chat.h"
+
+namespace Ui {
+namespace {
+
+base::options::toggle UseSmallMsgBubbleRadius({
+	.id = kOptionUseSmallMsgBubbleRadius,
+	.name = "Use small message bubble radius",
+	.description = "Makes most message bubbles square-ish again.",
+	.restartRequired = true,
+});
+
+} // namespace
+
+const char kOptionUseSmallMsgBubbleRadius[] = "use-small-msg-bubble-radius";
+
+int BubbleRadiusSmall() {
+	return st::bubbleRadiusSmall;
+}
+
+int BubbleRadiusLarge() {
+	static const auto result = [] {
+		if (UseSmallMsgBubbleRadius.value()) {
+			return st::bubbleRadiusSmall;
+		} else {
+			return st::bubbleRadiusLarge;
+		}
+	}();
+	return result;
+}
+
+int MsgFileThumbRadiusSmall() {
+	return st::msgFileThumbRadiusSmall;
+}
+
+int MsgFileThumbRadiusLarge() {
+	static const auto result = [] {
+		if (UseSmallMsgBubbleRadius.value()) {
+			return st::msgFileThumbRadiusSmall;
+		} else {
+			return st::msgFileThumbRadiusLarge;
+		}
+	}();
+	return result;
+}
+
+}

--- a/Telegram/SourceFiles/ui/chat/chat_style_radius.h
+++ b/Telegram/SourceFiles/ui/chat/chat_style_radius.h
@@ -1,0 +1,20 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+namespace Ui {
+
+[[nodiscard]] int BubbleRadiusSmall();
+[[nodiscard]] int BubbleRadiusLarge();
+
+[[nodiscard]] int MsgFileThumbRadiusSmall();
+[[nodiscard]] int MsgFileThumbRadiusLarge();
+
+extern const char kOptionUseSmallMsgBubbleRadius[];
+
+}

--- a/Telegram/SourceFiles/ui/chat/message_bubble.cpp
+++ b/Telegram/SourceFiles/ui/chat/message_bubble.cpp
@@ -48,8 +48,8 @@ void PaintBubbleGeneric(
 		? Corner::None
 		: bottomWithTailRight;
 	const auto rect = args.geometry;
-	const auto small = st::bubbleRadiusSmall;
-	const auto large = st::bubbleRadiusLarge;
+	const auto small = BubbleRadiusSmall();
+	const auto large = BubbleRadiusLarge();
 	const auto cornerSize = [&](Corner corner) {
 		return (corner == Corner::Large)
 			? large
@@ -250,8 +250,8 @@ void PaintSolidBubble(QPainter &p, const SimpleBubble &args) {
 std::unique_ptr<BubblePattern> PrepareBubblePattern(
 		not_null<const style::palette*> st) {
 	auto result = std::make_unique<Ui::BubblePattern>();
-	result->cornersSmall = Images::CornersMask(st::bubbleRadiusSmall);
-	result->cornersLarge = Images::CornersMask(st::bubbleRadiusLarge);
+	result->cornersSmall = Images::CornersMask(BubbleRadiusSmall());
+	result->cornersLarge = Images::CornersMask(BubbleRadiusLarge());
 	const auto addShadow = [&](QImage &bottomCorner) {
 		auto result = QImage(
 			bottomCorner.width(),

--- a/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
+++ b/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
@@ -786,8 +786,8 @@ void Generator::paintBubble(const Bubble &bubble) {
 	auto bubbleTop = y;
 	auto bubbleHeight = height;
 	if (isPhoto) {
-		bubbleTop -= st::bubbleRadiusLarge + 1;
-		bubbleHeight += st::bubbleRadiusLarge + 1;
+		bubbleTop -= Ui::BubbleRadiusLarge() + 1;
+		bubbleHeight += Ui::BubbleRadiusLarge() + 1;
 	}
 
 	auto left = bubble.outbg ? st::msgMargin.right() : st::msgMargin.left();

--- a/Telegram/cmake/td_ui.cmake
+++ b/Telegram/cmake/td_ui.cmake
@@ -188,6 +188,8 @@ PRIVATE
     ui/chat/attach/attach_single_media_preview.h
     ui/chat/chat_style.cpp
     ui/chat/chat_style.h
+    ui/chat/chat_style_radius.cpp
+    ui/chat/chat_style_radius.h
     ui/chat/chat_theme.cpp
     ui/chat/chat_theme.h
     ui/chat/continuous_scroll.cpp


### PR DESCRIPTION
This toggle allows switching to the pre-4.3.0, smaller message bubble radius after an app restart. The message bubble radius styles now have to be referenced via the `Ui::BubbleRadius*` and `Ui::MsgFileThumbRadius*` wrappers to use the appropriate value.