### PR TITLE
Changed dev name in org.telegram.desktop.metainfo.xml

### DIFF
--- a/lib/xdg/org.telegram.desktop.metainfo.xml
+++ b/lib/xdg/org.telegram.desktop.metainfo.xml
@@ -24,7 +24,7 @@
         <category>InstantMessaging</category>
     </categories>
     <update_contact>johnprestonmail_at_gmail.com</update_contact>
-    <developer_name>John Preston</developer_name>
+    <developer_name>Telegram FZ-LLC</developer_name>
     <url type="homepage">https://desktop.telegram.org/</url>
     <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>
     <url type="translate">https://translations.telegram.org/</url>

--- a/lib/xdg/org.telegram.desktop.metainfo.xml
+++ b/lib/xdg/org.telegram.desktop.metainfo.xml
@@ -23,7 +23,7 @@
         <category>Network</category>
         <category>InstantMessaging</category>
     </categories>
-    <developer_name>Telegram FZ-LLC</developer_name>
+    <developer id="org.telegram"><name>Telegram FZ-LLC</name></developer>
     <url type="homepage">https://desktop.telegram.org/</url>
     <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>
     <url type="translate">https://translations.telegram.org/</url>

--- a/lib/xdg/org.telegram.desktop.metainfo.xml
+++ b/lib/xdg/org.telegram.desktop.metainfo.xml
@@ -23,7 +23,6 @@
         <category>Network</category>
         <category>InstantMessaging</category>
     </categories>
-    <update_contact>johnprestonmail_at_gmail.com</update_contact>
     <developer_name>Telegram FZ-LLC</developer_name>
     <url type="homepage">https://desktop.telegram.org/</url>
     <url type="bugtracker">https://github.com/telegramdesktop/tdesktop/issues</url>


### PR DESCRIPTION
In flathub, and it's front-ends like KDE's Discover or GNOME Software, Telegram shows "By John Preston", and some users were hesitant to install it afraid that was "fake", so i changed it to Telegram, this would also make it consistent with snap, thanks!