### PR TITLE
Use wrapped version of g_spawn_check_exit_status

### DIFF
--- a/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
@@ -138,7 +138,7 @@ bool Launcher::launchUpdater(UpdaterLaunch action) {
 			nullptr,
 			nullptr,
 			&waitStatus,
-			nullptr) || !g_spawn_check_exit_status(waitStatus, nullptr)) {
+			nullptr) || !GLib::spawn_check_exit_status(waitStatus)) {
 		return false;
 	}
 	return launchUpdater(UpdaterLaunch::JustRelaunch);


### PR DESCRIPTION
It works since 579b358f8b83bca60ead84ed36f03d4eaa5375d3