### PR TITLE
Revert "Don't update mouse in non-active window."

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -1577,7 +1577,6 @@ void HistoryInner::mouseMoveEvent(QMouseEvent *e) {
 		mouseReleaseEvent(e);
 	}
 	if (reallyMoved) {
-		_mouseActive = true;
 		lastGlobalPosition = e->globalPos();
 		if (!buttonsPressed || (_scrollDateLink && ClickHandler::getPressed() == _scrollDateLink)) {
 			keepScrollDateForNow();
@@ -1624,7 +1623,6 @@ void HistoryInner::mousePressEvent(QMouseEvent *e) {
 		e->accept();
 		return; // ignore mouse press, that was hiding context menu
 	}
-	_mouseActive = true;
 	mouseActionStart(e->globalPos(), e->button());
 }
 
@@ -3528,7 +3526,6 @@ void HistoryInner::setShownPinned(HistoryItem *item) {
 }
 
 void HistoryInner::enterEventHook(QEnterEvent *e) {
-	_mouseActive = true;
 	mouseActionUpdate(QCursor::pos());
 	return TWidget::enterEventHook(e);
 }
@@ -3545,7 +3542,6 @@ void HistoryInner::leaveEventHook(QEvent *e) {
 		_cursor = style::cur_default;
 		setCursor(_cursor);
 	}
-	_mouseActive = false;
 	return TWidget::leaveEventHook(e);
 }
 
@@ -3896,7 +3892,7 @@ auto HistoryInner::reactionButtonParameters(
 }
 
 void HistoryInner::mouseActionUpdate() {
-	if (hasPendingResizedItems() || !_mouseActive) {
+	if (hasPendingResizedItems()) {
 		return;
 	}
 

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -499,7 +499,6 @@ private:
 	HistoryItem *_dragStateItem = nullptr;
 	CursorState _mouseCursorState = CursorState();
 	uint16 _mouseTextSymbol = 0;
-	bool _mouseActive = false;
 	bool _dragStateUserpic = false;
 	bool _pressWasInactive = false;
 	bool _recountedAfterPendingResizedItems = false;


### PR DESCRIPTION
This reverts commit 7ac849ab12c766149206a84fd2bd150f4dac8538.

This commit introduce bug on mobile linux with Wayland

1) the photo did not open after clicking
2) context menu did not appear after a long press
3) jumping to the original message after clicking on a quote didn't work

fix for https://github.com/telegramdesktop/tdesktop/issues/29008