### PR TITLE
Don't mark as read when unexposed

### DIFF
--- a/Telegram/SourceFiles/mainwindow.cpp
+++ b/Telegram/SourceFiles/mainwindow.cpp
@@ -517,6 +517,7 @@ bool MainWindow::markingAsRead() const {
 		&& !_layer
 		&& !isHidden()
 		&& !isMinimized()
+		&& windowHandle()->isExposed()
 		&& (AutoScrollInactiveChat.value()
 			|| (isActive() && !_main->session().updates().isIdle()));
 }


### PR DESCRIPTION
There's a yet another another visility state called "exposed" and the window could be unexposed while being not hidden and not minimized.

When the window is unexposed, Qt doesn't draw and the user can't see changes for sure.