### PR TITLE
Fix build error 'ambiguous symbol' on windows

### DIFF
--- a/Telegram/SourceFiles/settings/settings_calls.cpp
+++ b/Telegram/SourceFiles/settings/settings_calls.cpp
@@ -404,8 +404,8 @@ void Calls::initCaptureButton(
 	}, level->lifetime());
 }
 
+using namespace ::Platform;
 void Calls::requestPermissionAndStartTestingMicrophone() {
-	using namespace ::Platform;
 	const auto status = GetPermissionStatus(
 		PermissionType::Microphone);
 	if (status == PermissionStatus::Granted) {


### PR DESCRIPTION
If use a local namespace, the following build error will occur on windows
```
31>C:\tdesktop\Telegram\SourceFiles\settings\settings_calls.cpp(415,30): error C2872: 'Platform': ambiguous symbol
31>(compiling source file '../../Telegram/SourceFiles/settings/settings_calls.cpp')
31>    C:\tdesktop\Telegram\SourceFiles\calls\calls_instance.h(16,11):
31>    could be 'Platform'
31>    C:\tdesktop\Telegram\lib_webrtc\webrtc\webrtc_environment.h(15,11):
31>    or       'Webrtc::Platform'
31>C:\tdesktop\Telegram\SourceFiles\settings\settings_calls.cpp(417,39): error C2872: 'Platform': ambiguous symbol
31>(compiling source file '../../Telegram/SourceFiles/settings/settings_calls.cpp')
31>    C:\tdesktop\Telegram\SourceFiles\calls\calls_instance.h(16,11):
31>    could be 'Platform'
31>    C:\tdesktop\Telegram\lib_webrtc\webrtc\webrtc_environment.h(15,11):
31>    or       'Webrtc::Platform'
31>C:\tdesktop\Telegram\SourceFiles\settings\settings_calls.cpp(426,62): error C2872: 'Platform': ambiguous symbol
31>(compiling source file '../../Telegram/SourceFiles/settings/settings_calls.cpp')
31>    C:\tdesktop\Telegram\SourceFiles\calls\calls_instance.h(16,11):
31>    could be 'Platform'
31>    C:\tdesktop\Telegram\lib_webrtc\webrtc\webrtc_environment.h(15,11):
31>    or       'Webrtc::Platform'
31>settings_main.cpp
```
Of course, a better way is to declare it directly at the beginning
```
using namespace ::Platform;
using namespace Webrtc;
```
