### PR TITLE
Install launcher on every launch on Linux

### DIFF
--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -240,7 +240,6 @@ void Application::run() {
 	refreshGlobalProxy(); // Depends on app settings being read.
 
 	if (const auto old = Local::oldSettingsVersion(); old < AppVersion) {
-		Platform::InstallLauncher();
 		InvokeQueued(this, [] { RegisterUrlScheme(); });
 		Platform::NewVersionLaunched(old);
 	}

--- a/Telegram/SourceFiles/platform/mac/specific_mac.h
+++ b/Telegram/SourceFiles/platform/mac/specific_mac.h
@@ -33,9 +33,6 @@ inline bool SkipTaskbarSupported() {
 	return false;
 }
 
-inline void InstallLauncher(bool force) {
-}
-
 void ActivateThisProcess();
 
 inline uint64 ActivationWindowId(not_null<QWidget*> window) {

--- a/Telegram/SourceFiles/platform/platform_specific.h
+++ b/Telegram/SourceFiles/platform/platform_specific.h
@@ -42,7 +42,6 @@ bool TrayIconSupported();
 bool SkipTaskbarSupported();
 void WriteCrashDumpDetails();
 void NewVersionLaunched(int oldVersion);
-void InstallLauncher(bool force = false);
 
 [[nodiscard]] std::optional<bool> IsDarkMode();
 [[nodiscard]] inline bool IsDarkModeSupported() {

--- a/Telegram/SourceFiles/platform/win/specific_win.h
+++ b/Telegram/SourceFiles/platform/win/specific_win.h
@@ -27,9 +27,6 @@ inline bool SkipTaskbarSupported() {
 	return true;
 }
 
-inline void InstallLauncher(bool force) {
-}
-
 inline void ActivateThisProcess() {
 }
 

--- a/Telegram/SourceFiles/settings/settings_codes.cpp
+++ b/Telegram/SourceFiles/settings/settings_codes.cpp
@@ -7,7 +7,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "settings/settings_codes.h"
 
-#include "platform/platform_specific.h"
 #include "ui/toast/toast.h"
 #include "mainwidget.h"
 #include "mainwindow.h"
@@ -179,10 +178,6 @@ auto GenerateCodes() {
 	codes.emplace(u"registertg"_q, [](SessionController *window) {
 		Core::Application::RegisterUrlScheme();
 		Ui::Toast::Show("Forced custom scheme register.");
-	});
-	codes.emplace(u"installlauncher"_q, [](SessionController *window) {
-		Platform::InstallLauncher(true);
-		Ui::Toast::Show("Forced launcher installation.");
 	});
 
 #if defined Q_OS_WIN || defined Q_OS_MAC


### PR DESCRIPTION
Just like AppUserModelId on Windows

This makes the cheat code and having the function outside of private namespace unnecessary