### PR TITLE
Fix gobject-inrospection dependency in snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,12 +97,12 @@ parts:
       - LDFLAGS: -s
     build-packages:
       - clang
-      - gobject-introspection
       - python3
       - libasound2-dev
       - libavif-dev
       - libboost-program-options-dev
       - libfmt-dev
+      - libgirepository1.0-dev
       - libheif-dev
       - libopus-dev
       - libpulse-dev


### PR DESCRIPTION
Debian's weird package naming goes on