### PR TITLE
Accessibility: Implement Chat List Navigation and Subsection Context Announcements for Screen Readers

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -713,6 +713,8 @@ PRIVATE
     dialogs/ui/dialogs_topics_view.h
     dialogs/ui/dialogs_video_userpic.cpp
     dialogs/ui/dialogs_video_userpic.h
+    dialogs/dialogs_accessibility.h
+    dialogs/dialogs_accessibility.cpp
     dialogs/dialogs_entry.cpp
     dialogs/dialogs_entry.h
     dialogs/dialogs_indexed_list.cpp

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -7478,4 +7478,16 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 "lng_mac_hold_to_quit" = "Hold {text} to Quit";
 
+"lng_acc_unread_count#one" = "{count} unread message. ";
+"lng_acc_unread_count#other" = "{count} unread messages. ";
+"lng_acc_sender_you" = "You: ";
+"lng_acc_read_more" = "... read more. ";
+"lng_acc_msg_sent" = "Sent";
+"lng_acc_msg_received" = "Received";
+"lng_acc_time_today" = ". {action} today at {time}";
+"lng_acc_time_date" = ". {action} at {time}, {day}{suffix} of {month}";
+"lng_acc_hashtag_result" = "Hashtag result";
+"lng_acc_global_result" = "Global search result. ";
+"lng_acc_chat_list" = "Chat list";
+
 // Keys finished

