### PR TITLE
Don't use unneeded QEventLoop::ApplicationExec

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -296,8 +296,7 @@ void LaunchGApplication() {
 					Core::App().notifications().createManager();
 				});
 
-				QEventLoop loop;
-				loop.exec(QEventLoop::ApplicationExec);
+				QEventLoop().exec();
 				app->quit();
 			}, true);
 


### PR DESCRIPTION
Fixes (partially) #25513