### PR TITLE
Don't export a duplicate "text" field on star gift

### DIFF
--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -661,7 +661,7 @@ QByteArray SerializeMessage(
 		push("stars", data.stars);
 		push("is_limited", data.limited);
 		push("is_anonymous", data.anonymous);
-		pushBare("text", SerializeText(context, data.text));
+		pushBare("gift_text", SerializeText(context, data.text));
 	}, [](v::null_t) {});
 
 	if (v::is_null(message.action.content)) {


### PR DESCRIPTION
Fixes #28781