### PR TITLE
Checking for GNOME before making HTML escapes in title of desktop notification

### DIFF
--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -285,27 +285,19 @@ bool NotificationData::init(const Info &info) {
 	}
 
 	const auto &text = info.message;
-	if (HasCapability("body-markup")) {
-		if (qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower().contains("gnome")) {
-			_title = subtitle.isEmpty()
-				? title.toPlainText().toStdString()
-				: subtitle.toPlainText().toStdString() + " (" + title.toPlainText().toStdString() + ')';
-			_body = msg.toPlainText().toStdString();
-		} else {
-			_title = subtitle.isEmpty()
-				? title.toStdString()
-				: subtitle.toStdString() + " (" + title.toStdString() + ')';
-			_body = subtitle.isEmpty()
-				? msg.toHtmlEscaped().toStdString()
-				: u"<b>%1</b>\n%2"_q.arg(
-					subtitle.toHtmlEscaped(),
-					msg.toHtmlEscaped()).toStdString();
-		}
+	if (HasCapability("body-markup") && !qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower().contains("gnome")) {
+		_title = title.toStdString()
+
+		_body = subtitle.isEmpty()
+			? text.toHtmlEscaped().toStdString()
+			: u"<b>%1</b>\n%2"_q.arg(
+				subtitle.toHtmlEscaped(),
+				text.toHtmlEscaped()).toStdString();
 	} else {
 		_title = subtitle.isEmpty()
-			? title.toPlainText().toStdString()
-			: subtitle.toPlainText().toStdString() + " (" + title.toPlainText().toStdString() + ')';
-		_body = msg.toPlainText().toStdString();
+			? title.toStdString()
+			: subtitle.toStdString() + " (" + title.toStdString() + ')';
+		_body = text.toStdString();
 	}
 	
 

--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -284,6 +284,7 @@ bool NotificationData::init(const Info &info) {
 		return false;
 	}
 
+	const auto &text = info.message;
 	if (HasCapability("body-markup")) {
 		if (qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower().contains("gnome")) {
 			_title = subtitle.isEmpty()

--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
@@ -284,22 +284,29 @@ bool NotificationData::init(const Info &info) {
 		return false;
 	}
 
-	const auto &text = info.message;
 	if (HasCapability("body-markup")) {
-		_title = title.toStdString();
-
-		_body = subtitle.isEmpty()
-			? text.toHtmlEscaped().toStdString()
-			: u"<b>%1</b>\n%2"_q.arg(
-				subtitle.toHtmlEscaped(),
-				text.toHtmlEscaped()).toStdString();
+		if (qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower().contains("gnome")) {
+			_title = subtitle.isEmpty()
+				? title.toPlainText().toStdString()
+				: subtitle.toPlainText().toStdString() + " (" + title.toPlainText().toStdString() + ')';
+			_body = msg.toPlainText().toStdString();
+		} else {
+			_title = subtitle.isEmpty()
+				? title.toStdString()
+				: subtitle.toStdString() + " (" + title.toStdString() + ')';
+			_body = subtitle.isEmpty()
+				? msg.toHtmlEscaped().toStdString()
+				: u"<b>%1</b>\n%2"_q.arg(
+					subtitle.toHtmlEscaped(),
+					msg.toHtmlEscaped()).toStdString();
+		}
 	} else {
 		_title = subtitle.isEmpty()
-			? title.toStdString()
-			: subtitle.toStdString() + " (" + title.toStdString() + ')';
-
-		_body = text.toStdString();
+			? title.toPlainText().toStdString()
+			: subtitle.toPlainText().toStdString() + " (" + title.toPlainText().toStdString() + ')';
+		_body = msg.toPlainText().toStdString();
 	}
+	
 
 	if (HasCapability("actions")) {
 		_actions.push_back("default");


### PR DESCRIPTION
Hello, I have the same issue as [here (27940)](https://github.com/telegramdesktop/tdesktop/issues/27940). Explanation: GNOME does not support HTML formatting in desktop notifications. I'm not sure that this fragment of code can fix this, but you can try.