### PR TITLE
Don't use crl::on_main unnecessarily with XDP::SettingWatcher

### DIFF
--- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
@@ -216,14 +216,13 @@ LinuxIntegration::LinuxIntegration()
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 		QWindowSystemInterface::handleThemeChange();
 #else // Qt >= 6.5.0
-		try {
-			const auto ivalue = value.get_dynamic<uint>();
-
-			crl::on_main([=] {
-				Core::App().settings().setSystemDarkMode(ivalue == 1);
-			});
-		} catch (...) {
-		}
+		Core::Sandbox::Instance().customEnterFromEventLoop([&] {
+			try {
+				Core::App().settings().setSystemDarkMode(
+					value.get_dynamic<uint>() == 1);
+			} catch (...) {
+			}
+		});
 #endif // Qt < 6.5.0
 	}
 }) {


### PR DESCRIPTION
g_dbus_connection_signal_subscribe calls the callback on the same thread