### PR TITLE
Set CMAKE_MSVC_RUNTIME_LIBRARY for mozjpeg

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -586,6 +586,7 @@ stage('mozjpeg', """
 win:
     cmake . ^
         -A %WIN32X64% ^
+        -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" ^
         -DWITH_JPEG8=ON ^
         -DPNG_SUPPORTED=OFF
     cmake --build . --config Debug --parallel


### PR DESCRIPTION
The cherry-pick made in 9fd1f95ab88a90e8acde6d26b2f1d715961f5c24 broke mozjpeg's own WITH_CRT_DLL variable so we have to use the cmake one