### PR TITLE
Fix order of colors in name color settings

### DIFF
--- a/Telegram/SourceFiles/boxes/peers/edit_peer_color_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_color_box.cpp
@@ -206,10 +206,10 @@ void ColorSample::paintEvent(QPaintEvent *e) {
 		p.setPen(Qt::NoPen);
 		if (colors.outlines[1].alpha()) {
 			p.rotate(-45.);
-			p.setClipRect(-size, 0, 3 * size, size);
+			p.setClipRect(-size, -size, 3 * size, size);
 			p.setBrush(colors.outlines[1]);
 			p.drawEllipse(full);
-			p.setClipRect(-size, -size, 3 * size, size);
+			p.setClipRect(-size, 0, 3 * size, size);
 		}
 		p.setBrush(colors.outlines[0]);
 		p.drawEllipse(full);


### PR DESCRIPTION
This makes it consistent with iOS and Android apps.

## iOS

![image](https://github.com/telegramdesktop/tdesktop/assets/49933115/59dd8b00-61e9-4da7-acd9-3823f201bf89)

Notice how the colors in the last style from top left to bottom right are: yellow, white, blue.

## Currently

![image](https://github.com/telegramdesktop/tdesktop/assets/49933115/1afd3d1b-a949-411b-bf5a-c83e2b8356fa)

Notice how they are reversed here: blue, white, yellow. All others are reversed, too.

## This pull request

![image](https://github.com/telegramdesktop/tdesktop/assets/49933115/8ef700fd-b4ab-4caf-b17c-a963ebd07507)

