### PR TITLE
Fixing typo

### DIFF
--- a/Telegram/SourceFiles/lang/lang_instance.cpp
+++ b/Telegram/SourceFiles/lang/lang_instance.cpp
@@ -101,7 +101,7 @@ bool ValueParser::readTag() {
 	auto isTagChar = [](QChar ch) {
 		if (ch >= 'a' && ch <= 'z') {
 			return true;
-		} else if (ch >= 'A' && ch <= 'z') {
+		} else if (ch >= 'A' && ch <= 'Z') {
 			return true;
 		} else if (ch >= '0' && ch <= '9') {
 			return true;


### PR DESCRIPTION
isTagChar seems to check for alphanumeric + ```_``` input, but would accept extra ```[, ], ^, '``` because of typo