### PR TITLE
add bash shebang

### DIFF
--- a/Telegram/build/prepare/linux.sh
+++ b/Telegram/build/prepare/linux.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 FullExecPath=$PWD
 pushd `dirname $0` > /dev/null


### PR DESCRIPTION
I was having problems when running the script with zsh. Adding a bash shebang avoids that.

```
./Telegram/build/prepare/linux.sh: 3: pushd: not found
```