### PR TITLE
Add a power saving option to stop gif/video/video message preview

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -896,6 +896,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_power_emoji_status" = "Autoplay in premium status";
 "lng_settings_power_chat" = "Animations in Chats";
 "lng_settings_power_chat_background" = "Wallpaper rotation";
+"lng_settings_power_chat_media" = "Autoplay media";
 "lng_settings_power_chat_spoiler" = "Animated spoiler effect";
 "lng_settings_power_chat_effects" = "Effects in messages";
 "lng_settings_power_calls" = "Animations in Calls";

--- a/Telegram/SourceFiles/history/view/media/history_view_gif.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_gif.cpp
@@ -537,7 +537,7 @@ void Gif::draw(Painter &p, const PaintContext &context) const {
 		== PaintContext::SkipDrawingParts::Content;
 	const auto drawStreamed = streamed && (shouldBePlaying || !_videoCover);
 	if (drawStreamed && !skipDrawingContent && !fullHiddenBySpoiler) {
-		auto paused = context.paused || !shouldBePlaying;
+		auto paused = context.paused || !shouldBePlaying || On(PowerSaving::kChatMedia);
 		auto request = ::Media::Streaming::FrameRequest{
 			.outer = QSize(usew, painth) * style::DevicePixelRatio(),
 			.blurredBackground = true,

--- a/Telegram/SourceFiles/settings/settings_power_saving.cpp
+++ b/Telegram/SourceFiles/settings/settings_power_saving.cpp
@@ -165,6 +165,7 @@ EditFlagsDescriptor<PowerSaving::Flags> PowerSavingLabels() {
 		},
 		{ kChatSpoiler, tr::lng_settings_power_chat_spoiler(tr::now) },
 		{ kChatEffects, tr::lng_settings_power_chat_effects(tr::now) },
+		{ kChatMedia, tr::lng_settings_power_chat_media(tr::now) },
 	};
 	auto calls = std::vector<Label>{
 		{

--- a/Telegram/SourceFiles/ui/power_saving.h
+++ b/Telegram/SourceFiles/ui/power_saving.h
@@ -21,8 +21,9 @@ enum Flag : uint32 {
 	kCalls = (1U << 8),
 	kEmojiStatus = (1U << 9),
 	kChatEffects = (1U << 10),
+	kChatMedia = (1U << 11),
 
-	kAll = (1U << 11) - 1,
+	kAll = (1U << 12) - 1,
 };
 inline constexpr bool is_flag_type(Flag) { return true; }
 using Flags = base::flags<Flag>;


### PR DESCRIPTION
## The change

Add a power saving option to stop gif/video/video message preview.

The new "Autoplay media" option allows to disable media files preview in the chat history view.

## Discussion

- Do we need more configuration options, e.g., per media type (round video message, video, gif)?
- Should the setting name be more detailed (e.g., list the media types)?