### PR TITLE
Make dark mode update go through Qt code on Linux

### DIFF
--- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
@@ -16,6 +16,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/random.h"
 
 #include <QtCore/QAbstractEventDispatcher>
+#include <qpa/qwindowsysteminterface.h>
 
 #include <glibmm.h>
 #include <gio/gio.hpp>
@@ -212,6 +213,9 @@ LinuxIntegration::LinuxIntegration()
 	const Glib::VariantBase &value) {
 	if (group == "org.freedesktop.appearance"
 		&& key == "color-scheme") {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+		QWindowSystemInterface::handleThemeChange();
+#else // Qt >= 6.5.0
 		try {
 			const auto ivalue = value.get_dynamic<uint>();
 
@@ -220,6 +224,7 @@ LinuxIntegration::LinuxIntegration()
 			});
 		} catch (...) {
 		}
+#endif // Qt < 6.5.0
 	}
 }) {
 	LOG(("Icon theme: %1").arg(QIcon::themeName()));

--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -59,7 +59,7 @@ FROM builder AS patches
 RUN git init patches \
 	&& cd patches \
 	&& git remote add origin {{ GIT }}/desktop-app/patches.git \
-	&& git fetch --depth=1 origin edafe1a2484cd6ac9be357aa1e4cda61bf6a8b9a \
+	&& git fetch --depth=1 origin dbd8a5b00f5a0e7e09b11878b9e46afeb4b593c0 \
 	&& git reset --hard FETCH_HEAD \
 	&& rm -rf .git
 


### PR DESCRIPTION
This makes the behavior consistent and is possible now thanks to a Qt patch

Depends on https://github.com/desktop-app/patches/pull/149
Fixes #26461
Relates to #26370