### PR TITLE
Use absolute path of sed instead

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -489,7 +489,7 @@ stage('xz', """
 !win:
     git clone -b v5.2.9 https://git.tukaani.org/xz.git
     cd xz
-    sed -i '' '\\@check_symbol_exists(futimens "sys/types.h;sys/stat.h" HAVE_FUTIMENS)@d' CMakeLists.txt
+    /usr/bin/sed -i '' '\\@check_symbol_exists(futimens "sys/types.h;sys/stat.h" HAVE_FUTIMENS)@d' CMakeLists.txt
     CFLAGS="$UNGUARDED" CPPFLAGS="$UNGUARDED" cmake -B build . \\
         -D CMAKE_OSX_DEPLOYMENT_TARGET:STRING=$MACOSX_DEPLOYMENT_TARGET \\
         -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64" \\


### PR DESCRIPTION
I installed and linked gnu-sed and it would fail here. I need to explicitly specify /usr/bin/sed to resolve this.