### PR TITLE
Fix #25202: surrounding $PWD with double quotes

### DIFF
--- a/docs/building-linux.md
+++ b/docs/building-linux.md
@@ -20,7 +20,7 @@ Install [poetry](https://python-poetry.org), go to ***BuildPath*** and run
 Go to ***BuildPath*/tdesktop** and run (using [your **api_id** and **api_hash**](#obtain-your-api-credentials))
 
     docker run --rm -it \
-        -v $PWD:/usr/src/tdesktop \
+        -v "$PWD:/usr/src/tdesktop" \
         tdesktop:centos_env \
         /usr/src/tdesktop/Telegram/build/docker/centos_env/build.sh \
         -D TDESKTOP_API_ID=YOUR_API_ID \
@@ -29,7 +29,7 @@ Go to ***BuildPath*/tdesktop** and run (using [your **api_id** and **api_hash**]
 Or, to create a debug build, run (also using [your **api_id** and **api_hash**](#obtain-your-api-credentials))
 
     docker run --rm -it \
-        -v $PWD:/usr/src/tdesktop \
+        -v "$PWD:/usr/src/tdesktop" \
         -e CONFIG=Debug \
         tdesktop:centos_env \
         /usr/src/tdesktop/Telegram/build/docker/centos_env/build.sh \


### PR DESCRIPTION
## What was done

Added double quotes to work correctly with spaces in current directory's name

## How it was tested

Used [script](https://stackoverflow.com/a/4424334/9145106) in directory with name "/home/gooddok/test or not" to count number of arguments passed to the command, hope that's enough.

Before (13 arguments):
```
gooddok@ubuntu:~/test or not$ ./script.sh run --rm -it -v $PWD:/usr/src/tdesktop tdesktop:centos_env /usr/src/tdesktop/Telegram/build/docker/centos_env/build.sh -D TDESKTOP_API_ID=YOUR_API_ID -D TDESKTOP_API_HASH=YOUR_API_HASH
The number of arguments is: 13
The total length of all arguments is: 205: 
The length of argument 'run' is: 3
The length of argument '--rm' is: 4
The length of argument '-it' is: 3
The length of argument '-v' is: 2
The length of argument '/home/gooddok/test' is: 18
The length of argument 'or' is: 2
The length of argument 'not:/usr/src/tdesktop' is: 21
The length of argument 'tdesktop:centos_env' is: 19
The length of argument '/usr/src/tdesktop/Telegram/build/docker/centos_env/build.sh' is: 59
The length of argument '-D' is: 2
The length of argument 'TDESKTOP_API_ID=YOUR_API_ID' is: 27
The length of argument '-D' is: 2
The length of argument 'TDESKTOP_API_HASH=YOUR_API_HASH' is: 31
The counted number of arguments is: 13
The accumulated length of all arguments is: 193
```

After (11 arguments):
```
gooddok@ubuntu:~/test or not$ ./script.sh run --rm -it -v "$PWD:/usr/src/tdesktop" tdesktop:centos_env /usr/src/tdesktop/Telegram/build/docker/centos_env/build.sh -D TDESKTOP_API_ID=YOUR_API_ID -D TDESKTOP_API_HASH=YOUR_API_HASH
The number of arguments is: 11
The total length of all arguments is: 205: 
The length of argument 'run' is: 3
The length of argument '--rm' is: 4
The length of argument '-it' is: 3
The length of argument '-v' is: 2
The length of argument '/home/gooddok/test or not:/usr/src/tdesktop' is: 43
The length of argument 'tdesktop:centos_env' is: 19
The length of argument '/usr/src/tdesktop/Telegram/build/docker/centos_env/build.sh' is: 59
The length of argument '-D' is: 2
The length of argument 'TDESKTOP_API_ID=YOUR_API_ID' is: 27
The length of argument '-D' is: 2
The length of argument 'TDESKTOP_API_HASH=YOUR_API_HASH' is: 31
The counted number of arguments is: 11
The accumulated length of all arguments is: 195
```
## Why I contribute here

It's a sad story actually.

One year ago (on the 17th of May 2023, to be correct) I spotted a scam account using my name and photo in telegram. That was a surprising thing for me, so I reported that to notoscam bot. Then after several days reported to Telegram e-mails, then to volunteer support, then again to notoscam bot. Some time after I bought Telegram Premium thinking like "ok, now my requests are going to be prioritized". Then I filled several forms on telegram website. Then I started writing comments under Telegram's accounts in X. Then I wrote to Telegram Login Help...

What makes things worse is that the scammer uses the same login as I do in all other socials (gooddok, just like in Github) -- this login was already in use when I joined Telegram several years ago.

So, one year after I've got no response from a single person from Telegram side. Now I'm at the point when I started
* [posting memes](https://x.com/gooddok93/status/1785248077525254162?s=46) about my situation mentioning all Telegram X accounts 
* contributing to Telegram source code (this PR)

Actually, I wanted to make something more significant (e.g. increasing test coverage rate), but did not find much of low hanging fruits for me in this repo.
I believe that bringing a bit of effort into Telegram code could bring attention to my problem and maybe (maybe!) someone from Telegram Development Team could help me with this awful situation. Otherwise, I don't know where to go.