### PR TITLE
Build: Speed up third party libraries cloning

### DIFF
--- a/docs/building-mac.md
+++ b/docs/building-mac.md
@@ -20,6 +20,11 @@ Go to ***BuildPath*** and run
     git clone --recursive https://github.com/telegramdesktop/tdesktop.git
     ./tdesktop/Telegram/build/prepare/mac.sh
 
+> [!IMPORTANT]
+> You might not need Telegram Desktop's git dependency history, in which case you can run this command **instead of the last one** and save disk space and speed up cloning quite a bit:
+>
+>     ./tdesktop/Telegram/build/prepare/mac.sh no-deps-git-history
+
 ### Building the project
 
 Go to ***BuildPath*/tdesktop/Telegram** and run (using [your **api_id** and **api_hash**](#obtain-your-api-credentials))

--- a/docs/building-win-x64.md
+++ b/docs/building-win-x64.md
@@ -30,6 +30,11 @@ Open **x64 Native Tools Command Prompt for VS 2022.bat**, go to ***BuildPath*** 
     git clone --recursive https://github.com/telegramdesktop/tdesktop.git
     tdesktop\Telegram\build\prepare\win.bat
 
+> [!IMPORTANT]
+> You might not need Telegram Desktop's git dependency history, in which case you can run this command **instead of the last one** and save disk space and speed up cloning quite a bit:
+>
+>     tdesktop\Telegram\build\prepare\win.bat no-deps-git-history
+
 ## Build the project
 
 Go to ***BuildPath*\\tdesktop\\Telegram** and run (using [your **api_id** and **api_hash**](#obtain-your-api-credentials))

--- a/docs/building-win.md
+++ b/docs/building-win.md
@@ -30,6 +30,11 @@ Open **x86 Native Tools Command Prompt for VS 2022.bat**, go to ***BuildPath*** 
     git clone --recursive https://github.com/telegramdesktop/tdesktop.git
     tdesktop\Telegram\build\prepare\win.bat
 
+> [!IMPORTANT]
+> You might not need Telegram Desktop's git dependency history, in which case you can run this command **instead of the last one** and save disk space and speed up cloning quite a bit:
+>
+>     tdesktop\Telegram\build\prepare\win.bat no-deps-git-history
+
 ## Build the project
 
 Go to ***BuildPath*\\tdesktop\\Telegram** and run (using [your **api_id** and **api_hash**](#obtain-your-api-credentials))


### PR DESCRIPTION
When I tried to build Telegram Desktop from source code, I realized it was running pretty darn slow.

When I decided to look into it, I suddenly found out that the preparation script clones the entire git repository index of each third party library used, not just the last commit we need to build. So I looked at which stages `tdesktop` uses just a branch (without explicitly checkingout to a specific commit) and added the `--depth 1` parameter. This greatly reduces build preparation time, as well as disk space and traffic used, since some of the libraries used are very large.