### PR TITLE
Fix Mac build (disable qt_feature_brotli)

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1512,11 +1512,11 @@ mac:
         -system-webp \
         -I "$USED_PREFIX/include" \
         -no-feature-futimens \
+        -no-feature-brotli \
         -nomake examples \
         -nomake tests \
         -platform macx-clang -- \
         -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
-        -DQT_FEATURE_brotli=OFF \
         -DCMAKE_PREFIX_PATH="$USED_PREFIX"
 
     ninja


### PR DESCRIPTION
Explicitly disable brotli in QT build.
It was accidentally brought in by libjxl and leads to unresolved symbol linker errors on Mac

Fixes #27560