### PR TITLE
Get rid of QOpenGLWidget in main_window_mac

### DIFF
--- a/Telegram/SourceFiles/platform/mac/main_window_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/main_window_mac.mm
@@ -238,7 +238,6 @@ MainWindow::MainWindow(not_null<Window::Controller*> controller)
 : Window::MainWindow(controller)
 , _private(std::make_unique<Private>(this))
 , psMainMenu(this) {
-	auto forceOpenGL = std::make_unique<QOpenGLWidget>(this);
 	_hideAfterFullScreenTimer.setCallback([this] { hideAndDeactivate(); });
 }
 


### PR DESCRIPTION
ui_window_mac has logic depending on Qt version to use Metal when possible, this will conflict once Qt is updated to 6.4+