### PR TITLE
Add screencast-only fullscreen mode for group call screenshare

### DIFF
--- a/Telegram/SourceFiles/calls/calls.style
+++ b/Telegram/SourceFiles/calls/calls.style
@@ -1008,6 +1008,7 @@ groupCallScreenShareSmall: CallButton(groupCallSettingsSmall) {
 		rippleAreaPosition: point(8px, 12px);
 	}
 }
+
 groupCallMenuToggleSmall: CallButton(groupCallSettingsSmall) {
 	button: IconButton(groupCallSettingsInner) {
 		icon: icon {{ "calls/calls_more", groupCallIconFg }};

--- a/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
@@ -254,7 +254,11 @@ Panel::Panel(not_null<GroupCall*> call, ConferencePanelMigration info)
 	result.setAlphaF(kControlsBackgroundOpacity);
 	return result;
 })
-, _hideControlsTimer([=] { toggleWideControls(false); }) {
+, _hideControlsTimer([=] {
+	if (_rtmpFull || fullscreenForScreencastOnly()) {
+		toggleWideControls(false);
+	}
+}) {
 	_viewport->widget()->hide();
 	if (!_viewport->requireARGB32()) {
 		_call->setNotRequireARGB32();
@@ -387,28 +391,48 @@ void Panel::initWindow() {
 		subscribeToPeerChanges();
 	}
 
+	const auto wasFullscreen = std::make_shared<bool>(
+		(window()->windowState() & Qt::WindowFullScreen) != 0);
 	const auto updateFullScreen = [=] {
 		const auto state = window()->windowState();
-		const auto full = (state & Qt::WindowFullScreen)
-			|| (state & Qt::WindowMaximized);
+		const auto fullscreen = ((state & Qt::WindowFullScreen) != 0);
+		const auto maximized = ((state & Qt::WindowMaximized) != 0);
+		const auto full = (fullscreen || maximized);
+		if (!fullscreen) {
+			_screencastOnlyInFullscreen = false;
+		} else if (!*wasFullscreen && fullscreenForScreencast()) {
+			_screencastOnlyInFullscreen = true;
+		}
+		*wasFullscreen = fullscreen;
 		_rtmpFull = _call->rtmp() && full;
 		_fullScreenOrMaximized = full;
+		if (_subtitle && fullscreenForScreencastOnly()) {
+			_subtitle.destroy();
+		}
+		updateControlsGeometry();
+		if (fullscreenForScreencastOnly()) {
+			_hideControlsTimer.callOnce(kHideControlsTimeout);
+			toggleWideControls(true);
+		} else if (!_rtmpFull) {
+			_hideControlsTimer.cancel();
+			toggleWideControls(_viewport->widget()->underMouse());
+		}
 	};
 	base::install_event_filter(window().get(), [=](not_null<QEvent*> e) {
 		const auto type = e->type();
 		if (type == QEvent::Close && handleClose()) {
 			e->ignore();
 			return base::EventFilterResult::Cancel;
-		} else if (_call->rtmp()
-			&& (type == QEvent::KeyPress || type == QEvent::KeyRelease)) {
+		} else if (type == QEvent::KeyPress || type == QEvent::KeyRelease) {
 			const auto key = static_cast<QKeyEvent*>(e.get())->key();
-			if (key == Qt::Key_Space) {
+			if (_call->rtmp() && key == Qt::Key_Space) {
 				_call->pushToTalk(
 					e->type() == QEvent::KeyPress,
 					kSpacePushToTalkDelay);
-			} else if (key == Qt::Key_Escape
-				&& _fullScreenOrMaximized.current()) {
-				toggleFullScreen();
+			} else if ((type == QEvent::KeyPress)
+				&& (key == Qt::Key_Escape)
+				&& window()->isFullScreen()) {
+				toggleFullScreen(false);
 			}
 		} else if (type == QEvent::WindowStateChange) {
 			updateFullScreen();
@@ -422,6 +446,12 @@ void Panel::initWindow() {
 		using Flag = Ui::WindowTitleHitTestFlag;
 		if (!guard) {
 			return (Flag::None | Flag(0));
+		}
+		if (fullscreenForScreencast()
+			&& _viewport->widget()->geometry().contains(widgetPoint)) {
+			return window()->isFullScreen()
+				? (Flag::None | Flag(0))
+				: (Flag::FullScreen | Flag(0));
 		}
 		const auto titleRect = QRect(
 			0,
@@ -440,7 +470,11 @@ void Panel::initWindow() {
 		}
 		const auto shown = _window->topShownLayer();
 		return (!shown || !shown->geometry().contains(widgetPoint))
-			? (Flag::Move | Flag::Menu | Flag::Maximize)
+			? (Flag::Move
+				| Flag::Menu
+				| (fullscreenForScreencast()
+					? Flag::FullScreen
+					: Flag::Maximize))
 			: Flag::None;
 	});
 
@@ -450,7 +484,8 @@ void Panel::initWindow() {
 	}, lifetime());
 
 	_window->maximizeRequests() | rpl::on_next([=](bool maximized) {
-		if (_call->rtmp()) {
+		if (_call->rtmp() || fullscreenForScreencast()) {
+			_screencastOnlyInFullscreen = false;
 			toggleFullScreen(maximized);
 		} else {
 			window()->setWindowState(maximized
@@ -681,6 +716,9 @@ void Panel::toggleFullScreen() {
 }
 
 void Panel::toggleFullScreen(bool fullscreen) {
+	if (!fullscreen) {
+		_screencastOnlyInFullscreen = false;
+	}
 	if (fullscreen) {
 		window()->showFullScreen();
 	} else {
@@ -1027,7 +1065,28 @@ void Panel::setupMembers() {
 	) | rpl::filter([=] {
 		return !_rtmpFull;
 	}) | rpl::on_next([=](bool inside) {
-		toggleWideControls(inside);
+		if (fullscreenForScreencastOnly()) {
+			if (inside) {
+				_hideControlsTimer.callOnce(kHideControlsTimeout);
+				toggleWideControls(true);
+			} else {
+				_hideControlsTimer.cancel();
+				toggleWideControls(false);
+			}
+		} else {
+			_hideControlsTimer.cancel();
+			toggleWideControls(inside);
+		}
+	}, _viewport->lifetime());
+
+	_viewport->rp()->events(
+	) | rpl::filter([=](not_null<QEvent*> e) {
+		return (e->type() == QEvent::MouseMove);
+	}) | rpl::on_next([=] {
+		if (fullscreenForScreencastOnly()) {
+			_hideControlsTimer.callOnce(kHideControlsTimeout);
+			toggleWideControls(true);
+		}
 	}, _viewport->lifetime());
 
 	_members->show();
@@ -1080,6 +1139,7 @@ void Panel::setupMembers() {
 			enlargeVideo();
 		}
 		_viewport->showLarge(large);
+		updateControlsGeometry();
 	}, _callLifetime);
 }
 
@@ -1261,6 +1321,34 @@ void Panel::setupVideo(not_null<Viewport*> viewport) {
 		}
 	}, viewport->lifetime());
 
+	if (viewport == _viewport.get()) {
+		viewport->doubleClicks(
+		) | rpl::on_next([=](const VideoEndpoint &endpoint) {
+			if (endpoint.type != VideoEndpointType::Screen) {
+				return;
+			}
+			if (_call->videoEndpointLarge() != endpoint) {
+				if (_call->videoEndpointPinned()) {
+					_call->pinVideoEndpoint(endpoint);
+				} else {
+					_call->showVideoEndpointLarge(endpoint);
+				}
+			}
+			if (window()->isFullScreen()) {
+				_screencastOnlyInFullscreen = !_screencastOnlyInFullscreen;
+				if (fullscreenForScreencastOnly()) {
+					_hideControlsTimer.callOnce(kHideControlsTimeout);
+				} else {
+					_hideControlsTimer.cancel();
+				}
+				updateControlsGeometry();
+			} else {
+				_screencastOnlyInFullscreen = true;
+				toggleFullScreen(true);
+			}
+		}, viewport->lifetime());
+	}
+
 	viewport->qualityRequests(
 	) | rpl::on_next([=](const VideoQualityRequest &request) {
 		_call->requestVideoQuality(request.endpoint, request.quality);
@@ -1284,7 +1372,8 @@ void Panel::updateWideControlsVisibility() {
 	if (_wideControlsShown == shown) {
 		return;
 	}
-	_viewport->setCursorShown(!_rtmpFull || shown);
+	_viewport->setCursorShown(
+		(!_rtmpFull && !fullscreenForScreencastOnly()) || shown);
 	_wideControlsShown = shown;
 	_wideControlsAnimation.start(
 		[=] { updateButtonsGeometry(); },
@@ -1889,9 +1978,9 @@ void Panel::updateButtonsStyles() {
 			(wide
 				? &st::groupCallMessageActiveSmall
 				: &st::groupCallMessageActive));
-		_message->setText(wide
-			? rpl::single(QString())
-			: tr::lng_group_call_message());
+			_message->setText(wide
+				? rpl::single(QString())
+				: tr::lng_group_call_message());
 	}
 	if (_settings) {
 		_settings->setText(wide
@@ -2144,6 +2233,9 @@ void Panel::trackControl(Ui::RpWidget *widget, rpl::lifetime &lifetime) {
 				}
 			});
 			toggleWideControls(true);
+			if (_rtmpFull || fullscreenForScreencastOnly()) {
+				_hideControlsTimer.cancel();
+			}
 		} else if (type == QEvent::Leave) {
 			*over = false;
 			crl::on_main(widget, [=] {
@@ -2152,6 +2244,9 @@ void Panel::trackControl(Ui::RpWidget *widget, rpl::lifetime &lifetime) {
 				}
 			});
 			toggleWideControls(false);
+			if (_rtmpFull || fullscreenForScreencastOnly()) {
+				_hideControlsTimer.callOnce(kHideControlsTimeout);
+			}
 		}
 	}, lifetime);
 }
@@ -2468,13 +2563,16 @@ void Panel::updateButtonsGeometry() {
 			+ (_settings->width() + skip)
 			+ _hangup->width();
 		const auto membersSkip = st::groupCallNarrowSkip;
-		const auto membersWidth = rtmp
+		const auto screencastOnly = fullscreenForScreencastOnly();
+		const auto membersWidth = (rtmp || screencastOnly)
 			? membersSkip
 			: (st::groupCallNarrowMembersWidth + 2 * membersSkip);
-		auto left = membersSkip + (widget()->width()
-			- membersWidth
-			- membersSkip
-			- fullWidth) / 2;
+		auto left = screencastOnly
+			? (widget()->width() - fullWidth) / 2
+			: membersSkip + (widget()->width()
+				- membersWidth
+				- membersSkip
+				- fullWidth) / 2;
 
 		const auto forMessagesLeft = left
 			- st::groupCallControlsBackMargin.left();
@@ -2685,21 +2783,28 @@ void Panel::updateMembersGeometry() {
 	if (!_members) {
 		return;
 	}
-	_members->setVisible(!_call->rtmp());
+	_members->setVisible(!_call->rtmp() && !fullscreenForScreencastOnly());
 	const auto desiredHeight = _members->desiredHeight();
 	if (mode() == PanelMode::Wide) {
-		const auto skip = _rtmpFull ? 0 : st::groupCallNarrowSkip;
-		const auto membersWidth = st::groupCallNarrowMembersWidth;
-		const auto top = _rtmpFull ? 0 : st::groupCallWideVideoTop;
+		const auto screencastOnly = fullscreenForScreencastOnly();
+		const auto skip = (_rtmpFull || screencastOnly)
+			? 0
+			: st::groupCallNarrowSkip;
+		const auto membersWidth = screencastOnly
+			? 0
+			: st::groupCallNarrowMembersWidth;
+		const auto top = (_rtmpFull || screencastOnly)
+			? 0
+			: st::groupCallWideVideoTop;
 		_members->setGeometry(
 			widget()->width() - skip - membersWidth,
 			top,
 			membersWidth,
 			std::min(desiredHeight, widget()->height() - top - skip));
-		const auto viewportSkip = _call->rtmp()
+		const auto viewportSkip = (_call->rtmp() || screencastOnly)
 			? 0
 			: (skip + membersWidth);
-		_viewport->setGeometry(_rtmpFull, {
+		_viewport->setGeometry(_rtmpFull || screencastOnly, {
 			skip,
 			top,
 			widget()->width() - viewportSkip - 2 * skip,
@@ -2727,6 +2832,17 @@ void Panel::updateMembersGeometry() {
 			membersWidth,
 			std::min(desiredHeight, availableHeight));
 	}
+}
+
+bool Panel::fullscreenForScreencast() const {
+	const auto &endpoint = _call->videoEndpointLarge();
+	return endpoint && (endpoint.type == VideoEndpointType::Screen);
+}
+
+bool Panel::fullscreenForScreencastOnly() const {
+	return _screencastOnlyInFullscreen
+		&& window()->isFullScreen()
+		&& fullscreenForScreencast();
 }
 
 rpl::producer<QString> Panel::titleText() {

--- a/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
@@ -244,7 +244,11 @@ Panel::Panel(not_null<GroupCall*> call, ConferencePanelMigration info)
 	result.setAlphaF(kControlsBackgroundOpacity);
 	return result;
 })
-, _hideControlsTimer([=] { toggleWideControls(false); }) {
+, _hideControlsTimer([=] {
+	if (_rtmpFull || fullscreenForScreencastOnly()) {
+		toggleWideControls(false);
+	}
+}) {
 	_viewport->widget()->hide();
 	if (!_viewport->requireARGB32()) {
 		_call->setNotRequireARGB32();
@@ -377,29 +381,50 @@ void Panel::initWindow() {
 		subscribeToPeerChanges();
 	}
 
+	const auto wasFullscreen = std::make_shared<bool>(
+		(window()->windowState() & Qt::WindowFullScreen) != 0);
 	const auto updateFullScreen = [=] {
 		const auto state = window()->windowState();
-		const auto full = (state & Qt::WindowFullScreen)
-			|| (state & Qt::WindowMaximized);
+		const auto fullscreen = ((state & Qt::WindowFullScreen) != 0);
+		const auto maximized = ((state & Qt::WindowMaximized) != 0);
+		const auto full = (fullscreen || maximized);
+		if (!fullscreen) {
+			_screencastOnlyInFullscreen = false;
+		} else if (!*wasFullscreen && fullscreenForScreencast()) {
+			_screencastOnlyInFullscreen = true;
+		}
+		*wasFullscreen = fullscreen;
 		_rtmpFull = _call->rtmp() && full;
 		_fullScreenOrMaximized = full;
+		if (_subtitle && fullscreenForScreencastOnly()) {
+			_subtitle.destroy();
+		}
+		updateControlsGeometry();
+		if (fullscreenForScreencastOnly()) {
+			_hideControlsTimer.callOnce(kHideControlsTimeout);
+			toggleWideControls(true);
+		} else if (!_rtmpFull) {
+			_hideControlsTimer.cancel();
+			toggleWideControls(_viewport->widget()->underMouse());
+		}
 	};
 	base::install_event_filter(window().get(), [=](not_null<QEvent*> e) {
 		const auto type = e->type();
 		if (type == QEvent::Close && handleClose()) {
 			e->ignore();
 			return base::EventFilterResult::Cancel;
-		} else if (_call->rtmp()
-			&& (type == QEvent::KeyPress || type == QEvent::KeyRelease)) {
+		} else if (type == QEvent::KeyPress || type == QEvent::KeyRelease) {
 			const auto key = static_cast<QKeyEvent*>(e.get())->key();
-			if (key == Qt::Key_Space) {
+			if (_call->rtmp() && key == Qt::Key_Space) {
 				_call->pushToTalk(
 					e->type() == QEvent::KeyPress,
 					kSpacePushToTalkDelay);
-			} else if (key == Qt::Key_Escape
-				&& _fullScreenOrMaximized.current()) {
-				toggleFullScreen();
-			}
+		} else if ((type == QEvent::KeyPress)
+			&& (key == Qt::Key_Escape)
+			&& (window()->isFullScreen()
+				|| _fullScreenOrMaximized.current())) {
+			toggleFullScreen(false);
+		}
 		} else if (type == QEvent::WindowStateChange) {
 			updateFullScreen();
 		}
@@ -412,6 +437,12 @@ void Panel::initWindow() {
 		using Flag = Ui::WindowTitleHitTestFlag;
 		if (!guard) {
 			return (Flag::None | Flag(0));
+		}
+		if (fullscreenForScreencast()
+			&& _viewport->widget()->geometry().contains(widgetPoint)) {
+			return window()->isFullScreen()
+				? (Flag::None | Flag(0))
+				: (Flag::FullScreen | Flag(0));
 		}
 		const auto titleRect = QRect(
 			0,
@@ -431,7 +462,11 @@ void Panel::initWindow() {
 		}
 		const auto shown = _window->topShownLayer();
 		return (!shown || !shown->geometry().contains(widgetPoint))
-			? (Flag::Move | Flag::Menu | Flag::Maximize)
+			? (Flag::Move
+				| Flag::Menu
+				| (fullscreenForScreencast()
+					? Flag::FullScreen
+					: Flag::Maximize))
 			: Flag::None;
 	});
 
@@ -441,7 +476,8 @@ void Panel::initWindow() {
 	}, lifetime());
 
 	_window->maximizeRequests() | rpl::on_next([=](bool maximized) {
-		if (_call->rtmp()) {
+		if (_call->rtmp() || fullscreenForScreencast()) {
+			_screencastOnlyInFullscreen = false;
 			toggleFullScreen(maximized);
 		} else {
 			window()->setWindowState(maximized
@@ -672,6 +708,9 @@ void Panel::toggleFullScreen() {
 }
 
 void Panel::toggleFullScreen(bool fullscreen) {
+	if (!fullscreen) {
+		_screencastOnlyInFullscreen = false;
+	}
 	if (fullscreen) {
 		window()->showFullScreen();
 	} else {
@@ -1024,7 +1063,28 @@ void Panel::setupMembers() {
 	) | rpl::filter([=] {
 		return !_rtmpFull;
 	}) | rpl::on_next([=](bool inside) {
-		toggleWideControls(inside);
+		if (fullscreenForScreencastOnly()) {
+			if (inside) {
+				_hideControlsTimer.callOnce(kHideControlsTimeout);
+				toggleWideControls(true);
+			} else {
+				_hideControlsTimer.cancel();
+				toggleWideControls(false);
+			}
+		} else {
+			_hideControlsTimer.cancel();
+			toggleWideControls(inside);
+		}
+	}, _viewport->lifetime());
+
+	_viewport->rp()->events(
+	) | rpl::filter([=](not_null<QEvent*> e) {
+		return (e->type() == QEvent::MouseMove);
+	}) | rpl::on_next([=] {
+		if (fullscreenForScreencastOnly()) {
+			_hideControlsTimer.callOnce(kHideControlsTimeout);
+			toggleWideControls(true);
+		}
 	}, _viewport->lifetime());
 
 	_members->show();
@@ -1077,6 +1137,7 @@ void Panel::setupMembers() {
 			enlargeVideo();
 		}
 		_viewport->showLarge(large);
+		updateControlsGeometry();
 	}, _callLifetime);
 }
 
@@ -1281,6 +1342,34 @@ void Panel::setupVideo(not_null<Viewport*> viewport) {
 		}
 	}, viewport->lifetime());
 
+	if (viewport == _viewport.get()) {
+		viewport->doubleClicks(
+		) | rpl::on_next([=](const VideoEndpoint &endpoint) {
+			if (endpoint.type != VideoEndpointType::Screen) {
+				return;
+			}
+			if (_call->videoEndpointLarge() != endpoint) {
+				if (_call->videoEndpointPinned()) {
+					_call->pinVideoEndpoint(endpoint);
+				} else {
+					_call->showVideoEndpointLarge(endpoint);
+				}
+			}
+			if (window()->isFullScreen()) {
+				_screencastOnlyInFullscreen = !_screencastOnlyInFullscreen;
+				if (fullscreenForScreencastOnly()) {
+					_hideControlsTimer.callOnce(kHideControlsTimeout);
+				} else {
+					_hideControlsTimer.cancel();
+				}
+				updateControlsGeometry();
+			} else {
+				_screencastOnlyInFullscreen = true;
+				toggleFullScreen(true);
+			}
+		}, viewport->lifetime());
+	}
+
 	viewport->qualityRequests(
 	) | rpl::on_next([=](const VideoQualityRequest &request) {
 		_call->requestVideoQuality(request.endpoint, request.quality);
@@ -1304,7 +1393,8 @@ void Panel::updateWideControlsVisibility() {
 	if (_wideControlsShown == shown) {
 		return;
 	}
-	_viewport->setCursorShown(!_rtmpFull || shown);
+	_viewport->setCursorShown(
+		(!_rtmpFull && !fullscreenForScreencastOnly()) || shown);
 	_wideControlsShown = shown;
 	_wideControlsAnimation.start(
 		[=] { updateButtonsGeometry(); },
@@ -2213,6 +2303,9 @@ void Panel::trackControl(Ui::RpWidget *widget, rpl::lifetime &lifetime) {
 				}
 			});
 			toggleWideControls(true);
+			if (_rtmpFull || fullscreenForScreencastOnly()) {
+				_hideControlsTimer.cancel();
+			}
 		} else if (type == QEvent::Leave) {
 			*over = false;
 			crl::on_main(widget, [=] {
@@ -2221,6 +2314,9 @@ void Panel::trackControl(Ui::RpWidget *widget, rpl::lifetime &lifetime) {
 				}
 			});
 			toggleWideControls(false);
+			if (_rtmpFull || fullscreenForScreencastOnly()) {
+				_hideControlsTimer.callOnce(kHideControlsTimeout);
+			}
 		}
 	}, lifetime);
 }
@@ -2545,13 +2641,16 @@ void Panel::updateButtonsGeometry() {
 			+ (_settings->width() + skip)
 			+ _hangup->width();
 		const auto membersSkip = st::groupCallNarrowSkip;
-		const auto membersWidth = rtmp
+		const auto screencastOnly = fullscreenForScreencastOnly();
+		const auto membersWidth = (rtmp || screencastOnly)
 			? membersSkip
 			: (st::groupCallNarrowMembersWidth + 2 * membersSkip);
-		auto left = membersSkip + (widget()->width()
-			- membersWidth
-			- membersSkip
-			- fullWidth) / 2;
+		auto left = screencastOnly
+			? (widget()->width() - fullWidth) / 2
+			: membersSkip + (widget()->width()
+				- membersWidth
+				- membersSkip
+				- fullWidth) / 2;
 
 		const auto forMessagesLeft = left
 			- st::groupCallControlsBackMargin.left();
@@ -2762,21 +2861,28 @@ void Panel::updateMembersGeometry() {
 	if (!_members) {
 		return;
 	}
-	_members->setVisible(!_call->rtmp());
+	_members->setVisible(!_call->rtmp() && !fullscreenForScreencastOnly());
 	const auto desiredHeight = _members->desiredHeight();
 	if (mode() == PanelMode::Wide) {
-		const auto skip = _rtmpFull ? 0 : st::groupCallNarrowSkip;
-		const auto membersWidth = st::groupCallNarrowMembersWidth;
-		const auto top = _rtmpFull ? 0 : st::groupCallWideVideoTop;
+		const auto screencastOnly = fullscreenForScreencastOnly();
+		const auto skip = (_rtmpFull || screencastOnly)
+			? 0
+			: st::groupCallNarrowSkip;
+		const auto membersWidth = screencastOnly
+			? 0
+			: st::groupCallNarrowMembersWidth;
+		const auto top = (_rtmpFull || screencastOnly)
+			? 0
+			: st::groupCallWideVideoTop;
 		_members->setGeometry(
 			widget()->width() - skip - membersWidth,
 			top,
 			membersWidth,
 			std::min(desiredHeight, widget()->height() - top - skip));
-		const auto viewportSkip = _call->rtmp()
+		const auto viewportSkip = (_call->rtmp() || screencastOnly)
 			? 0
 			: (skip + membersWidth);
-		_viewport->setGeometry(_rtmpFull, {
+		_viewport->setGeometry(_rtmpFull || screencastOnly, {
 			skip,
 			top,
 			widget()->width() - viewportSkip - 2 * skip,
@@ -2804,6 +2910,17 @@ void Panel::updateMembersGeometry() {
 			membersWidth,
 			std::min(desiredHeight, availableHeight));
 	}
+}
+
+bool Panel::fullscreenForScreencast() const {
+	const auto &endpoint = _call->videoEndpointLarge();
+	return endpoint && (endpoint.type == VideoEndpointType::Screen);
+}
+
+bool Panel::fullscreenForScreencastOnly() const {
+	return _screencastOnlyInFullscreen
+		&& window()->isFullScreen()
+		&& fullscreenForScreencast();
 }
 
 rpl::producer<QString> Panel::titleText() {

--- a/Telegram/SourceFiles/calls/group/calls_group_panel.h
+++ b/Telegram/SourceFiles/calls/group/calls_group_panel.h
@@ -153,6 +153,8 @@ private:
 	void updateControlsGeometry();
 	void updateButtonsGeometry();
 	void updateTooltipGeometry();
+	[[nodiscard]] bool fullscreenForScreencast() const;
+	[[nodiscard]] bool fullscreenForScreencastOnly() const;
 	void updateButtonsStyles();
 	void updateMembersGeometry();
 	void refreshControlsBackground();
@@ -213,6 +215,7 @@ private:
 	std::shared_ptr<Window> _window;
 	rpl::variable<PanelMode> _mode;
 	rpl::variable<bool> _fullScreenOrMaximized = false;
+	bool _screencastOnlyInFullscreen = false;
 	bool _unpinnedMaximized = false;
 	bool _rtmpFull = false;
 

--- a/Telegram/SourceFiles/calls/group/calls_group_panel.h
+++ b/Telegram/SourceFiles/calls/group/calls_group_panel.h
@@ -153,6 +153,8 @@ private:
 	void updateControlsGeometry();
 	void updateButtonsGeometry();
 	void updateTooltipGeometry();
+	[[nodiscard]] bool fullscreenForScreencast() const;
+	[[nodiscard]] bool fullscreenForScreencastOnly() const;
 	void updateButtonsStyles();
 	void updateMembersGeometry();
 	void refreshControlsBackground();
@@ -210,6 +212,7 @@ private:
 	std::shared_ptr<Window> _window;
 	rpl::variable<PanelMode> _mode;
 	rpl::variable<bool> _fullScreenOrMaximized = false;
+	bool _screencastOnlyInFullscreen = false;
 	bool _unpinnedMaximized = false;
 	bool _rtmpFull = false;
 

--- a/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
@@ -126,6 +126,10 @@ void Viewport::setup() {
 			handleMousePress(
 				static_cast<QMouseEvent*>(e.get())->pos(),
 				static_cast<QMouseEvent*>(e.get())->button());
+		} else if (type == QEvent::MouseButtonDblClick) {
+			handleMouseDoubleClick(
+				static_cast<QMouseEvent*>(e.get())->pos(),
+				static_cast<QMouseEvent*>(e.get())->button());
 		} else if (type == QEvent::MouseButtonRelease) {
 			handleMouseRelease(
 				static_cast<QMouseEvent*>(e.get())->pos(),
@@ -208,10 +212,29 @@ void Viewport::handleMousePress(QPoint position, Qt::MouseButton button) {
 	setPressed(_selected);
 }
 
+void Viewport::handleMouseDoubleClick(
+		QPoint position,
+		Qt::MouseButton button) {
+	handleMouseMove(position);
+	if (button != Qt::LeftButton || videoStream()) {
+		return;
+	}
+	const auto tile = _selected.tile;
+	if (!tile) {
+		return;
+	}
+	_skipNextMouseRelease = true;
+	_doubleClicks.fire_copy(tile->endpoint());
+}
+
 void Viewport::handleMouseRelease(QPoint position, Qt::MouseButton button) {
 	handleMouseMove(position);
 	const auto pressed = _pressed;
 	setPressed({});
+	if (_skipNextMouseRelease && button == Qt::LeftButton) {
+		_skipNextMouseRelease = false;
+		return;
+	}
 	if (const auto tile = pressed.tile) {
 		if (pressed == _selected) {
 			if (videoStream()) {
@@ -963,6 +986,10 @@ rpl::producer<bool> Viewport::pinToggled() const {
 
 rpl::producer<VideoEndpoint> Viewport::clicks() const {
 	return _clicks.events();
+}
+
+rpl::producer<VideoEndpoint> Viewport::doubleClicks() const {
+	return _doubleClicks.events();
 }
 
 rpl::producer<VideoQualityRequest> Viewport::qualityRequests() const {

--- a/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
@@ -120,6 +120,10 @@ void Viewport::setup() {
 			handleMousePress(
 				static_cast<QMouseEvent*>(e.get())->pos(),
 				static_cast<QMouseEvent*>(e.get())->button());
+		} else if (type == QEvent::MouseButtonDblClick) {
+			handleMouseDoubleClick(
+				static_cast<QMouseEvent*>(e.get())->pos(),
+				static_cast<QMouseEvent*>(e.get())->button());
 		} else if (type == QEvent::MouseButtonRelease) {
 			handleMouseRelease(
 				static_cast<QMouseEvent*>(e.get())->pos(),
@@ -202,10 +206,29 @@ void Viewport::handleMousePress(QPoint position, Qt::MouseButton button) {
 	setPressed(_selected);
 }
 
+void Viewport::handleMouseDoubleClick(
+		QPoint position,
+		Qt::MouseButton button) {
+	handleMouseMove(position);
+	if (button != Qt::LeftButton || videoStream()) {
+		return;
+	}
+	const auto tile = _selected.tile;
+	if (!tile) {
+		return;
+	}
+	_skipNextMouseRelease = true;
+	_doubleClicks.fire_copy(tile->endpoint());
+}
+
 void Viewport::handleMouseRelease(QPoint position, Qt::MouseButton button) {
 	handleMouseMove(position);
 	const auto pressed = _pressed;
 	setPressed({});
+	if (_skipNextMouseRelease && button == Qt::LeftButton) {
+		_skipNextMouseRelease = false;
+		return;
+	}
 	if (const auto tile = pressed.tile) {
 		if (pressed == _selected) {
 			if (videoStream()) {
@@ -917,6 +940,10 @@ rpl::producer<bool> Viewport::pinToggled() const {
 
 rpl::producer<VideoEndpoint> Viewport::clicks() const {
 	return _clicks.events();
+}
+
+rpl::producer<VideoEndpoint> Viewport::doubleClicks() const {
+	return _doubleClicks.events();
 }
 
 rpl::producer<VideoQualityRequest> Viewport::qualityRequests() const {

--- a/Telegram/SourceFiles/calls/group/calls_group_viewport.h
+++ b/Telegram/SourceFiles/calls/group/calls_group_viewport.h
@@ -105,6 +105,7 @@ public:
 	[[nodiscard]] rpl::producer<int> fullHeightValue() const;
 	[[nodiscard]] rpl::producer<bool> pinToggled() const;
 	[[nodiscard]] rpl::producer<VideoEndpoint> clicks() const;
+	[[nodiscard]] rpl::producer<VideoEndpoint> doubleClicks() const;
 	[[nodiscard]] rpl::producer<VideoQualityRequest> qualityRequests() const;
 	[[nodiscard]] rpl::producer<bool> mouseInsideValue() const;
 
@@ -196,6 +197,7 @@ private:
 	void setPressed(Selection value);
 
 	void handleMousePress(QPoint position, Qt::MouseButton button);
+	void handleMouseDoubleClick(QPoint position, Qt::MouseButton button);
 	void handleMouseRelease(QPoint position, Qt::MouseButton button);
 	void handleMouseMove(QPoint position);
 	void updateSelected(QPoint position);
@@ -219,6 +221,7 @@ private:
 	int _scrollTop = 0;
 	QImage _shadow;
 	rpl::event_stream<VideoEndpoint> _clicks;
+	rpl::event_stream<VideoEndpoint> _doubleClicks;
 	rpl::event_stream<bool> _pinToggles;
 	rpl::event_stream<VideoQualityRequest> _qualityRequests;
 	float64 _controlsShownRatio = 1.;
@@ -229,6 +232,7 @@ private:
 	Layout _finishTilesLayout;
 	Selection _selected;
 	Selection _pressed;
+	bool _skipNextMouseRelease = false;
 	rpl::variable<bool> _mouseInside = false;
 
 	Ui::RpWidgetWrap * const _borrowed = nullptr;

--- a/Telegram/SourceFiles/calls/group/calls_group_viewport.h
+++ b/Telegram/SourceFiles/calls/group/calls_group_viewport.h
@@ -97,6 +97,7 @@ public:
 	[[nodiscard]] rpl::producer<int> fullHeightValue() const;
 	[[nodiscard]] rpl::producer<bool> pinToggled() const;
 	[[nodiscard]] rpl::producer<VideoEndpoint> clicks() const;
+	[[nodiscard]] rpl::producer<VideoEndpoint> doubleClicks() const;
 	[[nodiscard]] rpl::producer<VideoQualityRequest> qualityRequests() const;
 	[[nodiscard]] rpl::producer<bool> mouseInsideValue() const;
 
@@ -179,6 +180,7 @@ private:
 	void setPressed(Selection value);
 
 	void handleMousePress(QPoint position, Qt::MouseButton button);
+	void handleMouseDoubleClick(QPoint position, Qt::MouseButton button);
 	void handleMouseRelease(QPoint position, Qt::MouseButton button);
 	void handleMouseMove(QPoint position);
 	void updateSelected(QPoint position);
@@ -201,6 +203,7 @@ private:
 	int _scrollTop = 0;
 	QImage _shadow;
 	rpl::event_stream<VideoEndpoint> _clicks;
+	rpl::event_stream<VideoEndpoint> _doubleClicks;
 	rpl::event_stream<bool> _pinToggles;
 	rpl::event_stream<VideoQualityRequest> _qualityRequests;
 	float64 _controlsShownRatio = 1.;
@@ -211,6 +214,7 @@ private:
 	Layout _finishTilesLayout;
 	Selection _selected;
 	Selection _pressed;
+	bool _skipNextMouseRelease = false;
 	rpl::variable<bool> _mouseInside = false;
 
 	Ui::RpWidgetWrap * const _borrowed = nullptr;

--- a/Telegram/SourceFiles/calls/group/calls_group_viewport_opengl.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_viewport_opengl.cpp
@@ -1450,7 +1450,7 @@ void Viewport::RendererGL::validateNoiseTexture(
 void Viewport::RendererGL::validateOutlineAnimation(
 		not_null<VideoTile*> tile,
 		TileData &data) {
-	const auto outline = tile->row()->speaking();
+	const auto outline = !_owner->_fullscreen && tile->row()->speaking();
 	if (data.outline == outline) {
 		return;
 	}

--- a/Telegram/SourceFiles/calls/group/calls_group_viewport_raster.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_viewport_raster.cpp
@@ -186,7 +186,7 @@ void Viewport::RendererSW::paintTileOutline(
 		int width,
 		int height,
 		not_null<VideoTile*> tile) {
-	if (!tile->row()->speaking()) {
+	if (_owner->_fullscreen || !tile->row()->speaking()) {
 		return;
 	}
 	const auto outline = st::groupCallOutline;


### PR DESCRIPTION
When a screen endpoint is focused, entering fullscreen switches to a screencast-only layout that hides the members panel and expands the viewport. Double-click toggles the mode, controls auto-hide on inactivity and reappear on mouse movement. Titlebar maximize enters fullscreen for screenshare. Subtitle is destroyed in that mode and recreated via refreshTitle on exit. Speaking outline disabled in fullscreen to avoid full-frame highlight artifacts.