### PR TITLE
fix(integration_linux): include core_settings.h with Qt version <= 6.5.0

### DIFF
--- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
@@ -12,6 +12,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/platform/linux/base_linux_xdp_utilities.h"
 #include "core/sandbox.h"
 #include "core/application.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include "core/core_settings.h"
+#endif
 #include "base/random.h"
 
 #include <QtCore/QAbstractEventDispatcher>


### PR DESCRIPTION
This fixes the following build time error:
```
/var/cache/acbs/build/acbs.zwzqxh86/tdesktop-5.12.1-full/Telegram/SourceFiles/platform/linux/integration_linux.cpp: In lambda function:
/var/cache/acbs/build/acbs.zwzqxh86/tdesktop-5.12.1-full/Telegram/SourceFiles/platform/linux/integration_linux.cpp:153:45: error: invalid use of incomplete type ‘class Core::Settings’
  153 |                         Core::App().settings().setSystemDarkMode(value.get_uint32() == 1);
      |                         ~~~~~~~~~~~~~~~~~~~~^~
In file included from /var/cache/acbs/build/acbs.zwzqxh86/tdesktop-5.12.1-full/Telegram/SourceFiles/platform/linux/integration_linux.cpp:14:
/var/cache/acbs/build/acbs.zwzqxh86/tdesktop-5.12.1-full/Telegram/SourceFiles/core/application.h:115:7: note: forward declaration of ‘class Core::Settings’
  115 | class Settings;
      |       ^~~~~~~~
/var/cache/acbs/build/acbs.zwzqxh86/tdesktop-5.12.1-full/Telegram/SourceFiles/platform/linux/integration_linux.cpp: At global scope:
/var/cache/acbs/build/acbs.zwzqxh86/tdesktop-5.12.1-full/Telegram/SourceFiles/platform/linux/integration_linux.cpp:80:1: warning: ‘Platform::{anonymous}::Application::Application()’ defined but not used [-Wunused-function]
   80 | Application::Application()
      | ^~~~~~~~~~~
```

That include statement was removed in cf61dedc79957eb0e5ba8ed5494dd19d9e238977 , which leads to the build time error.