### PR TITLE
Search contact notes

### DIFF
--- a/Telegram/SourceFiles/boxes/peer_list_box.cpp
+++ b/Telegram/SourceFiles/boxes/peer_list_box.cpp
@@ -1007,7 +1007,7 @@ PeerListContent::PeerListContent(
 
 	using UpdateFlag = Data::PeerUpdate::Flag;
 	_controller->session().changes().peerUpdates(
-		UpdateFlag::Name | UpdateFlag::Photo | UpdateFlag::EmojiStatus
+		UpdateFlag::Name | UpdateFlag::Photo | UpdateFlag::EmojiStatus | UpdateFlag::ContactNote
 	) | rpl::start_with_next([=](const Data::PeerUpdate &update) {
 		if (update.flags & UpdateFlag::Name) {
 			handleNameChanged(update.peer);

--- a/Telegram/SourceFiles/data/data_peer.cpp
+++ b/Telegram/SourceFiles/data/data_peer.cpp
@@ -1075,6 +1075,7 @@ void PeerData::fillNames() {
 			appendToIndex(user->nameOrPhone);
 		}
 		appendToIndex(user->username());
+		appendToIndex(user->note().text);
 		if (isSelf()) {
 			const auto english = u"Saved messages"_q;
 			const auto localized = tr::lng_saved_messages(tr::now);


### PR DESCRIPTION
Notes were recently added to contacts, which is a great feature.
I thought it would be useful if they were searchable, so this adds note text to the peer index and updates when contact notes change.

**I couldn't build it locally** (my laptop kept dying), so please double-check that it works as expected.