### PR TITLE
Update mac build instructions with up-to-date homebrew link

### DIFF
--- a/docs/building-mac.md
+++ b/docs/building-mac.md
@@ -12,7 +12,7 @@ You will require **api_id** and **api_hash** to access the Telegram API servers.
 
 Go to ***BuildPath*** and run
 
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     brew install git automake cmake wget pkg-config gnu-tar ninja nasm meson
 
     sudo xcode-select -s /Applications/Xcode.app/Contents/Developer


### PR DESCRIPTION
https://raw.githubusercontent.com/Homebrew/install/master/install returns 404

I've provided a correct url, just not sure why use `/bin/bash -c` instead of `ruby -e`