### PR TITLE
Don't use/link libsharpyuv in libavif

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -812,7 +812,8 @@ mac:
         -D CMAKE_INSTALL_PREFIX:STRING=$USED_PREFIX \\
         -D BUILD_SHARED_LIBS=OFF \\
         -D AVIF_ENABLE_WERROR=OFF \\
-        -D AVIF_CODEC_DAV1D=ON
+        -D AVIF_CODEC_DAV1D=ON \\
+        -D CMAKE_DISABLE_FIND_PACKAGE_libsharpyuv=ON
     cmake --build . --config MinSizeRel $MAKE_THREADS_CNT
     cmake --install . --config MinSizeRel
 """)


### PR DESCRIPTION
Fixes MacOS actions on GH

Problem is
libavif - finds libsharpyuv library v1.4.0 (available on github worker) and uses it for build.
libwebp - builds libsharpyuv from libwebp repo (v1.3.1)
then libsharpyuv v1.3.1 is used in the Telegram build.

That feature is not used in kimageformats plugin and if it will be used, it can be used only during encoding.
AVIF plugin is used only for decoding AVIF anyway.