### PR TITLE
Unification of Send menu

### DIFF
--- a/Telegram/SourceFiles/menu/menu_send.cpp
+++ b/Telegram/SourceFiles/menu/menu_send.cpp
@@ -690,11 +690,6 @@ FillMenuResult FillSendMenu(
 		? *iconsOverride
 		: st::defaultComposeIcons;
 
-	if (sending && type != Type::Reminder) {
-		menu->addAction(
-			tr::lng_send_silent_message(tr::now),
-			[=] { action({ Api::SendOptions{ .silent = true } }, details); },
-			&icons.menuMute);
 	}
 	if (sending && type != Type::SilentOnly) {
 		menu->addAction(
@@ -712,6 +707,11 @@ FillMenuResult FillSendMenu(
 				details); },
 			&icons.menuWhenOnline);
 	}
+	if (sending && type != Type::Reminder) {
+		menu->addAction(
+			tr::lng_send_silent_message(tr::now),
+			[=] { action({ Api::SendOptions{ .silent = true } }, details); },
+			&icons.menuMute);
 
 	if ((type != Type::Disabled)
 		&& ((details.spoiler != SpoilerState::None)


### PR DESCRIPTION
Unification of Send menu (https://bugs.telegram.org/c/55220):

After this fix it will be as on Android:
- Schedule Message
- Send when Online
- Send without sound

Before fixing it was 
- Send without sound
- Schedule Message
- Send when Online