### PR TITLE
Remove no longer needed boost-program-options from snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,7 +96,6 @@ parts:
       - python3
       - libasound2-dev
       - libavif-dev
-      - libboost-program-options1.74-dev
       - libboost-regex1.74-dev
       - libfmt-dev
       - libgirepository1.0-dev


### PR DESCRIPTION
Looks like cppgir has stopped to use it during some of the updates