### PR TITLE
Fix D-Bus service with non-standard workdir or backslash in the path

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -346,12 +346,16 @@ bool GenerateServiceFile(bool silent = false) {
 		"Name",
 		QGuiApplication::desktopFileName().toStdString());
 
+	QStringList exec;
+	exec.append(executable);
+	if (Core::Launcher::Instance().customWorkingDir()) {
+		exec.append(u"-workdir"_q);
+		exec.append(cWorkingDir());
+	}
 	target->set_string(
 		group,
 		"Exec",
-		KShell::joinArgs({ executable }).replace(
-			'\\',
-			qstr("\\\\")).toStdString());
+		KShell::joinArgs(exec).toStdString());
 
 	try {
 		target->save_to_file(targetFile.toStdString());


### PR DESCRIPTION
Working dir not set leads to unrelevant instance being launched with unrelevant bus name and entire launchf fails.

D-Bus service files also don't need backslash escaping unlike the .desktop files.