### PR TITLE
fix: correct a typo in data_document_resolver.cpp

### DIFF
--- a/Telegram/SourceFiles/data/data_document_resolver.cpp
+++ b/Telegram/SourceFiles/data/data_document_resolver.cpp
@@ -43,7 +43,7 @@ base::options::toggle OptionExternalVideoPlayer({
 	.id = kOptionExternalVideoPlayer,
 	.name = "External video player",
 	.description = "Use system video player instead of the internal one. "
-		"This disabes video playback in messages.",
+		"This disables video playback in messages.",
 });
 
 void ConfirmDontWarnBox(


### PR DESCRIPTION
This pull request includes a small typo fix in the `Telegram/SourceFiles/data/data_document_resolver.cpp` file. The change corrects the word "disabes" to "disables" in the description of the `OptionExternalVideoPlayer` option.