### PR TITLE
Fix scroll issue in media view on some logitech hi-res wheel mouse

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -5186,27 +5186,43 @@ void OverlayWidget::handleKeyPress(not_null<QKeyEvent*> e) {
 void OverlayWidget::handleWheelEvent(not_null<QWheelEvent*> e) {
 	constexpr auto step = int(QWheelEvent::DefaultDeltasPerStep);
 
+	const auto _thisWheelDelta = e->angleDelta().y();
 	const auto acceptForJump = !_stories
 		&& ((e->source() == Qt::MouseEventNotSynthesized)
 			|| (e->source() == Qt::MouseEventSynthesizedBySystem));
-	_verticalWheelDelta += e->angleDelta().y();
-	while (qAbs(_verticalWheelDelta) >= step) {
-		if (_verticalWheelDelta < 0) {
-			_verticalWheelDelta += step;
+
+	const bool directionChanges =
+		std::signbit(_lastWheelDelta) != std::signbit(_thisWheelDelta);
+
+	if ((qAbs(_thisWheelDelta) != step) && directionChanges) {
+		// linux: first scroll after direction changes on hi-res wheel in
+		// libinput is unreliable. offen lost first half of it's value,
+		// or even only remain one with 15 delta, so we just hardcode it
+		// to same as step here, other system should be fine too.
+		_absWheelDelta = _thisWheelDelta > 0 ? step : step * -1;
+	} else {
+		_absWheelDelta += _thisWheelDelta;
+	}
+
+	while (qAbs(_absWheelDelta) >= step) {
+		if (_absWheelDelta < 0) {
+			// _absWheelDelta += step;
 			if (e->modifiers().testFlag(Qt::ControlModifier)) {
 				zoomOut();
 			} else if (acceptForJump) {
 				moveToNext(1);
 			}
 		} else {
-			_verticalWheelDelta -= step;
+			// _absWheelDelta -= step;
 			if (e->modifiers().testFlag(Qt::ControlModifier)) {
 				zoomIn();
 			} else if (acceptForJump) {
 				moveToNext(-1);
 			}
 		}
+		_absWheelDelta = 0; // reset to 0 to reduce pic move jump or skip.
 	}
+	_lastWheelDelta = _thisWheelDelta; // record last wheel delta
 }
 
 void OverlayWidget::setZoomLevel(int newZoom, bool force) {

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -725,7 +725,8 @@ private:
 	rpl::event_stream<TouchBarItemType> _touchbarDisplay;
 	rpl::event_stream<bool> _touchbarFullscreenToggled;
 
-	int _verticalWheelDelta = 0;
+	int _absWheelDelta = 0;
+	int _lastWheelDelta = 0;
 
 	bool _themePreviewShown = false;
 	uint64 _themePreviewId = 0;


### PR DESCRIPTION
on some hi-res wheel supported mouse, the scroll experience is not good. at least on my logitech g903 ls, when I ↑↓↑↓ my wheel for compare two picture, the first scroll that after scroll direction changed will always lost.

closes #27252

---
related links:
- https://gitlab.freedesktop.org/libinput/libinput/-/issues/889
- https://gitlab.freedesktop.org/libinput/libinput/-/issues/814
- https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2668
- https://gitlab.freedesktop.org/xorg/xserver/-/issues/1578
- https://www.phoronix.com/news/Linux-Disable-HiRes-Scroll-USB