### PR TITLE
 Fix Mac build (disable qt_feature_brotli)

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1512,6 +1512,7 @@ mac:
         -system-webp \
         -I "$USED_PREFIX/include" \
         -no-feature-futimens \
+        -no-feature-brotli \
         -nomake examples \
         -nomake tests \
         -platform macx-clang -- \


### PR DESCRIPTION
Explicitly disable brotli in QT build.
It was accidentally brought in by libjxl and leads to unresolved symbol linker errors on Mac

Fixes #27560 