### PR TITLE
Speed up app startup (use faster containers for emoji maps)

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.h
+++ b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.h
@@ -13,6 +13,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/round_rect.h"
 #include "base/timer.h"
 
+#include <map>
+
 class StickerPremiumMark;
 
 namespace style {
@@ -438,7 +440,7 @@ private:
 	QVector<EmojiPtr> _emoji[kEmojiSectionCount];
 	std::vector<CustomSet> _custom;
 	base::flat_set<DocumentId> _restrictedCustomList;
-	base::flat_map<EmojiStatusId, CustomEmojiInstance> _customEmoji;
+	std::map<EmojiStatusId, CustomEmojiInstance> _customEmoji;
 	base::flat_map<
 		DocumentId,
 		std::unique_ptr<Ui::Text::CustomEmoji>> _customRecent;

--- a/Telegram/SourceFiles/data/stickers/data_custom_emoji.h
+++ b/Telegram/SourceFiles/data/stickers/data_custom_emoji.h
@@ -149,7 +149,7 @@ private:
 	const not_null<Session*> _owner;
 
 	std::array<
-		base::flat_map<
+		std::unordered_map<
 			DocumentId,
 			std::unique_ptr<Ui::CustomEmoji::Instance>>,
 		kSizeCount> _instances;


### PR DESCRIPTION
This shaved off about a second of startup time for me.
I checked it locally with a bunch of `PROFILE_LOG`s: https://github.com/telegramdesktop/tdesktop/compare/dev...futpib:faster-startup?expand=1
The thing that slowed down the startup was [`EmojiListWidget::refreshCustom`](https://github.com/telegramdesktop/tdesktop/blob/2f80db329bfb44639376396ea4cdc46c8d189bca/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp#L2294) inserting ~8k of custom emojis where each subsequent insert was slower than previous
