### PR TITLE
click_handler_types.cpp UrlRequiresConfirmation(): add linkedin.com

### DIFF
--- a/Telegram/SourceFiles/core/click_handler_types.cpp
+++ b/Telegram/SourceFiles/core/click_handler_types.cpp
@@ -80,6 +80,7 @@ bool UrlRequiresConfirmation(const QUrl &url) {
 		"|graph\\.org"
 		"|fragment\\.com"
 		"|telesco\\.pe"
+		"|linkedin\\.com"
 		")$",
 		url.host(),
 		RegExOption::CaseInsensitive);


### PR DESCRIPTION
I think Linkedin is safe enough.