### PR TITLE
replace Ctrl+F by F for full screen

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -5078,7 +5078,7 @@ void OverlayWidget::handleKeyPress(not_null<QKeyEvent*> e) {
 			return;
 		}
 	} else if (_streamed) {
-		// Ctrl + F for full screen toggle is in eventFilter().
+		// F for full screen toggle is in eventFilter().
 		const auto toggleFull = (modifiers.testFlag(Qt::AltModifier) || ctrl)
 			&& (key == Qt::Key_Enter || key == Qt::Key_Return);
 		if (toggleFull) {
@@ -6006,7 +6006,7 @@ bool OverlayWidget::filterApplicationEvent(
 		const auto event = static_cast<QKeyEvent*>(e.get());
 		const auto key = event->key();
 		const auto ctrl = event->modifiers().testFlag(Qt::ControlModifier);
-		if (key == Qt::Key_F && ctrl && _streamed) {
+		if (key == Qt::Key_F && _streamed) {
 			playbackToggleFullScreen();
 			return true;
 		} else if (key == Qt::Key_0 && ctrl) {


### PR DESCRIPTION
F as a hotkey is commonly used for toggling full screen and is used in Telegram Web too. Also, there are hotkeys in Telegram Web such as Shift+F, Alt+F, and Ctrl+F that make video go fullscreen.

Previously Ctrl+F hotkey used to make the search bar active, but as far as I can see it got fixed by now.

Closes #25866