### PR TITLE
Use the same check for drag'n'drop image type as for file dialog

### DIFF
--- a/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
@@ -7,17 +7,22 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "ui/chat/attach/attach_extensions.h"
 
+#include <QtCore/QMimeDatabase>
+#include <QtGui/QImageReader>
+
 namespace Ui {
 
 const QStringList &ImageExtensions() {
-	static const auto result = QStringList{
-		u".bmp"_q,
-		u".jpg"_q,
-		u".jpeg"_q,
-		u".png"_q,
-		u".gif"_q,
-	};
-	return result;
+	static const auto result = [] {
+		const auto formats = QImageReader::supportedImageFormats();
+		return formats | ranges::views::transform([](const auto &format) {
+			return '.' + format.toLower();
+		}) | ranges::views::filter([](const auto &format) {
+			const auto mimes = QMimeDatabase().mimeTypesForFileName(format);
+			return mimes.isEmpty()
+				|| !mimes.front().name().startsWith(u"image/"_q);
+		}) | ranges::to<QStringList>;
+	}();
 	return result;
 }
 

--- a/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
@@ -18,15 +18,6 @@ const QStringList &ImageExtensions() {
 		u".gif"_q,
 	};
 	return result;
-}
-
-const QStringList &ExtensionsForCompression() {
-	static const auto result = QStringList{
-		u".bmp"_q,
-		u".jpg"_q,
-		u".jpeg"_q,
-		u".png"_q,
-	};
 	return result;
 }
 

--- a/Telegram/SourceFiles/ui/chat/attach/attach_extensions.h
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_extensions.h
@@ -10,6 +10,5 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Ui {
 
 [[nodiscard]] const QStringList &ImageExtensions();
-[[nodiscard]] const QStringList &ExtensionsForCompression();
 
 } // namespace Ui


### PR DESCRIPTION
The code path when choosing an image in file dialog tries to read a QImage with Images::Read and then only checks that mime type starts with image/ in ValidPhotoForAlbum

Core::FileIsImage and QImageReader::canRead checks should provide the same behavior