### PR TITLE
Fix notifications when passed through with a cursor too quickly

### DIFF
--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -188,16 +188,10 @@ void Manager::checkLastInput() {
 
 void Manager::startAllHiding() {
 	if (!hasReplyingNotification()) {
-		int notHidingCount = 0;
 		for (const auto &notification : _notifications) {
-			if (notification->isShowing()) {
-				++notHidingCount;
-			} else {
-				notification->startHiding();
-			}
+			notification->startHiding();
 		}
-		notHidingCount += _queuedNotifications.size();
-		if (_hideAll && notHidingCount < 2) {
+		if (_hideAll && _queuedNotifications.size() < 2) {
 			_hideAll->startHiding();
 		}
 	}

--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -549,6 +549,10 @@ void Widget::hideStop() {
 
 void Widget::hideAnimated(float64 duration, const anim::transition &func) {
 	_hiding = true;
+	// Stop the previous animation so as to make sure that the notification
+	// is fully restored before hiding it again.
+	// Relates to https://github.com/telegramdesktop/tdesktop/issues/28811.
+	_a_opacity.stop();
 	_a_opacity.start([this] { opacityAnimationCallback(); }, 1., 0., duration, func);
 }
 

--- a/Telegram/SourceFiles/window/notifications_manager_default.h
+++ b/Telegram/SourceFiles/window/notifications_manager_default.h
@@ -143,7 +143,7 @@ public:
 		int shift,
 		Direction shiftDirection);
 
-	bool isShowing() const {
+	bool isFadingIn() const {
 		return _a_opacity.animating() && !_hiding;
 	}
 


### PR DESCRIPTION
In this PR, for `Window::Notification::Default::internal::Widget` I:
- Rename `.isShowing()` to `.isFadingIn()` to clarify its behavior;
- Add a call to `Ui::Animations::Simple::stop` before `::start` in notification hiding animation.

~~Is blocked by desktop-app/lib_ui#254~~. Fixes #28811.

Kindly, see the commit messages for details.