### PR TITLE
Get GApplication out of experimental settings

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -389,7 +389,9 @@ NotificationData::NotificationData(
 	NotificationId id)
 : _manager(manager)
 , _id(id)
-, _application(UseGNotification() ? Gio::Application::get_default() : {}) {
+, _application(UseGNotification()
+		? Gio::Application::get_default()
+		: nullptr) {
 }
 
 bool NotificationData::init(

--- a/Telegram/SourceFiles/settings/settings_experimental.cpp
+++ b/Telegram/SourceFiles/settings/settings_experimental.cpp
@@ -148,7 +148,7 @@ void SetupExperimental(
 	addToggle(Settings::kOptionMonoSettingsIcons);
 	addToggle(Webview::kOptionWebviewDebugEnabled);
 	addToggle(kOptionAutoScrollInactiveChat);
-	addToggle(Windows::Notifications::kOptionGNotification);
+	addToggle(Window::Notifications::kOptionGNotification);
 }
 
 } // namespace

--- a/Telegram/SourceFiles/window/notifications_manager.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager.cpp
@@ -7,6 +7,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "window/notifications_manager.h"
 
+#include "base/options.h"
 #include "platform/platform_notifications_manager.h"
 #include "window/notifications_manager_default.h"
 #include "media/audio/media_audio_track.h"


### PR DESCRIPTION
GApplication will always be used on Linux now. GNotification gets a toggle instead.