### PR TITLE
Use window widget's devicePixelRatio when displaying interface scale value

### DIFF
--- a/Telegram/SourceFiles/settings/settings_main.cpp
+++ b/Telegram/SourceFiles/settings/settings_main.cpp
@@ -474,7 +474,8 @@ void SetupInterfaceScale(
 			if constexpr (Platform::IsMac()) {
 				return QString::number(scale) + '%';
 			} else {
-				return QString::number(scale * ratio) + '%';
+				const auto ratio = window->widget()->devicePixelRatioF();
+				return QString::number(int(scale * ratio)) + '%';
 			}
 		};
 		label->setText(labelText(cEvalScale(scale)));


### PR DESCRIPTION
This is less confusing in multi-monitor environments

Makes #25856 less confusing