### PR TITLE
Fix compilation with Clang-21 + libstdc++-16

### DIFF
--- a/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
+++ b/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
@@ -1403,7 +1403,7 @@ void WebViewInstance::showGame() {
 	Expects(v::is<WebViewSourceGame>(_source));
 
 	if (!_bot->isFullLoaded()) {
-		_botFullWaitingArgs.emplace();
+		_botFullWaitingArgs = ShowArgs{};
 		return;
 	}
 	const auto game = v::get<WebViewSourceGame>(_source);


### PR DESCRIPTION
.emplace() can only be used on constructible objects, while private nested struct is not considered as constructible due to access control.

Closes #29939