### PR TITLE
Fix bug in ChatBotCommands::update when commands empty

### DIFF
--- a/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
+++ b/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
@@ -18,10 +18,12 @@ ChatBotCommands::Changed ChatBotCommands::update(
 	} else {
 		for (const auto &commands : list) {
 			auto &value = operator[](commands.userId);
-			changed |= commands.commands.empty()
-				? remove(commands.userId)
-				: !ranges::equal(value, commands.commands);
-			value = commands.commands;
+			if (commands.commands.empty()) {
+				changed |= remove(commands.userId);
+			} else {
+				changed |= !ranges::equal(value, commands.commands);
+				value = commands.commands;
+			}
 		}
 	}
 	return changed;

--- a/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
+++ b/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
@@ -17,12 +17,15 @@ ChatBotCommands::Changed ChatBotCommands::update(
 		clear();
 	} else {
 		for (const auto &commands : list) {
-			auto &value = operator[](commands.userId);
 			if (commands.commands.empty()) {
 				changed |= remove(commands.userId);
 			} else {
-				changed |= !ranges::equal(value, commands.commands);
-				value = commands.commands;
+				auto &value = operator[](commands.userId);
+				const auto isEqual = ranges::equal(value, commands.commands);
+				changed |= !isEqual;
+				if (!isEqual) {
+					value = commands.commands;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Certain bots do not show commands in particular groups at random. This is a known issue, see e.g. #25027, #26735.

The issue is that we try to assign a value through an iterator even after we have called `remove`. This will cause the iterator to point to some other element, and then we copy an empty list of commands into that other list. This means that the bot list of some other bot, that is the bot with the next higher user ID, gets cleared instead.

This fixes the bug by making sure that we do not try to assign anything after calling `remove`.