### PR TITLE
Calls: enable audio sharing flow on Linux

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -5704,6 +5704,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_group_call_screen_share_stop" = "Stop Sharing";
 "lng_group_call_screen_title" = "Screen {index}";
 "lng_group_call_screen_share_audio" = "Share System Audio";
+"lng_group_call_sharing_screen_options" = "Sharing Options";
+"lng_group_call_choose_source" = "Choose Source";
 "lng_group_call_unmute" = "Unmute";
 "lng_group_call_unmute_sub" = "Hold space bar to temporarily unmute.";
 "lng_group_call_you_are_live" = "You are Live";

--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++ b/Telegram/SourceFiles/calls/calls_call.cpp
@@ -1433,7 +1433,9 @@ void Call::toggleCameraSharing(bool enabled) {
 	}), true);
 }
 
-void Call::toggleScreenSharing(std::optional<QString> uniqueId) {
+void Call::toggleScreenSharing(
+		std::optional<QString> uniqueId,
+		bool withAudio) {
 	if (!uniqueId) {
 		if (isSharingScreen()) {
 			if (_videoCapture) {
@@ -1443,13 +1445,20 @@ void Call::toggleScreenSharing(std::optional<QString> uniqueId) {
 		}
 		_videoCaptureDeviceId = QString();
 		_videoCaptureIsScreencast = false;
+		_screenWithAudio = false;
+		if (_systemAudioCapture) {
+			_systemAudioCapture->stop();
+			_systemAudioCapture = nullptr;
+		}
 		return;
-	} else if (screenSharingDeviceId() == *uniqueId) {
+	} else if (screenSharingDeviceId() == *uniqueId
+		&& _screenWithAudio == withAudio) {
 		return;
 	}
 	toggleCameraSharing(false);
 	_videoCaptureIsScreencast = true;
 	_videoCaptureDeviceId = *uniqueId;
+	_screenWithAudio = withAudio;
 	if (_videoCapture) {
 		_videoCapture->switchToDevice(uniqueId->toStdString(), true);
 		if (_instance) {
@@ -1457,6 +1466,29 @@ void Call::toggleScreenSharing(std::optional<QString> uniqueId) {
 		}
 	}
 	_videoOutgoing->setState(Webrtc::VideoState::Active);
+
+	if (_systemAudioCapture) {
+		_systemAudioCapture->stop();
+		_systemAudioCapture = nullptr;
+	}
+	if (withAudio && Webrtc::SystemAudioCaptureSupported()) {
+		_systemAudioCapture = Webrtc::CreateSystemAudioCapture(
+			[weak = base::make_weak(this)](std::vector<uint8_t> &&samples) {
+				crl::on_main(
+					weak,
+					[weak, samples = std::move(samples)]() mutable {
+						if (const auto strong = weak.get(); strong
+							&& strong->_instance
+							&& strong->_screenWithAudio) {
+							strong->_instance->addExternalAudioSamples(
+								std::move(samples));
+						}
+					});
+			});
+		if (_systemAudioCapture) {
+			_systemAudioCapture->start();
+		}
+	}
 }
 
 auto Call::peekVideoCapture() const
@@ -1617,6 +1649,10 @@ void Call::handleControllerError(const QString &error) {
 void Call::destroyController() {
 	_instanceLifetime.destroy();
 	Core::App().mediaDevices().setCaptureMuteTracker(this, false);
+	if (_systemAudioCapture) {
+		_systemAudioCapture->stop();
+		_systemAudioCapture = nullptr;
+	}
 
 	if (_instance) {
 		_instance->stop([](tgcalls::FinalState) {

--- a/Telegram/SourceFiles/calls/calls_call.h
+++ b/Telegram/SourceFiles/calls/calls_call.h
@@ -13,6 +13,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "mtproto/sender.h"
 #include "mtproto/mtproto_auth_key.h"
 #include "webrtc/webrtc_device_resolver.h"
+#include "webrtc/webrtc_system_audio_capture.h"
 
 namespace Data {
 class GroupCall;
@@ -252,7 +253,12 @@ public:
 	[[nodiscard]] QString cameraSharingDeviceId() const;
 	[[nodiscard]] QString screenSharingDeviceId() const;
 	void toggleCameraSharing(bool enabled);
-	void toggleScreenSharing(std::optional<QString> uniqueId);
+	void toggleScreenSharing(
+		std::optional<QString> uniqueId,
+		bool withAudio = false);
+	[[nodiscard]] bool screenSharingWithAudio() const {
+		return _screenWithAudio;
+	}
 	[[nodiscard]] auto peekVideoCapture() const
 		-> std::shared_ptr<tgcalls::VideoCaptureInterface>;
 
@@ -366,6 +372,8 @@ private:
 	std::shared_ptr<tgcalls::VideoCaptureInterface> _videoCapture;
 	QString _videoCaptureDeviceId;
 	bool _videoCaptureIsScreencast = false;
+	bool _screenWithAudio = false;
+	std::unique_ptr<Webrtc::SystemAudioCapture> _systemAudioCapture;
 	const std::unique_ptr<Webrtc::VideoTrack> _videoIncoming;
 	const std::unique_ptr<Webrtc::VideoTrack> _videoOutgoing;
 

--- a/Telegram/SourceFiles/calls/calls_panel.cpp
+++ b/Telegram/SourceFiles/calls/calls_panel.cpp
@@ -61,6 +61,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "media/streaming/media_streaming_utility.h"
 #include "window/main_window.h"
 #include "window/window_controller.h"
+#include "webrtc/webrtc_create_adm.h"
 #include "webrtc/webrtc_environment.h"
 #include "webrtc/webrtc_video_track.h"
 #include "styles/style_calls.h"
@@ -395,6 +396,13 @@ void Panel::initControls() {
 		} else if (const auto source = env->uniqueDesktopCaptureSource()) {
 			if (!chooseSourceActiveDeviceId().isEmpty()) {
 				chooseSourceStop();
+			} else if (chooseSourceWithAudioSupported()) {
+				const auto sourceId = *source;
+				Group::ShowUniqueCaptureOptions(
+					uiShow(),
+					crl::guard(this, [=](bool audio) {
+						chooseSourceAccepted(sourceId, audio);
+					}));
 			} else {
 				chooseSourceAccepted(*source, false);
 			}
@@ -564,15 +572,11 @@ QString Panel::chooseSourceActiveDeviceId() {
 }
 
 bool Panel::chooseSourceActiveWithAudio() {
-	return false;// _call->screenSharingWithAudio();
+	return _call->screenSharingWithAudio();
 }
 
 bool Panel::chooseSourceWithAudioSupported() {
-//#ifdef Q_OS_WIN
-//	return true;
-//#else // Q_OS_WIN
-	return false;
-//#endif // Q_OS_WIN
+	return Webrtc::LoopbackAudioCaptureSupported();
 }
 
 rpl::lifetime &Panel::chooseSourceInstanceLifetime() {
@@ -589,7 +593,7 @@ rpl::producer<bool> Panel::startOutgoingRequests() const {
 void Panel::chooseSourceAccepted(
 		const QString &deviceId,
 		bool withAudio) {
-	_call->toggleScreenSharing(deviceId/*, withAudio*/);
+	_call->toggleScreenSharing(deviceId, withAudio);
 }
 
 void Panel::chooseSourceStop() {

--- a/Telegram/SourceFiles/calls/group/calls_group_common.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_common.cpp
@@ -22,6 +22,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "tde2e/tde2e_integration.h"
 #include "ui/boxes/boost_box.h"
 #include "ui/widgets/buttons.h"
+#include "ui/widgets/checkbox.h"
 #include "ui/widgets/labels.h"
 #include "ui/widgets/popup_menu.h"
 #include "ui/layers/generic_box.h"
@@ -75,6 +76,28 @@ object_ptr<Ui::GenericBox> ScreenSharingPrivacyRequestBox() {
 #else // Q_OS_MAC
 	return { nullptr };
 #endif // Q_OS_MAC
+}
+
+void ShowUniqueCaptureOptions(
+		std::shared_ptr<Ui::Show> show,
+		Fn<void(bool withAudio)> done) {
+	show->showBox(Box([=](not_null<Ui::GenericBox*> box) {
+		box->setTitle(tr::lng_group_call_sharing_screen_options());
+		const auto withAudio = box->addRow(
+			object_ptr<Ui::Checkbox>(
+				box,
+				tr::lng_group_call_screen_share_audio(tr::now),
+				false,
+				st::groupCallCheckbox));
+		box->addButton(
+			tr::lng_group_call_choose_source(),
+			[=] {
+				const auto audio = withAudio->checked();
+				box->closeBox();
+				done(audio);
+			});
+		box->addButton(tr::lng_cancel(), [=] { box->closeBox(); });
+	}));
 }
 
 object_ptr<Ui::RpWidget> MakeRoundActiveLogo(

--- a/Telegram/SourceFiles/calls/group/calls_group_common.h
+++ b/Telegram/SourceFiles/calls/group/calls_group_common.h
@@ -162,6 +162,10 @@ using StickedTooltips = base::flags<StickedTooltip>;
 
 [[nodiscard]] object_ptr<Ui::GenericBox> ScreenSharingPrivacyRequestBox();
 
+void ShowUniqueCaptureOptions(
+	std::shared_ptr<Ui::Show> show,
+	Fn<void(bool withAudio)> done);
+
 [[nodiscard]] object_ptr<Ui::RpWidget> MakeRoundActiveLogo(
 	not_null<QWidget*> parent,
 	const style::icon &icon,

--- a/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
@@ -65,6 +65,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "webrtc/webrtc_environment.h"
 #include "webrtc/webrtc_video_track.h"
 #include "webrtc/webrtc_audio_input_tester.h"
+#include "webrtc/webrtc_create_adm.h"
 #include "styles/style_calls.h"
 #include "styles/style_layers.h"
 
@@ -356,11 +357,7 @@ bool Panel::chooseSourceActiveWithAudio() {
 }
 
 bool Panel::chooseSourceWithAudioSupported() {
-#ifdef Q_OS_WIN
-	return true;
-#else // Q_OS_WIN
-	return false;
-#endif // Q_OS_WIN
+	return Webrtc::LoopbackAudioCaptureSupported();
 }
 
 rpl::lifetime &Panel::chooseSourceInstanceLifetime() {
@@ -1527,6 +1524,13 @@ void Panel::chooseShareScreenSource() {
 		} else if (const auto source = env->uniqueDesktopCaptureSource()) {
 			if (_call->isSharingScreen()) {
 				_call->toggleScreenSharing(std::nullopt);
+			} else if (chooseSourceWithAudioSupported()) {
+				const auto sourceId = *source;
+				ShowUniqueCaptureOptions(
+					uiShow(),
+					crl::guard(this, [=](bool audio) {
+						chooseSourceAccepted(sourceId, audio);
+					}));
 			} else {
 				chooseSourceAccepted(*source, false);
 			}


### PR DESCRIPTION
Enables the desktop share audio flow on Linux within Calls UI and plumbing.

Summary

- Source handling: added unique-source handling for the desktop capture chooser.
- UI wiring: updated calls and group panel wiring for the Linux audio sharing flow.
- Group call UX: added screencast-only fullscreen mode and clarified voice vs screen-share audio controls.

Depends on https://github.com/desktop-app/lib_webrtc/pull/22
Closes #26642