### PR TITLE
Fixed the birthday selection box for February

### DIFF
--- a/Telegram/SourceFiles/ui/boxes/edit_birthday_box.cpp
+++ b/Telegram/SourceFiles/ui/boxes/edit_birthday_box.cpp
@@ -162,8 +162,8 @@ void EditBirthdayBox(
 			? max.day()
 			: (month == 2)
 			? ((!year || ((year % 4) && (!(year % 100) || (year % 400))))
-				? 29
-				: 28)
+				? 28
+				: 29)
 			: ((month == 4) || (month == 6) || (month == 9) || (month == 11))
 			? 30
 			: 31;


### PR DESCRIPTION
Fixed the birthday selection box for February. Currently (as shown in the GIF), leap years are determined incorrectly: leap years don’t have the 29th day, while non-leap years do. If you try to select that date, nothing happens because the logic in Telegram/SourceFiles/data/data_birthday.cpp is correct and prevents setting an invalid date. 
Now everything should display correctly.
![2025-07-1014-51-06-ezgif com-crop](https://github.com/user-attachments/assets/6ac7b32a-1ec1-49aa-ae47-b06b0f9e6df4)