--- a/Telegram/SourceFiles/dialogs/dialogs_accessibility.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_accessibility.cpp
@@ -11,7 +11,7 @@ QObject *AccessibleRow::object() const {
 }
 
 bool AccessibleRow::isValid() const {
-    if (!_parent) return false;
+    if (_parent.isNull()) return false;
     
     if (_index < 0) return false;
 
@@ -19,11 +19,16 @@ bool AccessibleRow::isValid() const {
 }
 
 QWindow *AccessibleRow::window() const {
-	return _parent ? _parent->window()->windowHandle() : nullptr;
+	if (_parent.isNull() || !_parent->window()) return nullptr;
+    return _parent->window()->windowHandle();
 }
 
 QAccessibleInterface *AccessibleRow::parent() const {
-	return QAccessible::queryAccessibleInterface(_parent);
+    if (_parent.isNull()) {
+        return nullptr;
+    }
+
+    return QAccessible::queryAccessibleInterface(_parent.data());
 }
 
 QAccessibleInterface *AccessibleRow::child(int index) const {

--- a/Telegram/SourceFiles/dialogs/dialogs_accessibility.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_accessibility.cpp
@@ -1,0 +1,150 @@
+#include "dialogs/dialogs_accessibility.h"
+#include "dialogs/dialogs_inner_widget.h"
+#include <QWindow>
+
+namespace Dialogs {
+
+AccessibleRow::AccessibleRow(InnerWidget *parent, int index) : _parent(parent), _index(index) {}
+
+QObject *AccessibleRow::object() const {
+	return nullptr;
+}
+
+bool AccessibleRow::isValid() const {
+    if (!_parent) return false;
+    
+    if (_index < 0) return false;
+
+    return _index < _parent->getAccessibleChildCount();
+}
+
+QWindow *AccessibleRow::window() const {
+	return _parent ? _parent->window()->windowHandle() : nullptr;
+}
+
+QAccessibleInterface *AccessibleRow::parent() const {
+	return QAccessible::queryAccessibleInterface(_parent);
+}
+
+QAccessibleInterface *AccessibleRow::child(int index) const {
+	return nullptr;
+}
+
+QAccessibleInterface *AccessibleRow::childAt(int x, int y) const {
+	return nullptr;
+}
+
+int AccessibleRow::childCount() const {
+	return 0;
+}
+
+int AccessibleRow::indexOfChild(const QAccessibleInterface *child) const {
+	return -1;
+}
+
+QString AccessibleRow::text(QAccessible::Text t) const {
+	if (!_parent) return QString();
+	
+	if (t == QAccessible::Name) {
+		return _parent->getAccessibleName(_index);
+	} else if (t == QAccessible::Description || t == QAccessible::Value) {
+		return _parent->getAccessibleDescription(_index);
+	}
+	return QString();
+}
+
+void AccessibleRow::setText(QAccessible::Text t, const QString &text) {
+}
+
+QRect AccessibleRow::rect() const {
+	if (!_parent) return QRect();
+	
+	// Use the helper on InnerWidget to calculate rect based on index
+	// This keeps the logic centralized.
+	QRect local = _parent->getAccessibleRect(_index);
+	
+	// If the item is logically selected but physically scrolled out of view,
+	// we must return a valid on-screen rect (e.g. at the edge) or the 
+	// screen reader will refuse to focus it.
+	if (local.isEmpty()) {
+		// Fallback: Use parent's top-left so it's at least "somewhere"
+		return QRect(_parent->mapToGlobal(QPoint(0,0)), QSize(1,1));
+	}
+	
+	QPoint globalTopLeft = _parent->mapToGlobal(local.topLeft());
+	return QRect(globalTopLeft, local.size());
+}
+
+QAccessible::Role AccessibleRow::role() const {
+	return QAccessible::ListItem;
+}
+
+QAccessible::State AccessibleRow::state() const {
+	QAccessible::State s;
+	s.selectable = true;
+	s.focusable = true;
+	
+	if (_parent && _parent->isAccessibleRowSelected(_index)) {
+		s.selected = true;
+		s.focused = true;
+	}
+	return s;
+}
+// AccessibleInnerWidget Implementation
+AccessibleInnerWidget::AccessibleInnerWidget(InnerWidget *widget) 
+    : QAccessibleWidget(widget, QAccessible::List), _inner(widget) {}
+
+QAccessibleInterface *AccessibleInnerWidget::child(int index) const {
+	if (!_inner || index < 0 || index >= childCount()) {
+		return nullptr;
+	}
+
+	return new AccessibleRow(_inner, index);
+}
+int AccessibleInnerWidget::childCount() const {
+	return _inner ? _inner->getAccessibleChildCount() : 0;
+}
+
+int AccessibleInnerWidget::indexOfChild(const QAccessibleInterface *child) const {
+	if (!child || !_inner) return -1;
+
+	if (child->role() == QAccessible::ListItem) {
+		const auto row = static_cast<const AccessibleRow*>(child);
+		return row->index();
+	}
+	return -1;
+}
+
+QAccessibleInterface *AccessibleInnerWidget::childAt(int x, int y) const {
+	if (!_inner) return nullptr;
+	QPoint local = _inner->mapFromGlobal(QPoint(x, y));
+	int index = _inner->getAccessibleIndexAt(local.y());
+	if (index >= 0) {
+		return child(index);
+	}
+	return nullptr;
+}
+
+QAccessibleInterface *AccessibleInnerWidget::focusChild() const {
+	if (!_inner) return nullptr;
+	if (_inner->hasFocus()) {
+		int index = _inner->currentAccessibleIndex();
+		if (index >= 0) {
+			return child(index);
+		}
+	}
+	return nullptr;
+}
+
+QAccessible::Role AccessibleInnerWidget::role() const {
+	return QAccessible::List;
+}
+
+QAccessible::State AccessibleInnerWidget::state() const {
+	auto s = QAccessibleWidget::state();
+	s.focusable = false; 
+	s.multiSelectable = false;
+	return s;
+}
+
+} // namespace Dialogs

--- a/Telegram/SourceFiles/dialogs/dialogs_accessibility.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_accessibility.h
@@ -3,6 +3,7 @@
 #include <QAccessibleWidget>
 #include <QAccessibleInterface>
 #include <QRect>
+#include <QtCore/QPointer>
 
 namespace Dialogs {
 
@@ -28,7 +29,7 @@ public:
     QAccessible::State state() const override;
 
 private:
-    InnerWidget *_parent = nullptr;
+    QPointer<InnerWidget> _parent;
     int _index = -1;
 };
 
@@ -44,7 +45,7 @@ public:
     QAccessible::State state() const override;
 
 private:
-    InnerWidget *_inner = nullptr;
+    QPointer<InnerWidget> _inner;
 };
 
 } // namespace Dialogs

