### PR TITLE
Update to changes in MPRIS SystemMediaControlsManager backend

### DIFF
--- a/Telegram/SourceFiles/media/system_media_controls_manager.cpp
+++ b/Telegram/SourceFiles/media/system_media_controls_manager.cpp
@@ -24,6 +24,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/text/format_song_document_name.h"
 #include "window/window_controller.h"
 
+#include <ksandbox.h>
+
 namespace Media {
 namespace {
 
@@ -52,7 +54,10 @@ SystemMediaControlsManager::SystemMediaControlsManager(
 		base::Platform::SystemMediaControls::PlaybackStatus;
 	using Command = base::Platform::SystemMediaControls::Command;
 
-	_controls->setServiceName(qsl("org.mpris.MediaPlayer2.tdesktop"));
+	// Flatpak provides default permission to MPRIS, but not snap
+	if (!KSandbox::isFlatpak()) {
+		_controls->setServiceName(qsl("tdesktop"));
+	}
 	_controls->setApplicationName(AppName.utf16());
 	const auto inited = _controls->init(controller->widget());
 	if (!inited) {


### PR DESCRIPTION
And let it use service name provided by flatpak by default

Depens on https://github.com/desktop-app/lib_base/pull/140