### PR TITLE
Prefer IPv6 over IPv4 for connection test

### DIFF
--- a/Telegram/SourceFiles/mtproto/session_private.cpp
+++ b/Telegram/SourceFiles/mtproto/session_private.cpp
@@ -185,7 +185,7 @@ void SessionPrivate::appendTestConnection(
 		const bytes::vector &protocolSecret) {
 	QWriteLocker lock(&_stateMutex);
 
-	const auto priority = (qthelp::is_ipv6(ip) ? 0 : 1)
+	const auto priority = (qthelp::is_ipv6(ip) ? 1 : 0)
 		+ (protocol == DcOptions::Variants::Tcp ? 1 : 0)
 		+ (protocolSecret.empty() ? 0 : 1);
 	_testConnections.push_back({


### PR DESCRIPTION
It is almost 2024 and there is no reason to perfer IPv4 over IPv6, especially in tdesktop user still need to toggle a switch to enable IPv6.

For tdesktop's connect test, if user does not have a routable IPv6 address, onDisconnect will be called promptly to fallback to another connection. If user's IPv6 connection is somehow filtering out connection to telegram's server, it will wait until kWaitForBetterTimeout and then fallback to another connection.

This implementation is actually in spirit of happy eyeballs recommandation.

Fixes: https://github.com/telegramdesktop/tdesktop/issues/2198