### PR TITLE
Freeze depot_tools at safe commit, main is broken

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -510,7 +510,8 @@ stage('depot_tools', """
 mac:
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
     cd depot_tools
-    ./update_depot_tools
+    git checkout 0e9c00fe9f9783104836bd68870b5253c8c76121
+    DEPOT_TOOLS_UPDATE=0 ./update_depot_tools
 """, 'ThirdParty')
 
 if not mac or 'build-stackwalk' in options:


### PR DESCRIPTION
Freeze depot_tools at safe commit, main branch is broken as of 3.9.2025, causing libraries build on mac to fail