### PR TITLE
Ensure clangd cache is out of build directory

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -5,11 +5,9 @@
         "vscode": {
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",
-                "clangd.arguments": [
-                    "--compile-commands-dir=${workspaceFolder}/out"
-                ],
                 "cmake.generator": "Ninja Multi-Config",
-                "cmake.buildDirectory": "${workspaceFolder}/out"
+                "cmake.buildDirectory": "${workspaceFolder}/out",
+                "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json"
             },
             "extensions": [
                 "ms-vscode.cpptools-extension-pack",

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ ipch/
 .vs/
 .vscode/
 .cache/
+compile_commands.json
 
 /Telegram/log.txt
 /Telegram/data


### PR DESCRIPTION
It's annoying to rebuild index after cleaning the build directory