### PR TITLE
Fix restrict user in recent actions

### DIFF
--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_inner.cpp
+++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_inner.cpp
@@ -1572,7 +1572,8 @@ void InnerWidget::suggestRestrictParticipant(
 				if (participant.type() == Type::Creator
 					|| participant.type() == Type::Admin) {
 					editRestrictions(true, {}, nullptr, 0);
-				} else if (const auto since = participant.restrictedSince()) {
+				} else {
+					const auto since = participant.restrictedSince();
 					editRestrictions(
 						false,
 						participant.restrictions(),


### PR DESCRIPTION
`if (const auto since = participant.restrictedSince())`
Cause `since` is always false when user is not restricted,
[restrictedSince() return 0](https://github.com/telegramdesktop/tdesktop/blob/dev/Telegram/SourceFiles/api/api_chat_participants.cpp#L372)
then EditRestrictedBox wouldn't pop up.