### PR TITLE
Get rid of sandboxed paths workaround

### DIFF
--- a/Telegram/SourceFiles/platform/linux/file_utilities_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/file_utilities_linux.cpp
@@ -96,11 +96,6 @@ bool Get(
 	if (parent) {
 		parent = parent->window();
 	}
-	// Workaround for sandboxed paths
-	static const auto docRegExp = QRegularExpression("^/run/user/\\d+/doc");
-	if (cDialogLastPath().contains(docRegExp)) {
-		InitLastPath();
-	}
 	return ::FileDialog::internal::GetDefault(
 		parent,
 		files,


### PR DESCRIPTION
This is fixed in xdg-desktop-portal 1.17.

There's no way to check xdg-desktop-portal version so it's either not having support for passing last used path at all in sandbox or encountering the bug on old systems.