### PR TITLE
Introduce initial accessibility support to Telegram Desktop

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -22,6 +22,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_menu_my_stories" = "My Stories";
 "lng_menu_my_groups" = "My Groups";
 "lng_menu_my_channels" = "My Channels";
+"lng_open_menu" = "Open navigation menu";
 
 "lng_disable_notifications_from_tray" = "Disable notifications";
 "lng_enable_notifications_from_tray" = "Enable notifications";
@@ -127,6 +128,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_cancel" = "Cancel";
 "lng_continue" = "Continue";
 "lng_close" = "Close";
+"lng_minimize_window" = "Minimize";
+"lng_maximize_window" = "Maximize";
+"lng_restore_window" = "Restore";
+"lng_go_back" = "Go back";
 "lng_connecting" = "Connecting...";
 "lng_reconnecting#one" = "Reconnect in {count} s...";
 "lng_reconnecting#other" = "Reconnect in {count} s...";
@@ -388,6 +393,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_country_ph" = "Search";
 "lng_country_none" = "Country not found";
 "lng_country_select" = "Select Country";
+"lng_phone_number" = "Phone number";
 
 "lng_code_ph" = "Code";
 "lng_code_desc" = "We've sent an activation code to your phone.\nPlease enter it below.";

--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -85,6 +85,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/qthelp_regex.h"
 #include "base/qthelp_url.h"
 #include "boxes/premium_limits_box.h"
+#include "ui/accessibility.h"
 #include "ui/boxes/confirm_box.h"
 #include "ui/controls/location_picker.h"
 #include "styles/style_window.h"
@@ -260,6 +261,8 @@ void Application::run() {
 	_notifications = std::make_unique<Window::Notifications::System>();
 
 	startLocalStorage();
+
+	Ui::InstallAccessibleFactory();
 
 	style::SetCustomFont(settings().customFontFamily());
 	style::internal::StartFonts();

--- a/Telegram/SourceFiles/core/ui_integration.cpp
+++ b/Telegram/SourceFiles/core/ui_integration.cpp
@@ -440,6 +440,18 @@ QString UiIntegration::phraseQuoteHeaderCopy() {
 	return tr::lng_code_block_header_copy(tr::now);
 }
 
+QString UiIntegration::phraseMinimize() {
+	return tr::lng_minimize_window(tr::now);
+}
+
+QString UiIntegration::phraseMaximize() {
+	return tr::lng_maximize_window(tr::now);
+}
+
+QString UiIntegration::phraseRestore() {
+	return tr::lng_restore_window(tr::now);
+}
+
 bool OpenGLLastCheckFailed() {
 	return QFile::exists(OpenGLCheckFilePath());
 }

--- a/Telegram/SourceFiles/core/ui_integration.h
+++ b/Telegram/SourceFiles/core/ui_integration.h
@@ -92,6 +92,9 @@ public:
 	QString phraseBotAllowWriteTitle() override;
 	QString phraseBotAllowWriteConfirm() override;
 	QString phraseQuoteHeaderCopy() override;
+	QString phraseMinimize() override;
+	QString phraseMaximize() override;
+	QString phraseRestore() override;
 
 };
 

