### PR TITLE
Fix building without spellcheck

### DIFF
--- a/Telegram/SourceFiles/boxes/translate_box.cpp
+++ b/Telegram/SourceFiles/boxes/translate_box.cpp
@@ -15,7 +15,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "main/main_session.h"
 #include "mtproto/sender.h"
 #include "settings/settings_common.h"
+#ifndef TDESKTOP_DISABLE_SPELLCHECK
 #include "spellcheck/platform/platform_language.h"
+#endif
 #include "ui/effects/loading_element.h"
 #include "ui/layers/generic_box.h"
 #include "ui/widgets/buttons.h"
@@ -342,6 +344,7 @@ bool SkipTranslate(TextWithEntities textWithEntities) {
 	if (!hasLetters) {
 		return true;
 	}
+#ifndef TDESKTOP_DISABLE_SPELLCHECK
 	const auto result = Platform::Language::Recognize(text);
 	if (result.unknown) {
 		return false;
@@ -354,6 +357,9 @@ bool SkipTranslate(TextWithEntities textWithEntities) {
 		? QLocale::English
 		: settingsLang;
 	return (result.locale.language() == skip);
+#else
+    return false;
+#endif
 }
 
 } // namespace Ui


### PR DESCRIPTION
Port from gentoo: https://github.com/gentoo/gentoo/blob/f62d7c6599bbb275f7863bd1fef0f5d31a673703/net-im/telegram-desktop/files/tdesktop-4.3.4-fix-disabling-spellcheck.patch

/var/tmp/portage/net-im/telegram-desktop-4.3.4/work/tdesktop-4.3.4-full/Telegram/SourceFiles/boxes/translate_box.cpp:18:10: fatal error: spellcheck/platform/platform_language.h: No such file or directory
   18 | #include "spellcheck/platform/platform_language.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
