### PR TITLE
prevent a message from registering into group, if message comes from a blocked peer

### DIFF
--- a/Telegram/SourceFiles/data/data_groups.cpp
+++ b/Telegram/SourceFiles/data/data_groups.cpp
@@ -47,7 +47,7 @@ void Groups::registerMessage(not_null<HistoryItem*> item) {
 	}
 	const auto i = _groups.emplace(item->groupId(), Group()).first;
 	auto &items = i->second.items;
-	if (items.size() < kMaxItemsInGroup) {
+	if (items.size() < kMaxItemsInGroup && !item->from()->isBlocked() ) {
 		items.insert(findPositionForItem(items, item), item);
 		if (items.size() > 1) {
 			refreshViews(items);


### PR DESCRIPTION
related issue #24854, and a long-time [request](https://bugs.telegram.org/c/37) in the forum

This is a preliminary attempt to "ignore blocked users in a group"

I'm very open to the following discussions, although I do want this feature:
- is it ok to assume that the user doesn't want to see the message?
- does the change interfere with group message update mechanism?(haven't read into this part yet, I can imagine the client tries to load since and consume more resources for both client and server)
- constraints violation regarding storage?
- is this the correct place?

(It seems to me that the message item is inserted into storage, then the client will try to register it, I'm not quite sure)