### PR TITLE
Fix Platform::ApplicationIconName for snap

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -779,9 +779,9 @@ QImage DefaultApplicationIcon() {
 }
 
 QString ApplicationIconName() {
-	static const auto Result = (KSandbox::isSnap()
+	static const auto Result = KSandbox::isSnap()
 		? u"snap.%1."_q.arg(qEnvironmentVariable("SNAP_INSTANCE_NAME"))
-		: QString()) + QGuiApplication::desktopFileName().remove(
+		: QGuiApplication::desktopFileName().remove(
 		u"._"_q + Core::Launcher::Instance().instanceHash());
 	return Result;
 }


### PR DESCRIPTION
Looks like it broke through rebases