### PR TITLE
Speed up app startup (remove redundant cache and pre-warming)

### DIFF
--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -88,7 +88,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "boxes/premium_limits_box.h"
 #include "ui/accessible/ui_accessible_factory.h"
 #include "ui/boxes/confirm_box.h"
-#include "ui/controls/location_picker.h"
 #include "styles/style_window.h"
 
 #include <QtCore/QStandardPaths>
@@ -324,11 +323,6 @@ void Application::run() {
 
 	// Create mime database, so it won't be slow later.
 	QMimeDatabase().mimeTypeForName(u"text/plain"_q);
-
-	// Check now to avoid re-entrance later.
-	[[maybe_unused]] const auto ivSupported = Iv::ShowButton();
-	[[maybe_unused]] const auto lpAvailable = Ui::LocationPicker::Available(
-		{});
 
 	_windows.emplace(nullptr, std::make_unique<Window::Controller>());
 	setLastActiveWindow(_windows.front().second.get());

--- a/Telegram/SourceFiles/iv/iv_data.cpp
+++ b/Telegram/SourceFiles/iv/iv_data.cpp
@@ -102,12 +102,9 @@ QString SiteNameFromUrl(const QString &url) {
 }
 
 bool ShowButton() {
-	static const auto Supported = [&] {
-		const auto availability = Webview::Availability();
-		return availability.customSchemeRequests
-			&& availability.customRangeRequests;
-	}();
-	return Supported;
+	const auto availability = Webview::Availability();
+	return availability.customSchemeRequests
+		&& availability.customRangeRequests;
 }
 
 void RecordShowFailure() {

--- a/Telegram/SourceFiles/ui/controls/location_picker.cpp
+++ b/Telegram/SourceFiles/ui/controls/location_picker.cpp
@@ -772,12 +772,10 @@ std::shared_ptr<Main::SessionShow> LocationPicker::uiShow() {
 }
 
 bool LocationPicker::Available(const LocationPickerConfig &config) {
-	static const auto Supported = [&] {
-		const auto availability = Webview::Availability();
-		return availability.customSchemeRequests
-			&& availability.customReferer;
-	}();
-	return Supported && !config.mapsToken.isEmpty();
+	const auto availability = Webview::Availability();
+	return availability.customSchemeRequests
+		&& availability.customReferer
+		&& !config.mapsToken.isEmpty();
 }
 
 void LocationPicker::setup(const Descriptor &descriptor) {


### PR DESCRIPTION
Iv::ShowButton() and LocationPicker::Available() each cache the result of Webview::Availability() in a static local.
These caches will be redundant if/when desktop-app/lib_webview#136 is merged.

TLDR: look at https://github.com/desktop-app/lib_webview/pull/136 first

### A better idea: https://github.com/desktop-app/lib_webview/pull/136#issuecomment-3921071476