### PR TITLE
Include media sizes to exports

### DIFF
--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
@@ -385,6 +385,7 @@ QByteArray SerializeMessage(
 	};
 	const auto pushPhoto = [&](const Image &image) {
 		pushPath(image.file, "photo");
+		push("photo_file_size", image.file.size);
 		if (image.width && image.height) {
 			push("width", image.width);
 			push("height", image.height);
@@ -696,8 +697,10 @@ QByteArray SerializeMessage(
 	}, [&](const Document &data) {
 		pushPath(data.file, "file");
 		push("file_name", data.name);
+		push("file_size", data.file.size);
 		if (data.thumb.width > 0) {
 			pushPath(data.thumb.file, "thumbnail");
+			push("thumbnail_file_size", data.thumb.file.size);
 		}
 		const auto pushType = [&](const QByteArray &value) {
 			push("media_type", value);
@@ -739,6 +742,7 @@ QByteArray SerializeMessage(
 		}));
 		if (!data.vcard.content.isEmpty()) {
 			pushPath(data.vcard, "contact_vcard");
+			push("contact_vcard_file_size", data.vcard.size);
 		}
 	}, [&](const GeoPoint &data) {
 		pushBare(


### PR DESCRIPTION
I hope this suggestion could be classified as "fixing the existing user experience" and therefore considered.

Currently it is possible to include various media types and set a size limit. But it's impossible to predict how much size and time the export will take, and how much data was below and above the limit.

This change saves media sizes even for skipped items, so allows to get this insights.

I've tested my change:
```json
  {
   "id": 111,
   "type": "message",
   "date": "2025-01-30T14:53:04",
   "date_unixtime": "1738245184",
   "from": "",
   "from_id": "",
   "photo": "(File not included. Change data exporting settings to download.)",
   "photo_size": 178404,
   "width": 960,
   "height": 1280,
   "text": "",
   "text_entities": []
  }
```