### PR TITLE
CMake: Define the SDK (Windows) version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ if (APPLE)
 endif()
 
 if (WIN32)
-	set(CMAKE_SYSTEM_VERSION 10.0.22000.0)
-endif()
-
-if (WIN32)
 	if(NOT ${CMAKE_GENERATOR} STREQUAL "Visual Studio 17 2022")
 		message(SEND_ERROR "It will not be possible to build codegen_emoji and therefore lib_ui on ${CMAKE_GENERATOR} (Please use Visual Studio 17 2022)")
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ if (APPLE)
     set(project_langs C CXX OBJC OBJCXX)
 endif()
 
+if (WIN32)
+	set(CMAKE_SYSTEM_VERSION 10.0.22000.0)
+endif()
+
 project(Telegram
     LANGUAGES ${project_langs}
     VERSION ${desktop_app_version_cmake}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ if (WIN32)
 	set(CMAKE_SYSTEM_VERSION 10.0.22000.0)
 endif()
 
+if (WIN32)
+	if(NOT ${CMAKE_GENERATOR} STREQUAL "Visual Studio 17 2022")
+		message(SEND_ERROR "It will not be possible to build codegen_emoji and therefore lib_ui on ${CMAKE_GENERATOR} (Please use Visual Studio 17 2022)")
+	endif()
+endif()
+
 project(Telegram
     LANGUAGES ${project_langs}
     VERSION ${desktop_app_version_cmake}


### PR DESCRIPTION
I suggest that you define the SDK (Windows) version in CMakeLists.txt so that CMake will set this version when generating code.

The version you propose to use in https://github.com/telegramdesktop/tdesktop/blob/dev/docs/building-win.md:
![image](https://user-images.githubusercontent.com/51059739/227724387-33e27f38-72bf-45ce-b466-6cc0da97e4ba.png)

This PR, I assume, will solve the problem:
https://github.com/telegramdesktop/tdesktop/issues/8361
https://github.com/desktop-app/lib_ui/issues/112