### PR TITLE
make web-apps resizeable

### DIFF
--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
@@ -328,7 +328,7 @@ Panel::Panel(
 , _widget(std::make_unique<SeparatePanel>())
 , _allowClipboardRead(allowClipboardRead) {
 	_widget->setWindowFlag(Qt::WindowStaysOnTopHint, false);
-	_widget->setInnerSize(st::botWebViewPanelSize);
+	_widget->setInnerSize(st::botWebViewPanelSize, false);
 
 	_widget->closeRequests(
 	) | rpl::start_with_next([=] {


### PR DESCRIPTION
It is just convenient to be able to resize the web view. I do not see any reason to restrict the size of the window on desktop to that of a mobile device.

This probably resolves #28254, but I'm not sure because I don't use any gamebots.

Depends on https://github.com/desktop-app/lib_ui/pull/237