### PR TITLE
Fix getting the screen of viewer/pip

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -817,7 +817,7 @@ void OverlayWidget::moveToScreen(bool inMove) {
 		? Core::App().activeWindow()->widget().get()
 		: nullptr;
 	const auto activeWindowScreen = widgetScreen(applicationWindow);
-	const auto myScreen = widgetScreen(_window);
+	const auto myScreen = _window->screen();
 	if (activeWindowScreen && myScreen != activeWindowScreen) {
 		const auto screenList = QGuiApplication::screens();
 		DEBUG_LOG(("Viewer Pos: Currently on screen %1, moving to screen %2")

--- a/Telegram/SourceFiles/media/view/media_view_pip.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_pip.cpp
@@ -514,8 +514,8 @@ void PipPanel::setPositionDefault() {
 		return widget->screen();
 	};
 	const auto parentScreen = widgetScreen(_parent);
-	const auto myScreen = widgetScreen(widget());
-	if (parentScreen && myScreen && myScreen != parentScreen) {
+	const auto myScreen = widget()->screen();
+	if (parentScreen && myScreen != parentScreen) {
 		widget()->windowHandle()->setScreen(parentScreen);
 	}
 	auto position = Position();

--- a/Telegram/cmake/lib_prisma.cmake
+++ b/Telegram/cmake/lib_prisma.cmake
@@ -30,8 +30,6 @@ PRIVATE
 )
 
 target_include_directories(lib_prisma
-PRIVATE
-    ${libs_loc}/regex/include
 PUBLIC
     ${prisma_loc}
 )


### PR DESCRIPTION
We need to workaround getting the actual screen for the parent by getting its position yet we need to get the setted screen for the widget itself as that's the screen used to compute the geometry

Fixes #26952