### PR TITLE
Don't set CMAKE_EXPORT_COMPILE_COMMANDS via cmake.configureSettings

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,10 +9,7 @@
                     "--compile-commands-dir=${workspaceFolder}/out"
                 ],
                 "cmake.generator": "Ninja Multi-Config",
-                "cmake.buildDirectory": "${workspaceFolder}/out",
-                "cmake.configureSettings": {
-                    "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-                }
+                "cmake.buildDirectory": "${workspaceFolder}/out"
             },
             "extensions": [
                 "ms-vscode.cpptools-extension-pack",


### PR DESCRIPTION
It's controlled by cmake.exportCompileCommandsFile and defaults to true