--- a/Telegram/SourceFiles/dialogs/dialogs_accessibility.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_accessibility.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QAccessibleWidget>
+#include <QAccessibleInterface>
+#include <QRect>
+
+namespace Dialogs {
+
+class InnerWidget;
+
+class AccessibleRow : public QAccessibleInterface {
+public:
+    AccessibleRow(InnerWidget *parent, int index);
+
+    QObject *object() const override;
+    bool isValid() const override;
+    QWindow *window() const override;
+    QAccessibleInterface *parent() const override;
+    QAccessibleInterface *child(int index) const override;
+    QAccessibleInterface *childAt(int x, int y) const override; 
+    int index() const { return _index; }
+    int childCount() const override;
+    int indexOfChild(const QAccessibleInterface *child) const override;
+    QString text(QAccessible::Text t) const override;
+    void setText(QAccessible::Text t, const QString &text) override; 
+    QRect rect() const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+
+private:
+    InnerWidget *_parent = nullptr;
+    int _index = -1;
+};
+
+class AccessibleInnerWidget : public QAccessibleWidget {
+public:
+    AccessibleInnerWidget(InnerWidget *widget);
+    QAccessibleInterface *child(int index) const override;
+    int childCount() const override;
+    int indexOfChild(const QAccessibleInterface *child) const override;
+    QAccessibleInterface *focusChild() const override;
+    QAccessibleInterface *childAt(int x, int y) const override;
+    QAccessible::Role role() const override;
+    QAccessible::State state() const override;
+
+private:
+    InnerWidget *_inner = nullptr;
+};
+
+} // namespace Dialogs

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -563,6 +563,74 @@ InnerWidget::InnerWidget(
 	setupShortcuts();
 }
 
