### PR TITLE
fix(ui/webview_helpers): prepend 0 if color channel value is 1 char long

### DIFF
--- a/Telegram/SourceFiles/ui/webview_helpers.cpp
+++ b/Telegram/SourceFiles/ui/webview_helpers.cpp
@@ -15,9 +15,9 @@ namespace {
 [[nodiscard]] QByteArray Serialize(const QColor &qt) {
 	if (qt.alpha() == 255) {
 		return '#'
-			+ QByteArray::number(qt.red(), 16).right(2)
-			+ QByteArray::number(qt.green(), 16).right(2)
-			+ QByteArray::number(qt.blue(), 16).right(2);
+			+ QByteArray::number(qt.red(), 16).rightJustified(2, '0')
+			+ QByteArray::number(qt.green(), 16).rightJustified(2, '0')
+			+ QByteArray::number(qt.blue(), 16).rightJustified(2, '0');
 	}
 	return "rgba("
 		+ QByteArray::number(qt.red()) + ","


### PR DESCRIPTION
fixes #28555 