### PR TITLE
Fixed Github Issue #30203 - overlay widget flickers on close MacOS

### DIFF
--- a/Telegram/SourceFiles/platform/mac/overlay_widget_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/overlay_widget_mac.mm
@@ -93,6 +93,7 @@ void MacOverlayWidgetHelper::updateStyles(bool fullscreen) {
 		? NSNormalWindowLevel
 		: NSPopUpMenuWindowLevel;
 	[window setLevel:level];
+	[window setAnimationBehavior:NSWindowAnimationBehaviorNone];
 	[window setHidesOnDeactivate:!_data->window->testAttribute(Qt::WA_MacAlwaysShowToolWindow)];
 	[window setTitleVisibility:NSWindowTitleHidden];
 	[window setTitlebarAppearsTransparent:YES];


### PR DESCRIPTION
Disable automatic window animations for the media overlay window by setting NSWindowAnimationBehaviorNone. This prevents a visual glitch where the window would briefly disappear, reappear at full opacity, and then fade out.

Now overlay widget disappears instantly without flickering

fixes https://github.com/telegramdesktop/tdesktop/issues/30203