### PR TITLE
update ada-url to v3.2.1

### DIFF
--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -807,12 +807,13 @@ RUN cmake --build out --config Debug --parallel \
 {%- endif %}
 
 FROM builder AS ada
-RUN git clone -b v2.9.0 --depth=1 {{ GIT }}/ada-url/ada.git \
+RUN git clone -b v3.2.1 --depth=1 {{ GIT }}/ada-url/ada.git \
 	&& cd ada \
 	&& cmake -GNinja -B build . \
 		-D CMAKE_BUILD_TYPE=None \
         -D ADA_TESTING=OFF \
         -D ADA_TOOLS=OFF \
+        -D ADA_INCLUDE_URL_PATTERN=OFF \
 	&& cmake --build build --parallel \
 	&& DESTDIR="{{ LibrariesPath }}/ada-cache" cmake --install build \
 	&& cd .. \

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1864,7 +1864,7 @@ release:
 """)
 
 stage('ada', """
-    git clone -b 3.2.1 https://github.com/ada-url/ada.git
+    git clone -b v3.2.1 https://github.com/ada-url/ada.git
     cd ada
 win:
     cmake -B out . ^

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1864,13 +1864,14 @@ release:
 """)
 
 stage('ada', """
-    git clone -b v2.9.0 https://github.com/ada-url/ada.git
+    git clone -b 3.2.1 https://github.com/ada-url/ada.git
     cd ada
 win:
     cmake -B out . ^
         -A %WIN32X64% ^
         -D ADA_TESTING=OFF ^
         -D ADA_TOOLS=OFF ^
+        -D ADA_INCLUDE_URL_PATTERN=OFF ^
         -D CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" ^
         -D CMAKE_C_FLAGS_DEBUG="/MTd /Zi /Ob0 /Od /RTC1" ^
         -D CMAKE_C_FLAGS_RELEASE="/MT /O2 /Ob2 /DNDEBUG"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -218,7 +218,7 @@ parts:
   ada:
     source: https://github.com/ada-url/ada.git
     source-depth: 1
-    source-tag: v2.9.0
+    source-tag: v3.2.1
     plugin: cmake
     build-environment:
       - LDFLAGS: ${LDFLAGS:+$LDFLAGS} -s
@@ -228,6 +228,7 @@ parts:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DADA_TESTING=OFF
       - -DADA_TOOLS=OFF
+      - -DADA_INCLUDE_URL_PATTERN=OFF
     prime:
       - -./usr/include
       - -./usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/cmake


### PR DESCRIPTION
I'm one of the authors of ada-url. I realized that telegram is using an old version of Ada, and wanted to contribute the following change to Telegram. The only major change I added was adding "ADA_INCLUDE_URL_PATTERN" flag which removes the URLPattern implementation, which Telegram doesn't depend on, since it's available after v3.