### PR TITLE
Fix incorrect use of reinterpret_cast

### DIFF
--- a/Telegram/SourceFiles/core/utils.cpp
+++ b/Telegram/SourceFiles/core/utils.cpp
@@ -29,7 +29,9 @@ extern "C" {
 #include <time.h>
 #endif
 
-uint64 _SharedMemoryLocation[4] = { 0x00, 0x01, 0x02, 0x03 };
+// For general-purpose storage, only the types “array of N unsigned char” or “array of N std::byte” are allowed.
+// https://eel.is/c++draft/intro.object#3
+alignas(uint64) std::byte _SharedMemoryLocation[4*sizeof(uint64)];
 
 // Base types compile-time check
 static_assert(sizeof(char) == 1, "Basic types size check failed");

--- a/Telegram/SourceFiles/core/utils.h
+++ b/Telegram/SourceFiles/core/utils.h
@@ -44,11 +44,14 @@ inline bool CanReadDirectory(const QString &path) {
 
 static const int32 ScrollMax = INT_MAX;
 
-extern uint64 _SharedMemoryLocation[];
+// For general-purpose storage, only the types “array of N unsigned char” or “array of N std::byte” are allowed.
+// https://eel.is/c++draft/intro.object#3
+alignas(uint64) extern std::byte _SharedMemoryLocation[];
 template <typename T, unsigned int N>
 T *SharedMemoryLocation() {
 	static_assert(N < 4, "Only 4 shared memory locations!");
-	return reinterpret_cast<T*>(_SharedMemoryLocation + N);
+	static_assert(alignof(T) <= alignof(uint64), "Storage or type alignment is invalid!");
+	return reinterpret_cast<T*>(_SharedMemoryLocation + N*sizeof(uint64));
 }
 
 inline void mylocaltime(struct tm * _Tm, const time_t * _Time) {

--- a/Telegram/SourceFiles/data/data_types.cpp
+++ b/Telegram/SourceFiles/data/data_types.cpp
@@ -10,6 +10,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/fields/input_field.h"
 #include "storage/cache/storage_cache_types.h"
 #include "base/openssl_help.h"
+#include <cstring>
 
 namespace Data {
 namespace {
@@ -48,8 +49,10 @@ Storage::Cache::Key WebDocumentCacheKey(const WebFileLocation &location) {
 	const auto bytes = bytes::make_span(hash);
 	const auto bytes1 = bytes.subspan(0, sizeof(uint32));
 	const auto bytes2 = bytes.subspan(sizeof(uint32), sizeof(uint64));
-	const auto part1 = *reinterpret_cast<const uint32*>(bytes1.data());
-	const auto part2 = *reinterpret_cast<const uint64*>(bytes2.data());
+	uint32 part1;
+	uint64 part2;
+	std::memcpy(&part1, bytes1.data(), sizeof(uint32));
+	std::memcpy(&part2, bytes2.data(), sizeof(uint64));
 	return Storage::Cache::Key{
 		Data::kWebDocumentCacheTag | (dcId << 32) | part1,
 		part2
@@ -65,9 +68,12 @@ Storage::Cache::Key UrlCacheKey(const QString &location) {
 	const auto bytes3 = bytes.subspan(
 		sizeof(uint32) + sizeof(uint64),
 		sizeof(uint16));
-	const auto part1 = *reinterpret_cast<const uint32*>(bytes1.data());
-	const auto part2 = *reinterpret_cast<const uint64*>(bytes2.data());
-	const auto part3 = *reinterpret_cast<const uint16*>(bytes3.data());
+	uint32 part1;
+	uint64 part2;
+	uint16 part3;
+	std::memcpy(&part1, bytes1.data(), sizeof(uint32));
+	std::memcpy(&part2, bytes2.data(), sizeof(uint64));
+	std::memcpy(&part3, bytes3.data(), sizeof(uint16));
 	return Storage::Cache::Key{
 		Data::kUrlCacheTag | (uint64(part3) << 32) | part1,
 		part2

--- a/Telegram/SourceFiles/mtproto/connection_tcp.h
+++ b/Telegram/SourceFiles/mtproto/connection_tcp.h
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "mtproto/connection_abstract.h"
 #include "mtproto/mtproto_auth_key.h"
+#include <cstring>
 
 namespace MTP {
 namespace details {
@@ -63,8 +64,20 @@ private:
 	mtpBuffer parsePacket(bytes::const_span bytes);
 	void ensureAvailableInBuffer(int amount);
 	static uint32 fourCharsToUInt(char ch1, char ch2, char ch3, char ch4) {
+#warning "need to select one of the options"
+#if 0
 		char ch[4] = { ch1, ch2, ch3, ch4 };
-		return *reinterpret_cast<uint32*>(ch);
+		uint32 value;
+		std::memcpy(&value, ch, 4);
+		return value;
+#else
+		const uint32 part1 = ch1;
+		const uint32 part2 = ch2;
+		const uint32 part3 = ch3;
+		const uint32 part4 = ch4;
+		// What should be the byte order in the value representation?
+		return uint32((part1 << 24) | (part2 << 16) | (part3 << 8) | part4);
+#endif
 	}
 
 	const not_null<Instance*> _instance;


### PR DESCRIPTION
Using `reinterpret_cast` from _string_ (array of chars) (?) to `uint32`, `uint64`, `uint16` is undefined behavior (program attempts to access the stored value of an object through a _glvalue_ through which it is not type-accessible).
https://eel.is/c++draft/basic.lval#11

> 11 An object of dynamic type Tobj is [type-accessible](https://eel.is/c++draft/basic.lval#def:type-accessible) through a glvalue of type Tref if Tref is similar ([[conv.qual]](https://eel.is/c++draft/conv.qual)) to:
>     (11.1) -- Tobj,
>     (11.2) -- a type that is the signed or unsigned type corresponding to Tobj, or
>     (11.3) -- a char, unsigned char, or std​::​byte type[.](https://eel.is/c++draft/basic.lval#11.sentence-1)
> 
> If a program attempts to access ([[defns.access]](https://eel.is/c++draft/defns.access)) the stored value of an object through a glvalue through which it is not type-accessible, the behavior is undefined[.](https://eel.is/c++draft/basic.lval#11.sentence-2)[38](https://eel.is/c++draft/basic.lval#footnote-38)

fix for https://github.com/telegramdesktop/tdesktop/issues/30300