### PR TITLE
Use std::invoke_result_t not ::result_of to fix C++20 tdesktop 4.3.4

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -356,9 +356,10 @@ void LaunchGApplication() {
 
 			using Window::Notifications::Manager;
 			using NotificationId = Manager::NotificationId;
-			using NotificationIdTuple = std::result_of<
-				decltype(&NotificationId::toTuple)(NotificationId*)
-			>::type;
+			using NotificationIdTuple = std::invoke_result_t<
+				decltype(&NotificationId::toTuple),
+				NotificationId*
+			>;
 
 			const auto notificationIdVariantType = [] {
 				try {


### PR DESCRIPTION
tdesktop defaults to (probably requires) C++20, but `std::result_of`[0]
was deprecated in C++17 and removed in C++20.

0: https://en.cppreference.com/w/cpp/types/result_of
