### PR TITLE
Update mime_type.cpp - add m3u to ip revealing types

### DIFF
--- a/Telegram/SourceFiles/core/mime_type.cpp
+++ b/Telegram/SourceFiles/core/mime_type.cpp
@@ -326,7 +326,7 @@ bool NameTypeAllowsThumbnail(NameType type) {
 
 bool IsIpRevealingPath(const QString &filepath) {
 	static const auto kExtensions = [] {
-		const auto joined = u"htm html svg m4v m3u8 xhtml"_q;
+		const auto joined = u"htm html svg m4v m3u m3u8 xhtml"_q;
 		const auto list = joined.split(' ');
 		return base::flat_set<QString>(list.begin(), list.end());
 	}();


### PR DESCRIPTION
Currently m3u is not listed as IP revealing MIME type, while m3u8 is. This commit adds m3u as well.