### PR TITLE
Fix unread badge counting from inactive accounts when notifyFromAll is disabled. Fix #26938

### DIFF
--- a/Telegram/SourceFiles/main/main_domain.cpp
+++ b/Telegram/SourceFiles/main/main_domain.cpp
@@ -244,7 +244,11 @@ void Domain::notifyUnreadBadgeChanged() {
 void Domain::updateUnreadBadge() {
 	_unreadBadge = 0;
 	_unreadBadgeMuted = true;
+	const auto notifyFromAll = Core::App().settings().notifyFromAll();
 	for (const auto &[index, account] : _accounts) {
+		if (!notifyFromAll && account.get() != _active.current()) {
+			continue;
+		}
 		if (const auto session = account->maybeSession()) {
 			const auto data = &session->data();
 			_unreadBadge += data->unreadBadge();
@@ -485,6 +489,9 @@ void Domain::activate(not_null<Main::Account*> account) {
 			crl::on_main(&Core::App(), [=] {
 				removeRedundantAccounts();
 			});
+		}
+		if (!Core::App().settings().notifyFromAll()) {
+			scheduleUpdateUnreadBadge();
 		}
 	}
 }

--- a/Telegram/SourceFiles/settings/sections/settings_notifications.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_notifications.cpp
@@ -847,6 +847,7 @@ void BuildMultiAccountSection(SectionBuilder &builder) {
 		}) | rpl::on_next([=](bool checked) {
 			Core::App().settings().setNotifyFromAll(checked);
 			Core::App().saveSettingsDelayed();
+			Core::App().domain().notifyUnreadBadgeChanged();
 			if (!checked) {
 				auto &notifications = Core::App().notifications();
 				const auto &list = Core::App().domain().accounts();


### PR DESCRIPTION
…ce, no prefix convention visible in their history) and includes the issue-closing keyword as required.Fixes #26938
Domain::updateUnreadBadge() unconditionally summed unread counts from all accounts. When notifyFromAll is disabled, it now skips inactive accounts, so the badge only reflects the active account's unreads.
Also triggers a badge recalculation when switching accounts (since the set of counted accounts changes), and when toggling the setting itself.
Changes
- main_domain.cpp: In updateUnreadBadge(), skip non-active accounts when notifyFromAll is off.
- main_domain.cpp: In activate(), schedule a badge update on account switch when notifyFromAll is off.
- settings_notifications.cpp: Call notifyUnreadBadgeChanged() when the setting is toggled so the badge updates immediately.
Note on #26938
The issue was closed as intended behavior (https://github.com/telegramdesktop/tdesktop/issues/26938#issuecomment-1768017498), with the reasoning that the "Notify from all accounts" setting was only meant to control desktop notifications, not badge counters.
I've read that and I'm ignoring it, because I think that tthis intention was stupid. A setting called "Notify from all accounts" that still counts unreads from all accounts in the badge is unintuitive — the badge is a notification. If this was intentional, the intention lacked common sense. Over two years have passed since that decision, and intentions can change. I'm opening this PR in the hope the maintainers will reconsider.