### PR TITLE
Fix typo in localimageloader.cpp

### DIFF
--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -54,7 +54,7 @@ using Ui::ValidateThumbDimensions;
 base::options::toggle SendLargePhotos({
 	.id = kOptionSendLargePhotos,
 	.name = "Send large photos",
-	.description = "Increase the side limit on compressed images to 2560px.",
+	.description = "Increase the size limit on compressed images to 2560px.",
 });
 std::atomic<bool> SendLargePhotosAtomic/* = false*/;
 


### PR DESCRIPTION
Perhaps it meant "size limit", not "side limit".