### PR TITLE
Remove systemd-detect-virt from snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,14 +115,12 @@ parts:
       - libxkbcommon-x11-dev
       - libxv-dev
     stage-packages:
-      - systemd
       - libgeoclue-2-0
       - libopenh264-7
       - libxcb-cursor0
       - libxcb-record0
       - libxcb-screensaver0
     stage:
-      - ./usr/bin/systemd-detect-virt
       - ./usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgeoclue-2.so*
       - ./usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libopenh264.so*
       - ./usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-cursor.so*


### PR DESCRIPTION
It could be used from the core snap since hardware-observe plug was connected