### PR TITLE
Don't involve locale in filename timestamp generation

### DIFF
--- a/Telegram/SourceFiles/core/file_utilities.cpp
+++ b/Telegram/SourceFiles/core/file_utilities.cpp
@@ -76,7 +76,7 @@ QString filedialogDefaultName(
 	QString base;
 	if (fileTime) {
 		const auto date = base::unixtime::parse(fileTime);
-		base = prefix + QLocale().toString(date, "_yyyy-MM-dd_HH-mm-ss");
+		base = prefix + date.toString("_yyyy-MM-dd_HH-mm-ss");
 	} else {
 		struct tm tm;
 		time_t t = time(NULL);


### PR DESCRIPTION
It was batch replaced as part of 7b5781b84573ba02cf968b093fa37f23c6b4cb3f, but it's not really semantically valid