### PR TITLE
Speed up Linux action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -93,6 +93,8 @@ jobs:
           fi
 
           ./configure.sh \
+          -D CMAKE_C_FLAGS_DEBUG="" \
+          -D CMAKE_CXX_FLAGS_DEBUG="" \
           -D CMAKE_C_FLAGS="-Werror" \
           -D CMAKE_CXX_FLAGS="-Werror" \
           -D CMAKE_EXE_LINKER_FLAGS="-s" \


### PR DESCRIPTION
The binary is stripped anyway, there's no sense in producing debug symbols