### PR TITLE
Fix macos build, use xcode 15

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -40,7 +40,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: macos-12
+    runs-on: macos-13
 
     strategy:
       matrix:
@@ -69,7 +69,7 @@ jobs:
           # Disable spotlight.
           sudo mdutil -a -i off
 
-          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_15.0.app/Contents/Developer
 
       - name: ThirdParty cache.
         id: cache-third-party


### PR DESCRIPTION
MacOS workflow is failing for few days already. 
CMake sets -ld_classic flag, that exists in xcode 15 only, but default is xcode 14.2 / 14.3.