### PR TITLE
Fix crash on some videos

### DIFF
--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
@@ -521,7 +521,7 @@ AVRational ValidateAspectRatio(AVRational aspect) {
 QSize CorrectByAspect(QSize size, AVRational aspect) {
 	Expects(IsValidAspectRatio(aspect));
 
-	return QSize(size.width() * aspect.num / aspect.den, size.height());
+	return QSize(size.width() * av_q2d(aspect), size.height());
 }
 
 bool RotationSwapWidthHeight(int rotation) {


### PR DESCRIPTION
This fixes issue #26917 when the client crashed playing a video with a non-standard SAR (pixel size) due to an incorrect calculation of the video width, it was -1034