### PR TITLE
Actually share files with Drag'n'Drop to shortcut on macOS

### DIFF
--- a/Telegram/Telegram.plist
+++ b/Telegram/Telegram.plist
@@ -42,6 +42,19 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>@desktop_app_version_string@</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
The code supported this since 4.8.3 (6aef6d7f4ecf785e1e9cde372d617de2dedee99a) for Linux but wasn't actually allowed on macOS via plist.