### PR TITLE
Add Esperanto to language list of translate box

### DIFF
--- a/Telegram/SourceFiles/boxes/translate_box.cpp
+++ b/Telegram/SourceFiles/boxes/translate_box.cpp
@@ -44,6 +44,7 @@ namespace {
 		QLocale::Czech,
 		QLocale::Danish,
 		QLocale::Dutch,
+		QLocale::Esperanto,
 		QLocale::Estonian,
 		QLocale::French,
 		QLocale::German,


### PR DESCRIPTION
TDesktop provides support for many languages for translating, it is already possible to translate from Esperanto, but unfortunately it lacks support for translating to Esperanto. This simple pull request will fix that.

I tested on Android and iOS, there I am able to translate to Esperanto:

![Translating to Esperanto on Android](https://user-images.githubusercontent.com/692029/204919959-89c9920d-6710-4aa1-b989-a9f8c9a8f7b1.png)

![Translating to Esperanto on iOS](https://user-images.githubusercontent.com/692029/204919586-fce33710-56d4-414f-a272-e0cef2f0ab72.png)
