### PR TITLE
Fixes #26012 libvpx build on VS 17.8+ 

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -855,9 +855,9 @@ win:
     SET MSYS2_PATH_TYPE=inherit
 
     if "%X8664%" equ "x64" (
-        SET "TARGET=x86_64-win64-vs17"
+        SET "TOOLCHAIN=x86_64-win64-vs17"
     ) else (
-        SET "TARGET=x86-win32-vs17"
+        SET "TOOLCHAIN=x86-win32-vs17"
     )
 
 depends:patches/build_libvpx_win.sh

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -418,7 +418,7 @@ if customRunCommand:
 stage('patches', """
     git clone https://github.com/desktop-app/patches.git
     cd patches
-    git checkout 94be868240
+    git checkout bed08b53a3
 """)
 
 stage('msys64', """


### PR DESCRIPTION
Fix libvpx build on VS 17.8+
used with https://github.com/desktop-app/patches/pull/182
Fixes #26012

i haven't updated commit point in snap & docker because they were on different sha from prepare.py and they don't need this fix.