### PR TITLE
Fix building against ffmpeg-4.x

### DIFF
--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
+++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
@@ -546,9 +546,10 @@ SwresamplePointer MakeSwresamplePointer(
 	}
 
 	// Initialize audio resampler
+	AvErrorWrap error;
 #if DA_FFMPEG_NEW_CHANNEL_LAYOUT
 	auto result = (SwrContext*)nullptr;
-	auto error = AvErrorWrap(swr_alloc_set_opts2(
+	error = AvErrorWrap(swr_alloc_set_opts2(
 		&result,
 		dstLayout,
 		dstFormat,
@@ -564,7 +565,7 @@ SwresamplePointer MakeSwresamplePointer(
 	}
 #else // DA_FFMPEG_NEW_CHANNEL_LAYOUT
 	auto result = swr_alloc_set_opts(
-		existing ? existing.get() : nullptr,
+		existing ? existing->get() : nullptr,
 		dstLayout,
 		dstFormat,
 		dstRate,

--- a/Telegram/SourceFiles/media/audio/media_audio_local_cache.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio_local_cache.cpp
@@ -44,7 +44,13 @@ constexpr auto kFrameSize = 4096;
 		return {};
 	}
 
+
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58, 79, 100)
 	auto inCodec = (const AVCodec*)nullptr;
+#else
+	auto inCodec = (AVCodec*)nullptr;
+#endif
+
 	const auto streamId = av_find_best_stream(
 		input.get(),
 		AVMEDIA_TYPE_AUDIO,
@@ -152,10 +158,10 @@ constexpr auto kFrameSize = 4096;
 		inCodecContext->sample_rate,
 		&outCodecContext->ch_layout,
 #else // DA_FFMPEG_NEW_CHANNEL_LAYOUT
-		&inCodecContext->channel_layout,
+		inCodecContext->channel_layout,
 		inCodecContext->sample_fmt,
 		inCodecContext->sample_rate,
-		&outCodecContext->channel_layout,
+		outCodecContext->channel_layout,
 #endif // DA_FFMPEG_NEW_CHANNEL_LAYOUT
 		outCodecContext->sample_fmt,
 		outCodecContext->sample_rate);

--- a/Telegram/SourceFiles/ui/controls/round_video_recorder.cpp
+++ b/Telegram/SourceFiles/ui/controls/round_video_recorder.cpp
@@ -341,10 +341,10 @@ bool RoundVideoRecorder::Private::initAudio() {
 		&_swrContext);
 #else // DA_FFMPEG_NEW_CHANNEL_LAYOUT
 	_swrContext = MakeSwresamplePointer(
-		&_audioCodec->channel_layout,
+		_audioCodec->channel_layout,
 		AV_SAMPLE_FMT_S16,
 		_audioCodec->sample_rate,
-		&_audioCodec->channel_layout,
+		_audioCodec->channel_layout,
 		_audioCodec->sample_fmt,
 		_audioCodec->sample_rate,
 		&_swrContext);


### PR DESCRIPTION
Tested against ffmpeg 4.4.5 and 6.1.2 though there may be versions in between where this breaks. Fixes #28660.