### PR TITLE
Use GNotification only in flatpak by default

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -1198,7 +1198,7 @@ void Manager::doClearFromSession(not_null<Main::Session*> session) {
 }
 
 bool Manager::doSkipAudio() const {
-	return _private->inhibited() || Gio::Application::get_default();
+	return _private->inhibited();
 }
 
 bool Manager::doSkipToast() const {
@@ -1206,7 +1206,7 @@ bool Manager::doSkipToast() const {
 }
 
 bool Manager::doSkipFlashBounce() const {
-	return _private->inhibited() || Gio::Application::get_default();
+	return _private->inhibited();
 }
 
 } // namespace Notifications

--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -268,25 +268,7 @@ void LaunchGApplication() {
 		return false;
 	};
 
-	const auto gtkNotifications = [&] {
-		try {
-			if (connection && NameHasOwner(
-				connection,
-				"org.gtk.Notifications")) {
-				return true;
-			}
-		} catch (...) {
-		}
-
-		if (ranges::contains(activatableNames, "org.gtk.Notifications")) {
-			return true;
-		}
-
-		return false;
-	};
-
 	if (OptionGApplication.value()
-		|| (!KSandbox::isSnap() && gtkNotifications())
 		|| (KSandbox::isFlatpak() && !freedesktopNotifications())) {
 		Glib::signal_idle().connect_once([] {
 			const auto appId = QGuiApplication::desktopFileName()

--- a/Telegram/SourceFiles/platform/platform_specific.cpp
+++ b/Telegram/SourceFiles/platform/platform_specific.cpp
@@ -16,8 +16,7 @@ const char kOptionGApplication[] = "gapplication";
 base::options::toggle OptionGApplication({
 	.id = kOptionGApplication,
 	.name = "GApplication",
-	.description = "Force enable GNOME's GApplication and GNotification."
-		" This changes notification behavior to be native to GNOME."
+	.description = "Force enable GLib's GApplication and GNotification."
 		" When disabled, autodetect is used.",
 	.scope = base::options::linux,
 	.restartRequired = true,


### PR DESCRIPTION
The UX is not the best without sound, so there's no advantage in using GNotification on GNOME.

Remove mention about being native to GNOME as it's not true anymore.