+QString GenerateRowDescription(not_null<Dialogs::Entry*> entry, HistoryItem *item, bool isFiltered) {
+    QString result;
+
+    if (!isFiltered) {
+        if (const auto history = entry->asHistory()) {
+            const int unread = history->unreadCount();
+            if (unread > 0) {
+                result += tr::lng_acc_unread_count(tr::now, lt_count, unread);
+            }
+        } else if (const auto folder = entry->asFolder()) {
+            const int unread = folder->chatListBadgesState().unreadCounter;
+            if (unread > 0) {
+                result += tr::lng_acc_unread_count(tr::now, lt_count, unread);
+            }
+        }
+    }
+
+    if (item) {
+        const auto from = item->from();
+        const auto chatName = entry->chatListName();
+        
+        if (from && !from->isSelf() && from->name() != chatName) {
+            result += from->name() + ": ";
+        } else if (from && from->isSelf()) {
+            result += tr::lng_acc_sender_you(tr::now);
+        }
+
+        QString message = item->notificationText().text;
+        message = message.replace(QChar('\n'), QChar(' '));
+        
+        const int kLimit = 50; 
+        if (message.length() > kLimit) {
+            result += message.left(kLimit) + tr::lng_acc_read_more(tr::now);
+        } else if (!message.isEmpty()) {
+            result += message + ". ";
+        }
+
+        const auto timestamp = item->date();
+        const QDateTime dt = QDateTime::fromSecsSinceEpoch(timestamp);
+        const QDateTime now = QDateTime::currentDateTime();
+        const bool isToday = (dt.date() == now.date());
+        const QString timeStr = dt.time().toString("h:mm AP");
+
+        const QString action = item->out() 
+            ? tr::lng_acc_msg_sent(tr::now) 
+            : tr::lng_acc_msg_received(tr::now);
+
+        if (isToday) {
+            result += tr::lng_acc_time_today(tr::now, lt_action, action, lt_time, timeStr);
+        } else {
+            const int day = dt.date().day();
+            QString suffix = "th";
+            if (day == 1 || day == 21 || day == 31) suffix = "st";
+            else if (day == 2 || day == 22) suffix = "nd";
+            else if (day == 3 || day == 23) suffix = "rd";
+            
+            result += tr::lng_acc_time_date(
+                tr::now, 
+                lt_action, action, 
+                lt_time, timeStr, 
+                lt_day, QString::number(day), 
+                lt_suffix, suffix, 
+                lt_month, dt.date().toString("MMMM"));
+        }
+    }
+    return result;
+}
+
 bool InnerWidget::updateEntryHeight(not_null<Entry*> entry) {
 	if (!_geometryInited) {
 		return false;
@@ -5585,6 +5653,264 @@ void InnerWidget::deactivateQuickAction() {
 		_inactiveQuickActions.push_back(
 			QuickActionPtr{ _activeQuickAction.release() });
 	}
+}
+//Accessibility
+int InnerWidget::getAccessibleChildCount() const {
+	if (_state == WidgetState::Default) {
+		return _collapsedRows.size() + _shownList->size();
+	} else if (_state == WidgetState::Filtered) {
+		return _hashtagResults.size() 
+			+ _filterResults.size() 
+			+ _peerSearchResults.size() 
+			+ _previewResults.size() 
+			+ _searchResults.size();
+	}
+	return 0;
+}
+
+int InnerWidget::currentAccessibleIndex() const {
+    // Calculate which index is currently selected based on internal state variables
+	if (_state == WidgetState::Default) {
+		if (_collapsedSelected >= 0) return _collapsedSelected;
+		if (_selected) {
+            // Find index of _selected in _shownList
+			auto idx = 0;
+			for (auto it = _shownList->cbegin(); it != _shownList->cend(); ++it, ++idx) {
+				if (it->get() == _selected) return _collapsedRows.size() + idx;
+			}
+		}
+	} else if (_state == WidgetState::Filtered) {
+		int offset = 0;
+		if (_hashtagSelected >= 0) return offset + _hashtagSelected;
+		offset += _hashtagResults.size();
+		
+		if (_filteredSelected >= 0) return offset + _filteredSelected;
+		offset += _filterResults.size();
+		
+		if (_peerSearchSelected >= 0) return offset + _peerSearchSelected;
+		offset += _peerSearchResults.size();
+		
+		if (_previewSelected >= 0) return offset + _previewSelected;
+		offset += _previewResults.size();
+		
+		if (_searchedSelected >= 0) return offset + _searchedSelected;
+	}
+	return -1;
+}
+
+bool InnerWidget::isAccessibleRowSelected(int index) const {
+	return index == currentAccessibleIndex();
+}
+
+QRect InnerWidget::getAccessibleRect(int index) const {
+	int y = 0;
+	int h = 0;
+
+	if (_state == WidgetState::Default) {
+		if (index < _collapsedRows.size()) {
+			y = index * st::dialogsImportantBarHeight;
+			h = st::dialogsImportantBarHeight;
+		} else {
+			int listIndex = index - _collapsedRows.size();
+			auto it = _shownList->cbegin();
+			std::advance(it, listIndex); // Efficient iterator move
+			if (it != _shownList->cend()) {
+				Row* r = it->get();
+				y = dialogsOffset() + r->top();
+				// Add pinned offset
+				if (listIndex < _pinnedRows.size()) {
+					y += qRound(_pinnedRows[listIndex].yadd.current());
+				}
+				h = r->height();
+			}
+		}
+	} else if (_state == WidgetState::Filtered) {
+		int current = index;
+
+		if (current < _hashtagResults.size()) {
+			y = hashtagsOffset() + current * st::mentionHeight;
+			h = st::mentionHeight;
+            return QRect(0, y, width(), h);
+		}
+		current -= _hashtagResults.size();
+
+		if (current < _filterResults.size()) {
+			const auto &res = _filterResults[current];
+			y = filteredOffset() + res.top;
+			h = res.row->height();
+            return QRect(0, y, width(), h);
+		}
+		current -= _filterResults.size();
+
+		if (current < _peerSearchResults.size()) {
+			y = peerSearchOffset() + current * st::dialogsRowHeight;
+			h = st::dialogsRowHeight;
+            return QRect(0, y, width(), h);
+		}
+		current -= _peerSearchResults.size();
+
+		if (current < _previewResults.size()) {
+			y = previewOffset() + current * _st->height;
+			h = _st->height;
+            return QRect(0, y, width(), h);
+		}
+		current -= _previewResults.size();
+
+		if (current < _searchResults.size()) {
+			y = searchedOffset() + current * _st->height;
+			h = _st->height;
+            return QRect(0, y, width(), h);
+		}
+	}
+    
+    if (h > 0) return QRect(0, y, width(), h);
+	return QRect();
+}
+
+// Main Accessible Name Function
+
+QString InnerWidget::getAccessibleName(int index) const {
+	if (_state == WidgetState::Default) {
+		if (index < _collapsedRows.size()) {
+			return _collapsedRows[index]->folder->chatListName();
+		}
+		int listIndex = index - _collapsedRows.size();
+		auto it = _shownList->cbegin();
+		std::advance(it, listIndex);
+		if (it != _shownList->cend()) {
+			return it->get()->entry()->chatListName();
+		}
+	} else if (_state == WidgetState::Filtered) {
+		int current = index;
+		
+		if (current < _hashtagResults.size()) return "#" + _hashtagResults[current]->tag;
+		current -= _hashtagResults.size();
+		
+		if (current < _filterResults.size()) return _filterResults[current].row->entry()->chatListName();
+		current -= _filterResults.size();
+		
+		if (current < _peerSearchResults.size()) return _peerSearchResults[current]->peer->name();
+		current -= _peerSearchResults.size();
+		
+		if (current < _previewResults.size()) return _previewResults[current]->name().toString();
+		current -= _previewResults.size();
+		
+		if (current < _searchResults.size()) return _searchResults[current]->name().toString();
+	}
+	return QString();
+}
+
+// Main Accessible Description Function 
+QString InnerWidget::getAccessibleDescription(int index) const {
+	if (_state == WidgetState::Default) {
+		// 1. Collapsed Row (Archive)
+		if (index < _collapsedRows.size()) {
+			return GenerateRowDescription(_collapsedRows[index]->folder, nullptr, false);
+		}
+		
+		// 2. Main Chat List
+		int listIndex = index - _collapsedRows.size();
+		auto it = _shownList->cbegin();
+		std::advance(it, listIndex);
+		
+		if (it != _shownList->cend()) {
+			Row* r = it->get();
+			HistoryItem* lastMsg = r->history() ? r->history()->lastMessage() : nullptr;
+			return GenerateRowDescription(r->entry(), lastMsg, false);
+		}
+	} else if (_state == WidgetState::Filtered) {
+		int current = index;
+		
+		if (current < _hashtagResults.size()) return tr::lng_acc_hashtag_result(tr::now);
+		current -= _hashtagResults.size();
+		
+		if (current < _filterResults.size()) {
+			Row* r = _filterResults[current].row.get();
+			HistoryItem* lastMsg = r->history() ? r->history()->lastMessage() : nullptr;
+			return GenerateRowDescription(r->entry(), lastMsg, true);
+		}
+		current -= _filterResults.size();
+		
+		if (current < _peerSearchResults.size()) {
+			return tr::lng_acc_global_result(tr::now) + _peerSearchResults[current]->peer->username();
+		}
+		current -= _peerSearchResults.size();
+		
+		if (current < _previewResults.size()) {
+			return GenerateRowDescription(
+				_previewResults[current]->item()->history(), 
+				_previewResults[current]->item(), 
+				true);
+		}
+		current -= _previewResults.size();
+		
+		if (current < _searchResults.size()) {
+			return GenerateRowDescription(
+				_searchResults[current]->item()->history(), 
+				_searchResults[current]->item(), 
+				true);
+		}
+	}
+	return QString();
+}
+
+
+int InnerWidget::getAccessibleIndexAt(int y) const {
+	if (_state == WidgetState::Default) {
+		// 1. Check Collapsed Rows (Top)
+		const int collapsedHeight = _collapsedRows.size() * st::dialogsImportantBarHeight;
+		if (y < collapsedHeight) {
+			return y / st::dialogsImportantBarHeight;
+		}
+
+		// 2. Check Main List
+		int listY = y - dialogsOffset();
+		
+		if (listY >= 0 && listY < _shownList->height()) {
+			auto it = _shownList->findByY(listY);
+			if (it != _shownList->cend()) {
+				int indexInList = it->get()->index();
+				return _collapsedRows.size() + indexInList;
+			}
+		}
+	} else if (_state == WidgetState::Filtered) {
+		int currentY = 0;
+		int index = 0;
+
+		// Helper to iterate a list
+		auto checkList = [&](int count, int itemHeight) -> int {
+			int height = count * itemHeight;
+			if (y >= currentY && y < currentY + height) {
+				return index + (y - currentY) / itemHeight;
+			}
+			currentY += height;
+			index += count;
+			return -1;
+		};
+
+		int found = checkList(_hashtagResults.size(), st::mentionHeight);
+		if (found != -1) return found;
+
+		for (const auto &res : _filterResults) {
+			int h = res.row->height();
+			if (y >= currentY && y < currentY + h) return index;
+			currentY += h;
+			index++;
+		}
+
+		currentY = peerSearchOffset();
+		found = checkList(_peerSearchResults.size(), st::dialogsRowHeight);
+		if (found != -1) return found;
+
+		currentY = previewOffset();
+		found = checkList(_previewResults.size(), _st->height);
+		if (found != -1) return found;
+
+		currentY = searchedOffset();
+		found = checkList(_searchResults.size(), _st->height);
+		if (found != -1) return found;
+	}
+	return -1;
 }
 
 } // namespace Dialogs

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -89,6 +89,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "styles/style_menu_icons.h"
 
 #include <QtWidgets/QApplication>
