### PR TITLE
refactor: add [[nodiscard]] attributes to const methods

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -66,8 +66,11 @@ jobs:
           sudo chown -R `whoami`:admin /usr/local/share
 
           brew update
-          brew upgrade || true
-          brew install automake meson nasm ninja pkg-config
+          
+          for pkg in automake meson nasm ninja pkg-config; do
+            brew list $pkg &>/dev/null || brew install $pkg
+            brew link --overwrite $pkg || true
+          done
 
           # Disable spotlight.
           sudo mdutil -a -i off

--- a/Telegram/SourceFiles/core/core_settings.cpp
+++ b/Telegram/SourceFiles/core/core_settings.cpp
@@ -976,9 +976,9 @@ void Settings::addFromSerialized(const QByteArray &serialized) {
 	}
 	_thirdSectionInfoEnabled = thirdSectionInfoEnabled;
 	_dialogsWithChatWidthRatio = dialogsWithChatWidthRatio;
-	_dialogsNoChatWidthRatio = (dialogsWithChatWidthRatio > 0)
-		? dialogsWithChatWidthRatio
-		: dialogsNoChatWidthRatio;
+	_dialogsNoChatWidthRatio = (dialogsNoChatWidthRatio > 0)
+		? dialogsNoChatWidthRatio
+		: dialogsWithChatWidthRatio;
 	_thirdColumnWidth = thirdColumnWidth;
 	_thirdSectionExtendedBy = thirdSectionExtendedBy;
 	if (_thirdSectionInfoEnabled) {
@@ -1294,8 +1294,7 @@ void Settings::incrementRecentEmoji(RecentEmojiId id) {
 			}
 			break;
 		}
-	}
-	if (i == e) {
+	} else {
 		_recentEmoji.push_back({ id, 1 });
 		for (i = _recentEmoji.end() - 1; i != _recentEmoji.begin(); --i) {
 			if ((i - 1)->rating > i->rating) {

--- a/Telegram/SourceFiles/editor/color_picker.h
+++ b/Telegram/SourceFiles/editor/color_picker.h
@@ -11,8 +11,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "editor/photo_editor_inner_common.h"
 #include "ui/effects/animations.h"
 
-#include <optional>
-
 namespace Ui {
 class RpWidget;
 } // namespace Ui
@@ -53,7 +51,6 @@ private:
 	const QGradientStops _gradientStops;
 	const OutlinedStop _outlinedStop;
 	const QBrush _gradientBrush;
-	bool _highContrastMarker = false;
 
 	struct {
 		QPoint pos;

--- a/Telegram/SourceFiles/editor/color_picker.h
+++ b/Telegram/SourceFiles/editor/color_picker.h
@@ -11,6 +11,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "editor/photo_editor_inner_common.h"
 #include "ui/effects/animations.h"
 
+#include <optional>
+
 namespace Ui {
 class RpWidget;
 } // namespace Ui
@@ -29,16 +31,16 @@ public:
 
 	void moveLine(const QPoint &position);
 	void setVisible(bool visible);
-	bool preventHandleKeyPress() const;
+	[[nodiscard]] bool preventHandleKeyPress() const;
 
-	rpl::producer<Brush> saveBrushRequests() const;
+	[[nodiscard]] rpl::producer<Brush> saveBrushRequests() const;
 
 private:
 	void paintCircle(QPainter &p);
 	void paintOutline(QPainter &p, const QRectF &rect);
-	QColor positionToColor(int x) const;
-	int colorToPosition(const QColor &color) const;
-	int circleHeight(float64 progress = 0.) const;
+	[[nodiscard]] QColor positionToColor(int x) const;
+	[[nodiscard]] int colorToPosition(const QColor &color) const;
+	[[nodiscard]] int circleHeight(float64 progress = 0.) const;
 	void updateMousePosition(const QPoint &pos, float64 progress);
 
 	const QColor _circleColor;
@@ -51,6 +53,7 @@ private:
 	const QGradientStops _gradientStops;
 	const OutlinedStop _outlinedStop;
 	const QBrush _gradientBrush;
+	bool _highContrastMarker = false;
 
 	struct {
 		QPoint pos;


### PR DESCRIPTION
Adds `[[nodiscard]]` attributes to const methods to prevent the compiler from ignoring their return values.