### PR TITLE
Fix invalid minimum birthday year in edit birthday box

### DIFF
--- a/Telegram/SourceFiles/data/data_birthday.h
+++ b/Telegram/SourceFiles/data/data_birthday.h
@@ -30,7 +30,7 @@ public:
 	friend inline constexpr auto operator<=>(Birthday, Birthday) = default;
 	friend inline constexpr bool operator==(Birthday, Birthday) = default;
 
-	static constexpr auto kYearMin = 1875;
+	static constexpr auto kYearMin = 1876;
 	static constexpr auto kYearMax = 2100;
 
 private:


### PR DESCRIPTION
The client allows selecting the year 1875 in the edit birthday box, which
results in a BIRTHDAY_INVALID error due to the 150-year age limit enforced by
the server.

This change updates kYearMin to 1876 so the client-side validation matches
the server restriction