### PR TITLE
Linux: fix notification urgency

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -249,8 +249,8 @@ bool NotificationData::init(
 			Gio::ThemedIcon::new_(base::IconName().toStdString()));
 
 		// for chat messages, according to
-		// https://docs.gtk.org/gio/enum.NotificationPriority.html
-		_notification.set_priority(Gio::NotificationPriority::HIGH_);
+		// https://specifications.freedesktop.org/notification-spec/1.2/urgency-levels.html
+		_notification.set_priority(Gio::NotificationPriority::NORMAL_);
 
 		// glib 2.70+, we keep glib 2.56+ compatibility
 		static const auto set_category = [] {


### PR DESCRIPTION
Telegram currently stores notifications data in GLib.Notification which uses Notification portal under the hood. But sends the data from it to notification server on `org.freedesktop.Notifications`.

These two methods use different specifications. Portal uses [this one](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Notification.html#) and `org.freedesktop.Notifications` [this one](https://specifications.freedesktop.org/notification-spec/1.2/index.html). And in conversion from portal version to fd.o urgency HIGH with byte number 2 becomes URGENT priority with the same byte number 2.

PS: I haven't tested these changes, because I don't know how to use make.