### PR TITLE
Remove force-disabling of Qt's color space support for sent images

### DIFF
--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -39,7 +39,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include <QtCore/QBuffer>
 #include <QtGui/QImageWriter>
-#include <QtGui/QColorSpace>
 
 namespace {
 
@@ -181,10 +180,6 @@ struct PreparedFileThumbnail {
 		return bytes;
 	}
 
-	// We have an example of dark .png image that when being sent without
-	// removing its color space is displayed fine on tdesktop, but with
-	// a light gray background on mobile apps.
-	full.setColorSpace(QColorSpace());
 	auto result = QByteArray();
 	QBuffer buffer(&result);
 	QImageWriter writer(&buffer, "JPEG");

--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -56,7 +56,7 @@ ENV CXXFLAGS $CFLAGS
 FROM builder AS patches
 RUN git clone {{ GIT }}/desktop-app/patches.git \
 	&& cd patches \
-	&& git checkout b842feb5f8 \
+	&& git checkout 8edd80d889 \
 	&& rm -rf .git
 
 FROM builder AS nasm

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -397,7 +397,7 @@ if customRunCommand:
 stage('patches', """
     git clone https://github.com/desktop-app/patches.git
     cd patches
-    git checkout b842feb5f8
+    git checkout 8edd80d889
 """)
 
 stage('msys64', """


### PR DESCRIPTION
Qt had a bug with interpreting PNG gamma, but it seems it's fixed now.