### PR TITLE
Fix handling of notification disappearing under cursor

### DIFF
--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -500,7 +500,13 @@ void Widget::opacityAnimationCallback() {
 	updateOpacity();
 	update();
 	if (!_a_opacity.animating() && _hiding) {
-		manager()->removeWidget(this);
+		if (underMouse()) {
+			// The notification is leaving from under the cursor, but in such case leave hook is not
+			// triggered automatically. But we still want the manager to start hiding notifications
+			// (see #28813).
+			manager()->startAllHiding();
+		}
+		manager()->removeWidget(this);  // Deletes `this`
 	}
 }
 


### PR DESCRIPTION
Previously, notifications disappearing under cursor (e.g., because closed manually or open from another device) did not notify the manager properly, as the leaveEventHook was not triggered. This could lead to notifications staying around when not supposed to (see #28813).

This commit fixes that by explicitly notifying manager when the notification widget disappears under the cursor.

Fixes #28813.