### PR TITLE
fixed editing cover in private groups and chats

### DIFF
--- a/Telegram/SourceFiles/boxes/send_files_box.cpp
+++ b/Telegram/SourceFiles/boxes/send_files_box.cpp
@@ -1069,9 +1069,7 @@ void SendFilesBox::pushBlock(int from, int till) {
 				? !hasPrice()
 				: (type == Ui::AttachActionType::EditCover)
 				? (file.isVideoFile()
-					&& _captionToPeer
-					&& (_captionToPeer->isBroadcast()
-						|| _captionToPeer->isSelf()))
+					&& _captionToPeer)
 				: (file.videoCover != nullptr);
 		});
 	auto &block = _blocks.back();


### PR DESCRIPTION
- now it is possible to edit cover in any types of dialogue: chats, groups, etc

This change attempts to fix #30120

