### PR TITLE
Use %NUMBER_OF_PROCESSORS% for jom

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1454,8 +1454,8 @@ win:
         -nomake tests ^
         -platform win32-msvc
 
-    jom -j16
-    jom -j16 install
+    jom -j%NUMBER_OF_PROCESSORS%
+    jom -j%NUMBER_OF_PROCESSORS% install
 mac:
     find ../../patches/qtbase_5.15.13 -type f -print0 | sort -z | xargs -0 git apply
     cd ..


### PR DESCRIPTION
Could be merged instead of #27585, as it tries to resolve the same problem: fixed thread count in Qt build. This PR resloves the problem by using the `%NUMBER_OF_PROCESSORS%`.

However, it should be known that it could return wrong value: https://learn.microsoft.com/en-us/troubleshoot/windows-server/setup-upgrade-and-drivers/number-of-processors-environment-variable-show-incorrect-values