### PR TITLE
Make chat filters sidebar accessible to screen readers

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -22,7 +22,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_menu_my_stories" = "My Stories";
 "lng_menu_my_groups" = "My Groups";
 "lng_menu_my_channels" = "My Channels";
-"lng_open_menu" = "Open navigation menu";
+"lng_main_menu" = "Main menu";
+"lng_filter_unread_chats#one" = "{text} ({count} unread chat)";
+"lng_filter_unread_chats#other" = "{text} ({count} unread chats)";
 
 "lng_disable_notifications_from_tray" = "Disable notifications";
 "lng_enable_notifications_from_tray" = "Enable notifications";

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -1323,6 +1323,7 @@ void Widget::setupMainMenuToggle() {
 	});
 	_mainMenu.under->stackUnder(_mainMenu.toggle);
 	_mainMenu.toggle->setClickedCallback([=] { showMainMenu(); });
+	_mainMenu.toggle->setAccessibleName(tr::lng_main_menu(tr::now));
 
 	rpl::single(rpl::empty) | rpl::then(
 		controller()->filtersMenuChanged()

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -66,6 +66,7 @@ FiltersMenu::~FiltersMenu() = default;
 
 void FiltersMenu::setup() {
 	setupMainMenuIcon();
+	_menu.setAccessibleName(tr::lng_main_menu(tr::now));
 
 	_outer.setAttribute(Qt::WA_OpaquePaintEvent);
 	_outer.show();
@@ -271,6 +272,9 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 		: container->add(std::move(prepared));
 	auto button = base::unique_qptr<Ui::SideBarButton>(std::move(added));
 	const auto raw = button.get();
+	const auto nameText = id
+		? title.text.text
+		: tr::lng_filters_all(tr::now);
 	const auto &icons = Ui::LookupFilterIcon(id
 		? icon
 		: Ui::FilterIcon::All);
@@ -293,6 +297,14 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 				? "99+"
 				: QString::number(count);
 			raw->setBadge(string, includeMuted && (count == muted));
+			raw->setAccessibleName(count
+				? tr::lng_filter_unread_chats(
+					tr::now,
+					lt_count,
+					count,
+					lt_text,
+					nameText)
+				: nameText);
 		}, raw->lifetime());
 	}
 	raw->setActive(_session->activeChatsFilterCurrent() == id);


### PR DESCRIPTION
s pull request implements accessibility for the chat filters (folders) sidebar, making it fully navigable and understandable for users with screen readers.
Problem
Previously, the chat filters sidebar was not exposed correctly to assistive technologies. Screen readers could not identify the list of filters as a single, cohesive widget group (like a tab list), preventing users from effectively navigating between their chat folders using the keyboard.
Solution
Following the pattern of Qt's complex accessible widgets (like QAccessibleTabBar), this PR introduces a virtual accessibility tree for the filters menu:
1. 
Window::FiltersMenu Refactoring: The class is converted from a simple manager class into a proper Ui::RpWidget.
2. 
Accessibility Role: It is assigned the QAccessible::Role::PageTabList role, which correctly identifies it as a list of tabs to screen readers.
3. 
Virtual Accessibility Tree:
◦ 
A custom AccessibleFiltersMenu interface is created to manage the list of filters as virtual children.
◦ 
A lightweight AccessibleFilterButton interface represents each filter button without being a real QWidget, providing necessary information like its name, state (selected), and position on demand.
4. 
Ui::SideBarButton Update: The Q_OBJECT macro and an active() getter were added to support qobject_cast and state querying required by the accessibility implementation.
How to Test
1. 
Enable a screen reader on your operating system (e.g., Narrator on Windows, VoiceOver on macOS).
2. 
Launch Telegram Desktop with these changes.
3. 
Navigate to the chat filters sidebar using the keyboard (e.g., with the Tab key).
4. 
Expected behavior:
◦ 
The screen reader should announce the component as a "Tab list" or similar.
◦ 
You should be able to navigate between the different filters using the arrow keys (up/down or left/right).
◦ 
As you navigate, the screen reader should announce the name of each filter (e.g., "All Chats", "Unread") and its selected state.