+#include "dialogs/dialogs_accessibility.h"
+#include <QAccessible>
 
 namespace Dialogs {
 namespace {
@@ -228,6 +230,13 @@ constexpr auto kPreviewPostsLimit = 3;
 }
 
 } // namespace
+
+QAccessibleInterface *InnerWidgetFactory(const QString &key, QObject *object) {
+    if (auto widget = dynamic_cast<InnerWidget*>(object)) {
+        return new AccessibleInnerWidget(widget);
+    }
+    return nullptr;
+}
 
 struct InnerWidget::CollapsedRow {
 	CollapsedRow(Data::Folder *folder) : folder(folder) {
@@ -561,6 +570,7 @@ InnerWidget::InnerWidget(
 	refreshWithCollapsedRows(true);
 
 	setupShortcuts();
+	setupAccessibility();
 }
 
 QString GenerateRowDescription(not_null<Dialogs::Entry*> entry, HistoryItem *item, bool isFiltered) {
@@ -4614,6 +4624,18 @@ void InnerWidget::selectSkip(int32 direction) {
 			scrollToItem(from, height);
 		}
 	}
+	if (const auto accessible = QAccessible::queryAccessibleInterface(this)) {
+    const auto index = currentAccessibleIndex();
+    if (index >= 0) {
+        if (QAccessibleInterface *child = accessible->child(index)) {
+            QAccessibleEvent focusEvent(child, QAccessible::Focus);
+            QAccessible::updateAccessibility(&focusEvent);
+            
+            QAccessibleEvent selectEvent(child, QAccessible::Selection);
+            QAccessible::updateAccessibility(&selectEvent);
+        }
+    }
+	}
 	update();
 }
 
@@ -4682,6 +4704,20 @@ void InnerWidget::selectSkipPage(int32 pixels, int32 direction) {
 		}
 	}
 	scrollToDefaultSelected();
