### PR TITLE
Explicitly specify QVector element type to fix build with clang13+range-v3+qt6

### DIFF
--- a/Telegram/SourceFiles/api/api_chat_filters.cpp
+++ b/Telegram/SourceFiles/api/api_chat_filters.cpp
@@ -227,7 +227,7 @@ void ImportInvite(
 	};
 	auto inputs = peers | ranges::views::transform([](auto peer) {
 		return MTPInputPeer(peer->input);
-	}) | ranges::to<QVector>();
+	}) | ranges::to<QVector<MTPInputPeer>>();
 	if (!slug.isEmpty()) {
 		api->request(MTPchatlists_JoinChatlistInvite(
 			MTP_string(slug),

--- a/Telegram/SourceFiles/boxes/filters/edit_filter_links.cpp
+++ b/Telegram/SourceFiles/boxes/filters/edit_filter_links.cpp
@@ -1028,7 +1028,7 @@ void ExportFilterLink(
 	const auto session = &front->session();
 	auto mtpPeers = peers | ranges::views::transform(
 		[](not_null<PeerData*> peer) { return MTPInputPeer(peer->input); }
-	) | ranges::to<QVector>();
+	) | ranges::to<QVector<MTPInputPeer>>();
 	session->api().request(MTPchatlists_ExportChatlistInvite(
 		MTP_inputChatlistDialogFilter(MTP_int(id)),
 		MTP_string(), // title
@@ -1061,7 +1061,7 @@ void EditLinkChats(
 	const auto session = &front->session();
 	auto mtpPeers = peers | ranges::views::transform(
 		[](not_null<PeerData*> peer) { return MTPInputPeer(peer->input); }
-	) | ranges::to<QVector>();
+	) | ranges::to<QVector<MTPInputPeer>>();
 	session->api().request(MTPchatlists_EditExportedInvite(
 		MTP_flags(MTPchatlists_EditExportedInvite::Flag::f_peers),
 		MTP_inputChatlistDialogFilter(MTP_int(link.id)),

--- a/Telegram/SourceFiles/settings/settings_folders.cpp
+++ b/Telegram/SourceFiles/settings/settings_folders.cpp
@@ -696,7 +696,7 @@ void FilterRowButton::paintEvent(QPaintEvent *e) {
 					row.removePeers
 				) | ranges::views::transform([](not_null<PeerData*> peer) {
 					return MTPInputPeer(peer->input);
-				}) | ranges::to<QVector>();
+				}) | ranges::to<QVector<MTPInputPeer>>();
 				removeChatlistRequests.push_back(
 					MTPchatlists_LeaveChatlist(
 						MTP_inputChatlistDialogFilter(MTP_int(newId)),

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -494,7 +494,7 @@ void FiltersMenu::remove(
 				leave
 			) | ranges::views::transform([](not_null<PeerData*> peer) {
 				return MTPInputPeer(peer->input);
-			}) | ranges::to<QVector>())
+			}) | ranges::to<QVector<MTPInputPeer>>())
 		)).done([=](const MTPUpdates &result) {
 			api->applyUpdates(result);
 		}).send();


### PR DESCRIPTION
Same story as 2b383a4 for #24014.
Fixes 4.8.0 build on OpenBSD/amd64 7.3 with clang 13.0.0, range-v3 0.12.0 and Qt 6.5.0.
