### PR TITLE
add option to export html and json in global export

### DIFF
--- a/Telegram/SourceFiles/export/view/export_view_settings.cpp
+++ b/Telegram/SourceFiles/export/view/export_view_settings.cpp
@@ -283,6 +283,7 @@ void SettingsWidget::setupPathAndFormat(
 	addLocationLabel(container);
 	addFormatOption(tr::lng_export_option_html(tr::now), Format::Html);
 	addFormatOption(tr::lng_export_option_json(tr::now), Format::Json);
+	addFormatOption(tr::lng_export_option_html_and_json(tr::now), Format::HtmlAndJson);
 }
 
 void SettingsWidget::addLocationLabel(


### PR DESCRIPTION
As started in #26199 and since [v4.9.6](https://github.com/telegramdesktop/tdesktop/releases/tag/v4.9.6) there is the option to export all data as html and json simultaneously.

This option is already implemented for exports of single chats. But the ui entry for the selection is still missing if all chats are going to be exported.