--- a/Telegram/SourceFiles/intro/intro_code.cpp
+++ b/Telegram/SourceFiles/intro/intro_code.cpp
@@ -39,6 +39,7 @@ CodeWidget::CodeWidget(
 , _callTimeout(getData()->callTimeout)
 , _callLabel(this, st::introDescription)
 , _checkRequestTimer([=] { checkRequest(); }) {
+	setAccessibleRole(QAccessible::Role::Dialog);
 	Lang::Updated(
 	) | rpl::start_with_next([=] {
 		refreshLang();

--- a/Telegram/SourceFiles/intro/intro_code_input.cpp
+++ b/Telegram/SourceFiles/intro/intro_code_input.cpp
@@ -160,6 +160,8 @@ void CodeDigit::paintEvent(QPaintEvent *e) {
 CodeInput::CodeInput(QWidget *parent)
 : Ui::RpWidget(parent) {
 	setFocusPolicy(Qt::StrongFocus);
+	setAccessibleRole(QAccessible::Role::EditableText);
+	setAccessibleName(tr::lng_code_ph(tr::now));
 }
 
 void CodeInput::setDigitsCountMax(int digitsCount) {

--- a/Telegram/SourceFiles/intro/intro_password_check.cpp
+++ b/Telegram/SourceFiles/intro/intro_password_check.cpp
@@ -37,6 +37,7 @@ PasswordCheckWidget::PasswordCheckWidget(
 , _codeField(this, st::introPassword, tr::lng_signin_code())
 , _toRecover(this, tr::lng_signin_recover(tr::now))
 , _toPassword(this, tr::lng_signin_try_password(tr::now)) {
+	setAccessibleRole(QAccessible::Role::Dialog);
 	Expects(_passwordState.hasPassword);
 
 	Lang::Updated(

--- a/Telegram/SourceFiles/intro/intro_phone.cpp
+++ b/Telegram/SourceFiles/intro/intro_phone.cpp
@@ -62,6 +62,9 @@ PhoneWidget::PhoneWidget(
 	st::introPhone,
 	[](const QString &s) { return Countries::Groups(s); })
 , _checkRequestTimer([=] { checkRequest(); }) {
+	setAccessibleRole(QAccessible::Role::Dialog);
+	_code->setAccessibleName(tr::lng_country_code(tr::now));
+	_phone->setAccessibleName(tr::lng_phone_number(tr::now));
 	_phone->frontBackspaceEvent(
 	) | rpl::start_with_next([=](not_null<QKeyEvent*> e) {
 		_code->startErasing(e);

--- a/Telegram/SourceFiles/intro/intro_qr.cpp
+++ b/Telegram/SourceFiles/intro/intro_qr.cpp
@@ -80,6 +80,8 @@ namespace {
 		style::PaletteChanged()
 	);
 	auto result = Ui::CreateChild<Ui::RpWidget>(parent.get());
+	result->setAccessibleRole(QAccessible::Role::Graphic);
+	result->setAccessibleName(tr::lng_intro_qr_title(tr::now));
 	const auto state = result->lifetime().make_state<State>(
 		[=] { result->update(); });
 	state->waiting.start();
@@ -181,6 +183,20 @@ QrWidget::QrWidget(
 	setTitleText(rpl::single(QString()));
 	setDescriptionText(rpl::single(QString()));
 	setErrorCentered(true);
+	setAccessibleRole(QAccessible::Role::Dialog);
+	setAccessibleName(tr::lng_intro_qr_title(tr::now));
+
+	const auto texts = {
+	tr::lng_intro_qr_step1,
+	tr::lng_intro_qr_step2,
+	tr::lng_intro_qr_step3,
+	};
+	QString fullDescription;
+	int index = 1;
+	for (const auto& text : texts) {
+		fullDescription += QString::number(index++) + ". " + text(tr::now) + "\n";
+	}
+	setAccessibleDescription(fullDescription);
 
 	cancelNearestDcRequest();
 
@@ -410,6 +426,10 @@ void QrWidget::sendCheckPasswordRequest() {
 void QrWidget::activate() {
 	Step::activate();
 	showChildren();
+
+	if (const auto skipButton = findChild<Ui::LinkButton*>()) {
+		skipButton->setFocus(Qt::OtherFocusReason);
+	}
 }
 
 void QrWidget::finished() {

--- a/Telegram/SourceFiles/intro/intro_step.cpp
+++ b/Telegram/SourceFiles/intro/intro_step.cpp
@@ -77,6 +77,7 @@ Step::Step(
 		_hasCover
 			? st::introCoverDescription
 			: st::introDescription)) {
+	setAccessibleRole(QAccessible::Pane);
 	hide();
 	style::PaletteChanged(
 	) | rpl::start_with_next([=] {
@@ -94,6 +95,7 @@ Step::Step(
 	_titleText.value(
 	) | rpl::start_with_next([=](const QString &text) {
 		_title->setText(text);
+		setAccessibleName(text);
 		updateLabelsPosition();
 	}, lifetime());
 
@@ -105,6 +107,7 @@ Step::Step(
 			EntityType::Spoiler,
 			&EntityInText::type);
 		label->setMarkedText(text);
+		setAccessibleDescription(text.text);
 		label->setAttribute(Qt::WA_TransparentForMouseEvents, hasSpoiler);
 		updateLabelsPosition();
 	}, lifetime());

--- a/Telegram/SourceFiles/intro/intro_widget.cpp
+++ b/Telegram/SourceFiles/intro/intro_widget.cpp
@@ -141,6 +141,7 @@ Widget::Widget(
 	}, lifetime());
 
 	_back->entity()->setClickedCallback([=] { backRequested(); });
+	_back->entity()->setAccessibleName(tr::lng_go_back(tr::now));
 	_back->hide(anim::type::instant);
 
 	if (_changeLanguage) {

--- a/Telegram/SourceFiles/settings/settings_intro.cpp
+++ b/Telegram/SourceFiles/settings/settings_intro.cpp
@@ -224,6 +224,8 @@ IntroWidget::IntroWidget(
 , _wrap(this)
 , _scroll(Ui::CreateChild<Ui::ScrollArea>(_wrap.data()))
 , _topShadow(this) {
+	setAccessibleRole(QAccessible::Dialog);
+	setAccessibleName(tr::lng_menu_settings(tr::now));
 	_wrap->setAttribute(Qt::WA_OpaquePaintEvent);
 	_wrap->paintRequest(
 	) | rpl::start_with_next([=](QRect clip) {
@@ -290,6 +292,7 @@ void IntroWidget::createTopBar(not_null<Window::Controller*> window) {
 		base::make_unique_q<Ui::IconButton>(
 			_topBar,
 			st::infoLayerTopBarClose));
+	close->setAccessibleName(tr::lng_close(tr::now));
 	close->addClickHandler([=] {
 		window->hideSettingsAndLayer();
 	});

--- a/Telegram/SourceFiles/ui/countryinput.cpp
+++ b/Telegram/SourceFiles/ui/countryinput.cpp
@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/countryinput.h"
 
 #include "lang/lang_keys.h"
+#include "ui/accessibility.h"
 #include "ui/widgets/scroll_area.h"
 #include "ui/widgets/multi_select.h"
 #include "ui/effects/ripple_animation.h"
@@ -29,6 +30,9 @@ CountryInput::CountryInput(
 , _st(st)
 , _text(tr::lng_country_code(tr::now)) {
 	resize(_st.width, _st.heightMin);
+	setFocusPolicy(Qt::StrongFocus);
+	setAccessibleRole(QAccessible::Role::PushButton);
+	setAccessibleName(_text);
 }
 
 void CountryInput::paintEvent(QPaintEvent *e) {
@@ -198,4 +202,5 @@ void CountryInput::setText(const QString &newText) {
 	_text = _st.style.font->elided(
 		newText,
 		width() - _st.textMargins.left() - _st.textMargins.right());
+	setAccessibleName(newText);
 }

--- a/Telegram/SourceFiles/ui/countryinput.h
+++ b/Telegram/SourceFiles/ui/countryinput.h
@@ -41,6 +41,7 @@ protected:
 	void paintEvent(QPaintEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;
 	void mousePressEvent(QMouseEvent *e) override;
+	void keyPressEvent(QKeyEvent* e) override;
 	void enterEventHook(QEnterEvent *e) override;
 	void leaveEventHook(QEvent *e) override;
 

--- a/Telegram/SourceFiles/window/window_connecting_widget.cpp
+++ b/Telegram/SourceFiles/window/window_connecting_widget.cpp
@@ -498,6 +498,7 @@ ConnectionState::Widget::Widget(
 : AbstractButton(parent)
 , _account(account)
 , _currentLayout(layout) {
+	setAccessibleRole(QAccessible::StatusBar);
 	_proxyIcon = Ui::CreateChild<ProxyIcon>(this);
 	_progress = Ui::CreateChild<Progress>(this);
 
@@ -619,6 +620,7 @@ void ConnectionState::Widget::setLayout(const Layout &layout) {
 	_currentLayout = layout;
 	_proxyIcon->setToggled(_currentLayout.proxyEnabled);
 	refreshRetryLink(_currentLayout.hasRetry);
+	setAccessibleName(_currentLayout.text);
 }
 
 void ConnectionState::Widget::setProgressVisibility(bool visible) {


### PR DESCRIPTION
Telegram Desktop previously had no accessibility support.  
This pull request introduces the initial set of improvements to make the application accessible to screen reader users.

✔ Changes included:
- Added a base accessibility class to initialize accessibility support.
- Integrated accessibility factory initialization in Application::run.
- Set accessibility names and roles for MainWindow, intro steps, labels, and titles.
- Added accessible names and roles for CodeInput, CodeDigit, and CountryInput widgets.
- Introduced accessibility strings for digits and navigation.
- Added accessible names for intro widgets and MainWindow, consistent with other UI elements.

🧪 Testing:
All changes were tested with NVDA screen reader on Windows and worked without issues.

🚀 Next steps:
If there is positive feedback and interest, I plan to continue improving accessibility across the rest of Telegram Desktop.
