### PR TITLE
Fix tdesktop 4.15.6 build on OpenBSD

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -37,6 +37,7 @@ namespace Notifications {
 namespace {
 
 using namespace gi::repository;
+namespace GObject = gi::repository::GObject;
 
 constexpr auto kService = "org.freedesktop.Notifications";
 constexpr auto kObjectPath = "/org/freedesktop/Notifications";


### PR DESCRIPTION
7.5-current with clang 16.0.6 and Qt6 fails, not entirely sure why...