### PR TITLE
Export plaintext message content in JSON `text` field

### DIFF
--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -158,9 +158,6 @@ QByteArray SerializeText(
 	const auto text = ranges::views::all(
 		data
 	) | ranges::views::transform([&](const Data::TextPart &part) {
-		if ((part.type == Type::Text) && !serializeToObjects) {
-			return SerializeString(part.text);
-		}
 		const auto typeString = [&] {
 			switch (part.type) {
 			case Type::Unknown: return "unknown";
@@ -187,6 +184,10 @@ QByteArray SerializeText(
 			}
 			Unexpected("Type in SerializeText.");
 		}();
+		if (!serializeToObjects) {
+			return SerializeString(part.text);
+		}
+
 		const auto additionalName = (part.type == Type::MentionName)
 			? "user_id"
 			: (part.type == Type::CustomEmoji)
@@ -213,9 +214,14 @@ QByteArray SerializeText(
 	context.nesting.pop_back();
 
 	if (!serializeToObjects) {
-		if (data.size() == 1 && data[0].type == Data::TextPart::Type::Text) {
-			return text[0];
+		auto result = QByteArray();
+		result.append('"');
+		for (const auto &part : text) {
+			result.append(part.mid(1, part.size() - 2));
 		}
+		result.append('"');
+		return result;
+
 	}
 	return SerializeArray(context, text);
 }


### PR DESCRIPTION
**Related Problem**
As of v4.8.1, when exporting chats as JSON, the `text` fields of messages has two return types:

1. `string` if message is entirely in plain text, with no message entities
2. `array` of mixed types otherwise (`string` for plain text, `object` for styled text)

This was first identified in #25000.

Consider the following message:

> Lorem ipsum dolor sit **amet, consectetur** _adipiscing elit._
> `Morbi lobortis` lacus eget leo iaculis maximus.

The `text` field of the resulting JSON export for the message is 
```json
"text": [
    "Lorem ipsum dolor sit",
    {
     "type": "bold",
     "text": " amet, consectetur"
    },
    " ",
    {
     "type": "italic",
     "text": "adipiscing elit"
    },
    ".\n",
    {
     "type": "code",
     "text": "Morbi lobortis"
    },
    " lacus eget leo iaculis maximus."
   ],
```

**Proposed Solution**
Concatenate the plaintext content for all message entities, producing a single string for the text field.

For example, the `text` and `text_entity` fields for message above would be exported as
```json
{
   "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nMorbi lobortis lacus eget leo iaculis maximus.",
   "text_entities": [
    {
     "type": "plain",
     "text": "Lorem ipsum dolor sit"
    },
    {
     "type": "bold",
     "text": " amet, consectetur"
    },
    {
     "type": "plain",
     "text": " "
    },
    {
     "type": "italic",
     "text": "adipiscing elit"
    },
    {
     "type": "plain",
     "text": ".\n"
    },
    {
     "type": "code",
     "text": "Morbi lobortis"
    },
    {
     "type": "plain",
     "text": " lacus eget leo iaculis maximus."
    }
   ]
  }
```

This behaviour is also in keeping with the Telegram API and Bot API, where Message objects have `message` and `text` fields respectively for storing the plaintext content of a message.