### PR TITLE
Remove unity7 plug from snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,6 @@ apps:
       - network-bind
       - network-status
       - removable-media
-      - unity7
     slots:
       - mpris
 


### PR DESCRIPTION
Looks like the desktop plug has everything needed since snapd 2.67