+	if (const auto accessible = QAccessible::queryAccessibleInterface(this)) {
+        const auto index = currentAccessibleIndex();
+        if (index >= 0) {
+            if (QAccessibleInterface *child = accessible->child(index)) {
+                // Notify that the focus has moved to the new row
+                QAccessibleEvent focusEvent(child, QAccessible::Focus);
+                QAccessible::updateAccessibility(&focusEvent);
+                
+                // Notify that the new row is officially selected
+                QAccessibleEvent selectEvent(child, QAccessible::Selection);
+                QAccessible::updateAccessibility(&selectEvent);
+            }
+        }
+    }
 	update();
 }
 
@@ -5655,6 +5691,10 @@ void InnerWidget::deactivateQuickAction() {
 	}
 }
 //Accessibility
+void InnerWidget::setupAccessibility() {
+	QAccessible::installFactory(InnerWidgetFactory);
+}
+
 int InnerWidget::getAccessibleChildCount() const {
 	if (_state == WidgetState::Default) {
 		return _collapsedRows.size() + _shownList->size();

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.h
@@ -82,6 +82,8 @@ class ChatSearchIn;
 enum class HashOrCashtag : uchar;
 struct RightButton;
 enum class ChatTypeFilter : uchar;
+class AccessibleInnerWidget;
+class AccessibleRow;
 
 struct ChosenRow {
 	Key key;
@@ -232,6 +234,7 @@ public:
 	void prepareQuickAction(int64 key, Dialogs::Ui::QuickDialogAction);
 	void clearQuickActions();
 
+	void setupAccessibility();
     [[nodiscard]] int getAccessibleChildCount() const;
     [[nodiscard]] QString getAccessibleName(int index) const;
     [[nodiscard]] QString getAccessibleDescription(int index) const;
@@ -260,6 +263,8 @@ private:
 	struct SponsoredSearchResult;
 	struct PeerSearchResult;
 	struct TagCache;
+	friend class AccessibleInnerWidget;
+    friend class AccessibleRow;
 
 	enum class JumpSkip {
 		PreviousOrBegin,

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.h
@@ -232,6 +232,14 @@ public:
 	void prepareQuickAction(int64 key, Dialogs::Ui::QuickDialogAction);
 	void clearQuickActions();
 
+    [[nodiscard]] int getAccessibleChildCount() const;
+    [[nodiscard]] QString getAccessibleName(int index) const;
+    [[nodiscard]] QString getAccessibleDescription(int index) const;
+    [[nodiscard]] QRect getAccessibleRect(int index) const;
+    [[nodiscard]] bool isAccessibleRowSelected(int index) const;
+    [[nodiscard]] int currentAccessibleIndex() const;
+    [[nodiscard]] int getAccessibleIndexAt(int y) const;
+
 protected:
 	void visibleTopBottomUpdated(
 		int visibleTop,

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -97,6 +97,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtGui/QTextBlock>
 #include <QtWidgets/QScrollBar>
 #include <QtWidgets/QTextEdit>
+#include <QTimer>
+#include <QAccessible>
+#include <QAccessibleEvent>
+#include <QAccessibleTableModelChangeEvent>
 
 namespace Dialogs {
 namespace {
@@ -1878,6 +1882,30 @@ void Widget::changeOpenedSubsection(
 	_showAnimation = nullptr;
 	destroyChildListCanvas();
 	change();
+	if (QAccessible::isActive()) {
+        QString name;
+        if (_openedForum) {
+            name = _openedForum->peer()->name();
+        } else if (_openedFolder) {
+            name = (_openedFolder->id() == Data::Folder::kId)
+                ? tr::lng_archived_name(tr::now)
+                : _openedFolder->chatListName();
+        } else {
+            name = tr::lng_acc_chat_list(tr::now);
+        }
+        if (_inner) {
+        _inner->setAccessibleName(name);
+		}
+
+        QTimer::singleShot(st::slideDuration, _inner, [=] {
+ 
+                QAccessibleEvent event(_inner, QAccessible::NameChanged);
+                QAccessible::updateAccessibility(&event);
+                
+                QAccessibleEvent focusEvent(_inner, QAccessible::Focus);
+                QAccessible::updateAccessibility(&focusEvent);
+            });
+    }
 	refreshTopBars();
 	updateControlsVisibility(true);
 	_peerSearch.clear();


### PR DESCRIPTION
This Pull Request enhances the screen reader accessibility of the chat list and its associated subsections. By implementing native accessibility interfaces, the application now provides accurate contextual feedback during navigation, specifically announcing the current chat name and its related metadata (such as unread counts and last message content) while traversing the list in both Default and Filtered states."

**Technical Details**

- Interfaces: Added AccessibleInnerWidget and AccessibleRow to bridge internal data with QAccessibleInterface.
- InnerWidget Helpers: Implemented getAccessibleChildCount, getAccessibleName, getAccessibleDescription, and getAccessibleRect for accurate data retrieval.
- Synchronization: Utilized QAccessible::updateAccessibility to keep assistive devices synchronized with UI state changes.