### PR TITLE
Remove smooth scrolling in profiles when "Interface Animations" setting is disabled

### DIFF
--- a/Telegram/SourceFiles/info/info_flexible_scroll.cpp
+++ b/Telegram/SourceFiles/info/info_flexible_scroll.cpp
@@ -166,7 +166,11 @@ void FlexibleScrollHelper::setupScrollHandling() {
 				: previousValue;
 			if (!_scrollAnimation.animating()) {
 				_scrollTopTo = ((nextStep != -1) ? nextStep : top);
-				_scrollAnimation.start();
+				if (!anim::Disabled()) {
+					_scrollAnimation.start();
+				} else {
+					scrollToY(_scrollTopTo);
+				}
 			} else {
 				if (_scrollTopTo > _scrollTopFrom) {
 					// Down.
@@ -303,7 +307,11 @@ void FlexibleScrollHelper::setupScrollHandlingWithFilter() {
 		_scrollTopFrom = top;
 		if (!animationActive) {
 			_scrollTopTo = (nextStep != -1) ? nextStep : targetTop;
-			_scrollAnimation.start();
+			if (!anim::Disabled()) {
+				_scrollAnimation.start();
+			} else {
+				scrollToY(_scrollTopTo);
+			}
 		} else {
 			if (_scrollTopTo > _scrollTopFrom) {
 				if (_scrollTopTo == step1) {


### PR DESCRIPTION
disabling `"Interface Animations"` option in battery settings does not disable the smooth scrolling in profiles. experimental option `"Use legacy scroll processing in profiles"` does not disable it either. smooth scrolling is not present in any other scrollable interface element except for just profiles, which makes it inconsistent across the application

## Expected behavior
disabling "Interface animations" also should disable smooth scrolling in profiles

## Factual behavior
smooth scrolling in profiles is unaffected by any setting

## Implementation
disable smooth scrolling animation in profile pages when `Interface Animations` setting is turned off in battery saving settings. the fix checks `anim::Disabled()` before starting scroll animations in `setupScrollHandling()` and `setupScrollHandlingWithFilter()` methods

i have reviewed how the check for disabled `Interface Animations` is implemented in other parts of the source code to make sure that my changes are consistent with the already existing patterns, and it was, in fact, a simple "if else" check for `anim::Disabled()`, so i did just that