### PR TITLE
Add reactions to export chat history

### DIFF
--- a/Telegram/Resources/export_html/css/style.css
+++ b/Telegram/Resources/export_html/css/style.css
@@ -602,6 +602,16 @@ div.toast_shown {
     color: #fff;
 }
 
+.reactions .reaction.paid {
+    background-color: #fdf6e1;
+    color: #c58523;
+}
+
+.reactions .reaction.active.paid {
+    background-color: #ecae0a;
+    color: #fdf6e1;
+}
+
 .reactions .reaction .emoji {
     line-height: 20px;
     margin: 0 5px;

--- a/Telegram/Resources/export_html/css/style.css
+++ b/Telegram/Resources/export_html/css/style.css
@@ -582,3 +582,45 @@ div.toast_shown {
 .bot_button_column_separator {
     width: 2px
 }
+
+.reactions {
+    margin: 5px 0;
+}
+
+.reactions .reaction {
+    display: inline-flex;
+    height: 20px;
+    border-radius: 15px;
+    background-color: #e8f5fc;
+    color: #168acd;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.reactions .reaction.active {
+    background-color: #40a6e2;
+    color: #fff;
+}
+
+.reactions .reaction .emoji {
+    line-height: 20px;
+    margin: 0 5px;
+    font-size: 15px;
+}
+
+.reactions .reaction .userpic:not(:first-child) {
+    margin-left: -8px;
+}
+
+.reactions .reaction .userpic {
+    display: inline-block;
+}
+
+.reactions .reaction .userpic .initials {
+    font-size: 8px;
+}
+
+.reactions .reaction .count {
+    margin-right: 8px;
+    line-height: 20px;
+}

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -361,9 +361,9 @@ std::vector<Reaction> ParseReactions(const MTPMessageReactions &data) {
 	auto reactionsMap = std::map<QString, Reaction>();
 	auto reactionsOrder = std::vector<Utf8String>();
 	for (const auto &single : data.data().vresults().v) {
-		Reaction reaction = ParseReaction(single.data().vreaction());
+		auto reaction = ParseReaction(single.data().vreaction());
 		reaction.count = single.data().vcount().v;
-		Utf8String id = Reaction::Id(reaction);
+		auto id = Reaction::Id(reaction);
 		auto const &[_, inserted] = reactionsMap.try_emplace(id, reaction);
 		if (inserted) {
 			reactionsOrder.push_back(id);
@@ -372,8 +372,8 @@ std::vector<Reaction> ParseReactions(const MTPMessageReactions &data) {
 	if (data.data().vrecent_reactions().has_value()) {
 		if (const auto list = data.data().vrecent_reactions()) {
 			for (const auto &single : list->v) {
-				Reaction reaction = ParseReaction(single.data().vreaction());
-				Utf8String id = Reaction::Id(reaction);
+				auto reaction = ParseReaction(single.data().vreaction());
+				auto id = Reaction::Id(reaction);
 				auto const &[it, inserted] = reactionsMap.try_emplace(id, reaction);
 				if (inserted) {
 					reactionsOrder.push_back(id);

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -342,7 +342,7 @@ Utf8String Reaction::Id(const Reaction &reaction) {
 }
 
 Reaction ParseReaction(const MTPReaction& reaction) {
-	Reaction result;
+	auto result = Reaction();
 	reaction.match([&](const MTPDreactionEmoji &data) {
 		result.type = Reaction::Type::Emoji;
 		result.emoji = qs(data.vemoticon());

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -348,6 +348,8 @@ Reaction ParseReaction(const MTPReaction& reaction) {
 	}, [&](const MTPDreactionCustomEmoji &data) {
 		result.type = Reaction::Type::CustomEmoji;
 		result.documentId = NumberToString(data.vdocument_id().v);
+	}, [&](const MTPDreactionPaid &data) {
+		result.type = Reaction::Type::Paid;
 	}, [&](const MTPDreactionEmpty &data) {
 		result.type = Reaction::Type::Empty;
 	});

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -358,8 +358,8 @@ Reaction ParseReaction(const MTPReaction& reaction) {
 }
 
 std::vector<Reaction> ParseReactions(const MTPMessageReactions &data) {
-	std::map<QString, Reaction> reactionsMap;
-	std::vector<Utf8String> reactionsOrder;
+	auto reactionsMap = std::map<QString, Reaction>();
+	auto reactionsOrder = std::vector<Utf8String>();
 	for (const auto &single : data.data().vresults().v) {
 		Reaction reaction = ParseReaction(single.data().vreaction());
 		reaction.count = single.data().vcount().v;

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -370,17 +370,19 @@ std::vector<Reaction> ParseReactions(const MTPMessageReactions &data) {
 		}
 	}
 	if (data.data().vrecent_reactions().has_value()) {
-		for (const auto &single : data.data().vrecent_reactions().value_or_empty()) {
-			Reaction reaction = ParseReaction(single.data().vreaction());
-			Utf8String id = Reaction::Id(reaction);
-			auto const &[it, inserted] = reactionsMap.try_emplace(id, reaction);
-			if (inserted) {
-				reactionsOrder.push_back(id);
+		if (const auto list = data.data().vrecent_reactions()) {
+			for (const auto &single : list->v) {
+				Reaction reaction = ParseReaction(single.data().vreaction());
+				Utf8String id = Reaction::Id(reaction);
+				auto const &[it, inserted] = reactionsMap.try_emplace(id, reaction);
+				if (inserted) {
+					reactionsOrder.push_back(id);
+				}
+				it->second.recent.push_back({
+					.peerId = ParsePeerId(single.data().vpeer_id()),
+					.date = single.data().vdate().v,
+				});
 			}
-			it->second.recent.push_back({
-				.peerId = ParsePeerId(single.data().vpeer_id()),
-				.date = single.data().vdate().v,
-			});
 		}
 	}
 	std::vector<Reaction> results;

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -329,14 +329,14 @@ Utf8String Reaction::TypeToString(const Reaction &reaction) {
 }
 
 Utf8String Reaction::Id(const Reaction &reaction) {
-	Utf8String id;
+	auto id = Utf8String();
 	switch (reaction.type) {
-		case Reaction::Type::Emoji:
-			id = reaction.emoji.toUtf8();
-			break;
-		case Reaction::Type::CustomEmoji:
-			id = reaction.documentId;
-			break;
+	case Reaction::Type::Emoji:
+		id = reaction.emoji.toUtf8();
+		break;
+	case Reaction::Type::CustomEmoji:
+		id = reaction.documentId;
+		break;
 	}
 	return Reaction::TypeToString(reaction) + id;
 }

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -384,7 +384,7 @@ std::vector<Reaction> ParseReactions(const MTPMessageReactions &data) {
 		}
 	}
 	std::vector<Reaction> results;
-	for (const auto& id : reactionsOrder) {
+	for (const auto &id : reactionsOrder) {
 		results.push_back(reactionsMap[id]);
 	}
 	return results;

--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -323,6 +323,7 @@ Utf8String Reaction::TypeToString(const Reaction &reaction) {
 		case Reaction::Type::Empty: return "empty";
 		case Reaction::Type::Emoji: return "emoji";
 		case Reaction::Type::CustomEmoji: return "custom_emoji";
+		case Reaction::Type::Paid: return "paid";
 	}
 	Unexpected("Type in Reaction::Type.");
 }

--- a/Telegram/SourceFiles/export/data/export_data_types.h
+++ b/Telegram/SourceFiles/export/data/export_data_types.h
@@ -677,6 +677,7 @@ struct Reaction {
 		Empty,
 		Emoji,
 		CustomEmoji,
+		Paid,
 	};
 	
 	static Utf8String TypeToString(const Reaction &);

--- a/Telegram/SourceFiles/export/data/export_data_types.h
+++ b/Telegram/SourceFiles/export/data/export_data_types.h
@@ -672,6 +672,29 @@ struct TextPart {
 	}
 };
 
+struct Reaction {
+	enum class Type {
+		Empty,
+		Emoji,
+		CustomEmoji,
+	};
+	
+	static Utf8String TypeToString(const Reaction &);
+
+	static Utf8String Id(const Reaction &);
+
+	struct Recent {
+		PeerId peerId = 0;
+		TimeId date = 0;
+	};
+
+	Type type;
+	QString emoji;
+	Utf8String documentId;
+	uint32 count = 0;
+	std::vector<Recent> recent;
+};
+
 struct MessageId {
 	ChannelId channelId;
 	int32 msgId = 0;
@@ -744,6 +767,7 @@ struct Message {
 	int32 replyToMsgId = 0;
 	PeerId replyToPeerId = 0;
 	std::vector<TextPart> text;
+	std::vector<Reaction> reactions;
 	Media media;
 	ServiceAction action;
 	bool out = false;

--- a/Telegram/SourceFiles/export/export_api_wrap.cpp
+++ b/Telegram/SourceFiles/export/export_api_wrap.cpp
@@ -1812,8 +1812,8 @@ Data::FileOrigin ApiWrap::currentFileMessageOrigin() const {
 	return result;
 }
 
-std::optional<Utf8String> ApiWrap::getCustomEmoji(Utf8String &data) {
-	if (const auto id = data->toULongLong()) {
+std::optional<QByteArray> ApiWrap::getCustomEmoji(QByteArray &data) {
+	if (const auto id = data.toULongLong()) {
 		const auto i = _resolvedCustomEmoji.find(id);
 		if (i == end(_resolvedCustomEmoji)) {
 			return Data::TextPart::UnavailableEmoji();
@@ -1842,15 +1842,15 @@ std::optional<Utf8String> ApiWrap::getCustomEmoji(Utf8String &data) {
 			return file.relativePath.toUtf8();
 		}
 	}
-	return std::nullopt;
+	return data;
 }
 
 bool ApiWrap::messageCustomEmojiReady(Data::Message &message) {
 	for (auto &part : message.text) {
 		if (part.type == Data::TextPart::Type::CustomEmoji) {
-			auto custom = getCustomEmoji(part.additional);
-			if (custom.has_value()) {
-				part.additional = *custom;
+			auto data = getCustomEmoji(part.additional);
+			if (data.has_value()) {
+				part.additional = *data;
 			} else {
 				return false;
 			}
@@ -1858,9 +1858,9 @@ bool ApiWrap::messageCustomEmojiReady(Data::Message &message) {
 	}
 	for (auto &reaction : message.reactions) {
 		if (reaction.type == Data::Reaction::Type::CustomEmoji) {
-			auto custom = getCustomEmoji(reaction.documentId);
-			if (custom.has_value()) {
-				reaction.documentId = *custom;
+			auto data = getCustomEmoji(reaction.documentId);
+			if (data.has_value()) {
+				reaction.documentId = *data;
 			} else {
 				return false;
 			}

--- a/Telegram/SourceFiles/export/export_api_wrap.h
+++ b/Telegram/SourceFiles/export/export_api_wrap.h
@@ -183,7 +183,7 @@ private:
 	void resolveCustomEmoji();
 	void loadMessagesFiles(Data::MessagesSlice &&slice);
 	void loadNextMessageFile();
-	std::optional<Utf8String> getCustomEmoji(Utf8String &data);
+	std::optional<QByteArray> getCustomEmoji(QByteArray &data);
 	bool messageCustomEmojiReady(Data::Message &message);
 	bool loadMessageFileProgress(FileProgress value);
 	void loadMessageFileDone(const QString &relativePath);

--- a/Telegram/SourceFiles/export/export_api_wrap.h
+++ b/Telegram/SourceFiles/export/export_api_wrap.h
@@ -183,6 +183,7 @@ private:
 	void resolveCustomEmoji();
 	void loadMessagesFiles(Data::MessagesSlice &&slice);
 	void loadNextMessageFile();
+	bool renderCustomEmoji(QByteArray *data);
 	bool messageCustomEmojiReady(Data::Message &message);
 	bool loadMessageFileProgress(FileProgress value);
 	void loadMessageFileDone(const QString &relativePath);

--- a/Telegram/SourceFiles/export/export_api_wrap.h
+++ b/Telegram/SourceFiles/export/export_api_wrap.h
@@ -183,7 +183,7 @@ private:
 	void resolveCustomEmoji();
 	void loadMessagesFiles(Data::MessagesSlice &&slice);
 	void loadNextMessageFile();
-	bool renderCustomEmoji(QByteArray *data);
+	std::optional<Utf8String> getCustomEmoji(Utf8String &data);
 	bool messageCustomEmojiReady(Data::Message &message);
 	bool loadMessageFileProgress(FileProgress value);
 	void loadMessageFileDone(const QString &relativePath);

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -1528,7 +1528,7 @@ auto HtmlWriter::Wrap::pushMessage(
 		block.append(pushDiv("reactions"));
 		for (const auto& reaction : message.reactions) {
 			QByteArray reactionClass = "reaction";
-			for (const auto& recent : reaction.recent) {
+			for (const auto &recent : reaction.recent) {
 				auto peer = peers.peer(recent.peerId);
 				if (peer.user() && peer.user()->isSelf) {
 					reactionClass += " active";

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -231,18 +231,18 @@ QByteArray JoinList(
 }
 
 QByteArray FormatCustomEmoji(
-	const Data::Utf8String &custom_emoji,
-	const QByteArray &text,
-	const QString &relativeLinkBase) {
+		const Data::Utf8String &custom_emoji,
+		const QByteArray &text,
+		const QString &relativeLinkBase) {
 	return (custom_emoji.isEmpty()
-			? "<a href=\"\" onclick=\"return ShowNotLoadedEmoji();\">"
-			: (custom_emoji == Data::TextPart::UnavailableEmoji())
-			? "<a href=\"\" onclick=\"return ShowNotAvailableEmoji();\">"
-			: ("<a href = \""
-				+ (relativeLinkBase + custom_emoji).toUtf8()
-				+ "\">"))
-			+ text
-			+ "</a>";
+		? "<a href=\"\" onclick=\"return ShowNotLoadedEmoji();\">"
+		: (custom_emoji == Data::TextPart::UnavailableEmoji())
+		? "<a href=\"\" onclick=\"return ShowNotAvailableEmoji();\">"
+		: ("<a href = \""
+			+ (relativeLinkBase + custom_emoji).toUtf8()
+			+ "\">"))
+		+ text
+		+ "</a>";
 }
 
 QByteArray FormatText(

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -230,6 +230,21 @@ QByteArray JoinList(
 	return result;
 }
 
+QByteArray FormatCustomEmoji(
+	const Data::Utf8String &custom_emoji,
+	const QByteArray &text,
+	const QString &relativeLinkBase) {
+	return (custom_emoji.isEmpty()
+			? "<a href=\"\" onclick=\"return ShowNotLoadedEmoji();\">"
+			: (custom_emoji == Data::TextPart::UnavailableEmoji())
+			? "<a href=\"\" onclick=\"return ShowNotAvailableEmoji();\">"
+			: ("<a href = \""
+				+ (relativeLinkBase + custom_emoji).toUtf8()
+				+ "\">"))
+			+ text
+			+ "</a>";
+}
+
 QByteArray FormatText(
 		const std::vector<Data::TextPart> &data,
 		const QString &internalLinksDomain,
@@ -287,15 +302,8 @@ QByteArray FormatText(
 			"onclick=\"ShowSpoiler(this)\">"
 			"<span aria-hidden=\"true\">"
 			+ text + "</span></span>";
-		case Type::CustomEmoji: return (part.additional.isEmpty()
-			? "<a href=\"\" onclick=\"return ShowNotLoadedEmoji();\">"
-			: (part.additional == Data::TextPart::UnavailableEmoji())
-			? "<a href=\"\" onclick=\"return ShowNotAvailableEmoji();\">"
-			: ("<a href = \""
-				+ (relativeLinkBase + part.additional).toUtf8()
-				+ "\">"))
-			+ text
-			+ "</a>";
+		case Type::CustomEmoji: return FormatCustomEmoji(
+			part.additional, text, relativeLinkBase);
 		}
 		Unexpected("Type in text entities serialization.");
 	}) | ranges::to_vector);
@@ -1514,6 +1522,67 @@ auto HtmlWriter::Wrap::pushMessage(
 		block.append(popTag());
 	}
 	if (showForwardedInfo) {
+		block.append(popTag());
+	}
+	if (!message.reactions.empty()) {
+		block.append(pushDiv("reactions"));
+		for (const auto& reaction : message.reactions) {
+			QByteArray reactionClass = "reaction";
+			for (const auto& recent : reaction.recent) {
+				auto peer = peers.peer(recent.peerId);
+				if (peer.user() && peer.user()->isSelf) {
+					reactionClass += " active";
+					break;
+				}
+			}
+
+			block.append(pushTag("div", {
+				{ "class", reactionClass },
+			}));
+			block.append(pushTag("div", {
+				{ "class", "emoji" },
+			}));
+			switch (reaction.type) {
+				case Reaction::Type::Emoji:
+					block.append(SerializeString(reaction.emoji.toUtf8()));
+					break;
+				case Reaction::Type::CustomEmoji:
+					block.append(FormatCustomEmoji(
+						reaction.documentId,
+						"(custom emoji)",
+						_base));
+					break;
+			}
+			block.append(popTag());
+			if (!reaction.recent.empty()) {
+				block.append(pushTag("div", {
+					{ "class", "userpics" },
+				}));
+				for (const auto& recent : reaction.recent) {
+					auto peer = peers.peer(recent.peerId);
+					block.append(pushUserpic(UserpicData({
+						.colorIndex = peer.colorIndex(),
+						.pixelSize = 20,
+						.firstName = peer.user()
+							? peer.user()->info.firstName
+							: peer.name(),
+						.lastName = peer.user()
+							? peer.user()->info.lastName
+							: "",
+						.tooltip = peer.name(),
+					})));
+				}
+				block.append(popTag());
+			}
+			if (reaction.recent.empty() || reaction.count > reaction.recent.size()) {
+				block.append(pushTag("div", {
+					{ "class", "count" },
+				}));
+				block.append(NumberToString(reaction.count));
+				block.append(popTag());
+			}
+			block.append(popTag());
+		}
 		block.append(popTag());
 	}
 	block.append(popTag());

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -1552,7 +1552,7 @@ auto HtmlWriter::Wrap::pushMessage(
 				case Reaction::Type::CustomEmoji:
 					block.append(FormatCustomEmoji(
 						reaction.documentId,
-						"(custom emoji)",
+						"\U0001F44B",
 						_base));
 					break;
 				case Reaction::Type::Paid:

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -1564,7 +1564,7 @@ auto HtmlWriter::Wrap::pushMessage(
 				block.append(pushTag("div", {
 					{ "class", "userpics" },
 				}));
-				for (const auto& recent : reaction.recent) {
+				for (const auto &recent : reaction.recent) {
 					auto peer = peers.peer(recent.peerId);
 					block.append(pushUserpic(UserpicData({
 						.colorIndex = peer.colorIndex(),

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -302,8 +302,8 @@ QByteArray FormatText(
 			"onclick=\"ShowSpoiler(this)\">"
 			"<span aria-hidden=\"true\">"
 			+ text + "</span></span>";
-		case Type::CustomEmoji: return FormatCustomEmoji(
-			part.additional, text, relativeLinkBase);
+		case Type::CustomEmoji:
+			return FormatCustomEmoji(part.additional, text, relativeLinkBase);
 		}
 		Unexpected("Type in text entities serialization.");
 	}) | ranges::to_vector);

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -1526,7 +1526,7 @@ auto HtmlWriter::Wrap::pushMessage(
 	}
 	if (!message.reactions.empty()) {
 		block.append(pushDiv("reactions"));
-		for (const auto& reaction : message.reactions) {
+		for (const auto &reaction : message.reactions) {
 			QByteArray reactionClass = "reaction";
 			for (const auto &recent : reaction.recent) {
 				auto peer = peers.peer(recent.peerId);

--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
@@ -1535,6 +1535,9 @@ auto HtmlWriter::Wrap::pushMessage(
 					break;
 				}
 			}
+			if (reaction.type == Reaction::Type::Paid) {
+				reactionClass += " paid";
+			}
 
 			block.append(pushTag("div", {
 				{ "class", reactionClass },
@@ -1551,6 +1554,9 @@ auto HtmlWriter::Wrap::pushMessage(
 						reaction.documentId,
 						"(custom emoji)",
 						_base));
+					break;
+				case Reaction::Type::Paid:
+					block.append(SerializeString("\u2B50"));
 					break;
 			}
 			block.append(popTag());

--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -296,7 +296,7 @@ QByteArray SerializeMessage(
 					+ Data::NumberToString(chat.bare));
 		} else if (const auto channel = peerToChannel(peerId)) {
 			return SerializeString("channel"
-					+ Data::NumberToString(channel.bare));
+				+ Data::NumberToString(channel.bare));
 		}
 		return SerializeString("user"
 			+ Data::NumberToString(peerToUser(peerId).bare));

--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -290,6 +290,17 @@ QByteArray SerializeMessage(
 		pushBare("edited_unixtime", SerializeDateRaw(message.edited));
 	}
 
+	const auto wrapPeerId = [&](PeerId peerId) {
+		if (const auto chat = peerToChat(peerId)) {
+			return SerializeString("chat"
+					+ Data::NumberToString(chat.bare));
+		} else if (const auto channel = peerToChannel(peerId)) {
+			return SerializeString("channel"
+					+ Data::NumberToString(channel.bare));
+		}
+		return SerializeString("user"
+				+ Data::NumberToString(peerToUser(peerId).bare));
+	};
 	const auto push = [&](const QByteArray &key, const auto &value) {
 		using V = std::decay_t<decltype(value)>;
 		if constexpr (std::is_same_v<V, bool>) {
@@ -297,22 +308,7 @@ QByteArray SerializeMessage(
 		} else if constexpr (std::is_arithmetic_v<V>) {
 			pushBare(key, Data::NumberToString(value));
 		} else if constexpr (std::is_same_v<V, PeerId>) {
-			if (const auto chat = peerToChat(value)) {
-				pushBare(
-					key,
-					SerializeString("chat"
-						+ Data::NumberToString(chat.bare)));
-			} else if (const auto channel = peerToChannel(value)) {
-				pushBare(
-					key,
-					SerializeString("channel"
-						+ Data::NumberToString(channel.bare)));
-			} else {
-				pushBare(
-					key,
-					SerializeString("user"
-						+ Data::NumberToString(peerToUser(value).bare)));
-			}
+			pushBare(key, wrapPeerId(value));
 		} else {
 			const auto wrapped = QByteArray(value);
 			if (!wrapped.isEmpty()) {
@@ -865,6 +861,63 @@ QByteArray SerializeMessage(
 		) | ranges::views::transform(serializeRow) | ranges::to_vector;
 		context.nesting.pop_back();
 		pushBare("inline_bot_buttons", SerializeArray(context, rows));
+	}
+
+	if (!message.reactions.empty()) {
+		const auto serializeReaction = [&](const Reaction &reaction) {
+			context.nesting.push_back(Context::kObject);
+			const auto guard = gsl::finally([&] { context.nesting.pop_back(); });
+
+			auto pairs = std::vector<std::pair<QByteArray, QByteArray>>();
+			pairs.push_back({
+				"type",
+				SerializeString(Reaction::TypeToString(reaction)),
+			});
+			pairs.push_back({
+				"count",
+				NumberToString(reaction.count),
+			});
+			switch (reaction.type) {
+				case Reaction::Type::Emoji:
+					pairs.push_back({
+						"emoji",
+						SerializeString(reaction.emoji.toUtf8()),
+					});
+					break;
+				case Reaction::Type::CustomEmoji:
+					pairs.push_back({
+						"document_id",
+						SerializeString(reaction.documentId),
+					});
+					break;
+			}
+
+			if (!reaction.recent.empty()) {
+				context.nesting.push_back(Context::kArray);
+				const auto recents = ranges::views::all(
+					reaction.recent
+				) | ranges::views::transform([&](const Reaction::Recent &recent) {
+					context.nesting.push_back(Context::kArray);
+					const auto guard = gsl::finally([&] { context.nesting.pop_back(); });
+					return SerializeObject(context, {
+						{"from", wrapPeerName(recent.peerId)},
+						{"from_id", wrapPeerId(recent.peerId)},
+						{"date", SerializeDate(recent.date)}
+					});
+				}) | ranges::to_vector;
+				pairs.push_back({"recent", SerializeArray(context, recents)});
+				context.nesting.pop_back();
+			}
+
+			return SerializeObject(context, pairs);
+		};
+
+		context.nesting.push_back(Context::kArray);
+		const auto reactions = ranges::views::all(
+			message.reactions
+		) | ranges::views::transform(serializeReaction) | ranges::to_vector;
+		pushBare("reactions", SerializeArray(context, reactions));
+		context.nesting.pop_back();
 	}
 
 	return serialized();

--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -293,7 +293,7 @@ QByteArray SerializeMessage(
 	const auto wrapPeerId = [&](PeerId peerId) {
 		if (const auto chat = peerToChat(peerId)) {
 			return SerializeString("chat"
-					+ Data::NumberToString(chat.bare));
+				+ Data::NumberToString(chat.bare));
 		} else if (const auto channel = peerToChannel(peerId)) {
 			return SerializeString("channel"
 				+ Data::NumberToString(channel.bare));

--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -900,9 +900,9 @@ QByteArray SerializeMessage(
 					context.nesting.push_back(Context::kArray);
 					const auto guard = gsl::finally([&] { context.nesting.pop_back(); });
 					return SerializeObject(context, {
-						{"from", wrapPeerName(recent.peerId)},
-						{"from_id", wrapPeerId(recent.peerId)},
-						{"date", SerializeDate(recent.date)}
+						{ "from", wrapPeerName(recent.peerId) },
+						{ "from_id", wrapPeerId(recent.peerId) },
+						{ "date", SerializeDate(recent.date) },
 					});
 				}) | ranges::to_vector;
 				pairs.push_back({"recent", SerializeArray(context, recents)});

--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -299,7 +299,7 @@ QByteArray SerializeMessage(
 					+ Data::NumberToString(channel.bare));
 		}
 		return SerializeString("user"
-				+ Data::NumberToString(peerToUser(peerId).bare));
+			+ Data::NumberToString(peerToUser(peerId).bare));
 	};
 	const auto push = [&](const QByteArray &key, const auto &value) {
 		using V = std::decay_t<decltype(value)>;


### PR DESCRIPTION
This should allow to export reactions in both JSON and HTML exports. Fixes #27971

Tested in a local environment.

Current limitations in HTML output:
- Not rendering userpics. Only initials. As far as I understand, chat messages also don't render userpics.
- Not rendering custom emojis. It looks like there is no existing way to render them in HTML output and in messages they are not rendered as well. But instead, simple emoji alternative is rendered. Unfortunately, for reactions there is no simplified emoji provided. Thus, it is not possible to render custom emojis. As a placeholder I added "(custom emoji)".

Example JSON message with reactions:
```
  {
   "id": 112233,
   "type": "message",

   ...

   "reactions": [
     {
      "type": "emoji",
      "count": 1,
      "emoji": "😁",
      "recent": [
       {
        "from": "Jane Smith",
        "from_id": "user54321",
        "date": "2023-11-08T10:10:30"
       }
      ]
     },
     {
      "type": "emoji",
      "count": 1,
      "emoji": "😢",
      "recent": [
       {
        "from": "John Doe",
        "from_id": "user12345",
        "date": "2023-11-08T10:20:30"
       }
      ]
     }
    ]
  },
```

Example generated HTML:

![Example generated HTML](https://s3.amazonaws.com/i.snag.gy/jtV0xH.jpg)

As you can see, custom emojis embedded into `text_entries` were properly serialized as a path to an image. I tried to follow the same code for serializing custom emojis in reactions, but somehow it is still different. I am definitely missing something, but cannot yet figure out exactly what.
