### PR TITLE
Update building-mac.md

### DIFF
--- a/docs/building-mac.md
+++ b/docs/building-mac.md
@@ -13,7 +13,7 @@ You will require **api_id** and **api_hash** to access the Telegram API servers.
 Go to ***BuildPath*** and run
 
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    brew install git automake cmake wget pkg-config gnu-tar
+    brew install git automake cmake wget pkg-config gnu-tar ninja
 
     sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
 


### PR DESCRIPTION
I started the build process on a new mac and ninja is required to run prepare.py, let's fix the document.