### PR TITLE
snap: connect to the network-bind interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,7 @@ apps:
       - hardware-observe
       - home
       - network
+      - network-bind
       - network-status
       - opengl
       - removable-media


### PR DESCRIPTION
snap: connect to the network-bind interface, necessary on systems where desktop-legacy isn't supported like Ubuntu Core Desktop.