### PR TITLE
Disable system proxy support on Linux

### DIFF
--- a/Telegram/SourceFiles/core/sandbox.cpp
+++ b/Telegram/SourceFiles/core/sandbox.cpp
@@ -33,6 +33,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtGui/QSessionManager>
 #include <QtGui/QScreen>
 #include <QtGui/qpa/qplatformscreen.h>
+#include <ksandbox.h>
 
 namespace Core {
 namespace {
@@ -517,8 +518,10 @@ void Sandbox::refreshGlobalProxy() {
 		|| proxy.type == MTP::ProxyData::Type::Http) {
 		QNetworkProxy::setApplicationProxy(
 			MTP::ToNetworkProxy(MTP::ToDirectIpProxy(proxy)));
-	} else if (!Core::IsAppLaunched()
-		|| Core::App().settings().proxy().isSystem()) {
+	} else if ((!Core::IsAppLaunched()
+		|| Core::App().settings().proxy().isSystem())
+		// this works stable only in sandboxed environment where it works through portal
+		&& (!Platform::IsLinux() || KSandbox::isInside() || cDebugMode())) {
 		QNetworkProxyFactory::setUseSystemConfiguration(true);
 	} else {
 		QNetworkProxy::setApplicationProxy(QNetworkProxy::NoProxy);


### PR DESCRIPTION
Reading system proxy on Linux reads to massive crashes in system libraries.

Since those crashes are unreproducible in development environment, it's not possible to find the root cause.

Workarounds #27482.