### PR TITLE
Let QIcon::fromTheme check whether the tray icon is valid

### DIFF
--- a/Telegram/SourceFiles/platform/linux/tray_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/tray_linux.cpp
@@ -95,7 +95,7 @@ QIcon IconGraphic::systemIcon() const {
 		if (candidate.isEmpty()) {
 			continue;
 		}
-		const auto icon = QIcon::fromTheme(candidate);
+		const auto icon = QIcon::fromTheme(candidate, QIcon());
 		if (icon.name() == candidate) {
 			return icon;
 		}


### PR DESCRIPTION
QIcon::fromTheme overload with a fallback does a smarter check whether the icon is valid, use it to prevent getting a half-valid QIcon.

Should fix #29131 (but not sure)