### PR TITLE
Ensure GNotification is not autodetected in snap

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -286,7 +286,7 @@ void LaunchGApplication() {
 	};
 
 	if (OptionGApplication.value()
-		|| gtkNotifications()
+		|| (!KSandbox::isSnap() && gtkNotifications())
 		|| (KSandbox::isFlatpak() && !freedesktopNotifications())) {
 		Glib::signal_idle().connect_once([] {
 			const auto appId = QGuiApplication::desktopFileName()


### PR DESCRIPTION
Snap reports it as present, but prevents the access and GNotification attempts to use portal that doesn't work in snap