### PR TITLE
Fix version used in snapcraft for desktop-app/patches.git repo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,6 +172,7 @@ parts:
   patches:
     source: https://github.com/desktop-app/patches.git
     source-depth: 1
+    source-commit: 6442ae042bb6d43391747f7413c7a88a6a37c7ef
     plugin: dump
     override-pull: |
       craftctl default


### PR DESCRIPTION
Fix version used in snapcraft for desktop-app/patches.git repo.
Otherwise snap build uses latest, and anything, but latest dev branch - is not buildable anymore.

Dockerfile: https://github.com/telegramdesktop/tdesktop/blob/dev/Telegram/build/docker/centos_env/Dockerfile#L57
snapcraft: https://github.com/telegramdesktop/tdesktop/blob/dev/snap/snapcraft.yaml#L173

Also: 
There are two other differences between snapcraft.yml and Docker file
I am not sure which of two is the right in each case. Happy to include in this PR if codeowners decide what is the right fix.

## rnnoise
Docker: specifies master
Snapcraft: specifies 7f449bf8bd3b933891d12c30112268c4090e4d59
they are the same, but semantic is different. Dockerfile can pickup accidental update from rnnoise project

## Protobuf:
Docker file: -b v21.9
Snapcraft: source-tag: v24.3
These tags are different