### PR TITLE
 Fixed: GitHub Issue #29530 - Missing Expandable Quote Button in Caption Field

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/chat_helpers.style
+++ b/Telegram/SourceFiles/chat_helpers/chat_helpers.style
@@ -1433,6 +1433,7 @@ defaultComposeFilesMenu: IconButton(defaultIconButton) {
 defaultComposeFilesField: InputField(defaultInputField) {
 	textMargins: margins(1px, 26px, 31px, 4px);
 	heightMax: 158px;
+	style: historyTextStyle;
 }
 defaultComposeFiles: ComposeFiles {
 	check: defaultCheck;


### PR DESCRIPTION
 Problem: When composing a message with media/files, the button to convert quotes to "expandable quotes" was missing from the caption field, even though it works in the regular message input.

  Root Cause: The caption field used a style (boxTextStyle via defaultInputField) that had an empty blockquote configuration with no expand/collapse icons. The main message input uses historyTextStyle which has properly configured blockquote icons.

  Fix: Added style: historyTextStyle; to defaultComposeFilesField in Telegram/SourceFiles/chat_helpers/chat_helpers.style:1436.

  This one-line change affects all caption fields that use this style:
  - SendFilesBox - Caption when sending files/media
  - EditCaptionBox - Editing captions on existing media
  - SendGifWithCaptionBox - GIF captions
  - Stories caption field - Inherits from the same style

fix #29530 