### PR TITLE
Restore icon key in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: telegram-desktop
 adopt-info: telegram
+icon: Telegram/Resources/art/icon512@2x.png
 
 base: core24
 grade: stable


### PR DESCRIPTION
Looks like it didn't help with themed icon after all and snapcraft chooses a 64x64 icon without it which looks blurry with HiDPI