### PR TITLE
removed downscaling 2560px images before displaying them - #2206

### DIFF
--- a/Telegram/SourceFiles/data/data_photo_media.cpp
+++ b/Telegram/SourceFiles/data/data_photo_media.cpp
@@ -101,14 +101,6 @@ void PhotoMedia::set(
 		QImage image,
 		QByteArray bytes) {
 	const auto index = PhotoSizeIndex(size);
-	const auto limit = PhotoData::SideLimit();
-	if (image.width() > limit || image.height() > limit) {
-		image = image.scaled(
-			limit,
-			limit,
-			Qt::KeepAspectRatio,
-			Qt::SmoothTransformation);
-	}
 	_images[index] = PhotoImage{
 		.data = std::make_unique<Image>(std::move(image)),
 		.bytes = std::move(bytes),


### PR DESCRIPTION

I tested it for, a day, and it looks good enough for me.  I honestly don't see the reason why we would like to downscale them here. 

If we receive 2560px image, we display it as 2560px image. Images sent from tdesktop are still downscaled to 1280px. This behavior is consistent with other telegram clients.

Fixes #2206