### PR TITLE
Remove pre-defined title from feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -2,7 +2,6 @@
 name: Feature request
 description: Suggest an idea.
 labels: [enhancement]
-title: "[Feature Request] "
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
There are labels for this purpose, pre-defined title lets people to not to think about the title what leads to feature requests not having title