### PR TITLE
fix mac build on github

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -64,7 +64,11 @@ jobs:
       - name: First set up.
         run: |
           sudo chown -R `whoami`:admin /usr/local/share
-          brew install automake ninja pkg-config nasm meson
+          brew install automake ninja pkg-config nasm
+          # meson@1.4.0 depends on python 3.12 that is already installed
+          # but howbrew tries to install it again and failed
+          # solution: just install meson w/o dependencies
+          brew install --ignore-dependencies meson
 
           # Disable spotlight.
           sudo mdutil -a -i off


### PR DESCRIPTION
homebrew has recently updated version of meson to 1.4.0. This version depends on python 3.12. Homebrew tries to install it and get into conflict, because python 3.12 already installed and can't be replaced.

Previous meson version was 1.3.4. It had python3-11 as a dependency and homebrew was not trying to install it on GH runners. Unfortunately older version is not available (install meson@1.3.4 does not work).

Right solution most likely should be to fix homebrew to detect that python 3.12 already installed. But I am not familiar with that.

Solution in this PR - installs meson only w/o dependencies. 
https://formulae.brew.sh/formula/meson
Meson has two dependencies: ninja and python.
* Ninja is explicitly installed one line above
* Python assumed to exists and skipped