### PR TITLE
Deduplicate notification actions on Linux

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -337,7 +337,7 @@ void LaunchGApplication() {
 		}();
 
 		app->add_action_with_parameter(
-			"notification-reply",
+			"notification-activate",
 			notificationIdVariantType,
 			[](const Glib::VariantBase &parameter) {
 				Core::Sandbox::Instance().customEnterFromEventLoop([&] {


### PR DESCRIPTION
As there are notification daemons with quick reply support and GNotification API having mandatory default action support now, it's the time to reconsider button arrangement.

This also makes it possible for legacy notification daemons without default action support opening the chat when no buttons are allowed since 05524c3f6c5a1a4688ed111b51317970b22fac8e again.