### PR TITLE
Replace deprecated x64 architecture identifier

### DIFF
--- a/Telegram/build/setup.iss
+++ b/Telegram/build/setup.iss
@@ -42,8 +42,8 @@ SignTool=sha256
   #define ArchModulesFolder "arm64"
   AppVerName={#MyAppName} {#MyAppVersion} arm64
 #elif MyBuildTarget == "win64"
-  ArchitecturesAllowed="x64 arm64"
-  ArchitecturesInstallIn64BitMode="x64 arm64"
+  ArchitecturesAllowed="x64compatible"
+  ArchitecturesInstallIn64BitMode="x64compatible"
   OutputBaseFilename=tsetup-x64.{#MyAppVersionFull}
   #define ArchModulesFolder "x64"
   AppVerName={#MyAppName} {#MyAppVersion} 64bit


### PR DESCRIPTION
While compiling installer with Inno Setup Compiler, this warning appeared:
> Warning: Architecture identifier "x64" is deprecated. Substituting "x64os", but note that "x64compatible" is preferred in most cases. See the "Architecture Identifiers" topic in help file for more information.

This pull request fixes this warning according to [Inno Setup Docs page](https://jrsoftware.org/ishelp/index.php?topic=archidentifiers).