### PR TITLE
Speed up app startup (use rename instead of copy for log file rotation)

### DIFF
--- a/Telegram/SourceFiles/logs.cpp
+++ b/Telegram/SourceFiles/logs.cpp
@@ -144,36 +144,48 @@ private:
 			if (postfix.isEmpty()) { // instance checked, need to move to log.txt
 				Assert(!files[type]->fileName().isEmpty()); // one of log_startXX.txt should've been opened already
 
-				auto to = std::make_unique<QFile>(_logsFilePath(type, postfix));
-				if (to->exists() && !to->remove()) {
-					LOG(("Could not delete '%1' file to start new logging: %2").arg(to->fileName(), to->errorString()));
+				const auto startName = files[type]->fileName();
+				const auto targetName = _logsFilePath(type, postfix);
+
+				auto target = QFile(targetName);
+				if (target.exists() && !target.remove()) {
+					LOG(("Could not delete '%1' file to start new logging: %2").arg(targetName, target.errorString()));
 					return false;
 				}
-				if (auto from = QFile(files[type]->fileName()); !from.copy(to->fileName())) { // don't close files[type] yet
-					LOG(("Could not copy '%1' to '%2' to start new logging: %3").arg(files[type]->fileName(), to->fileName(), from.errorString()));
+
+				files[type]->close();
+
+				const auto reopenStart = [&] {
+					files[type]->setFileName(startName);
+					files[type]->open(mode | QIODevice::Append);
+				};
+
+				auto source = QFile(startName);
+				if (!source.rename(targetName)) {
+					reopenStart();
+					LOG(("Could not rename '%1' to '%2' to start new logging: %3").arg(startName, targetName, source.errorString()));
 					return false;
 				}
-				if (to->open(mode | QIODevice::Append)) {
-					std::swap(files[type], to);
-					LOG(("Moved logging from '%1' to '%2'!").arg(to->fileName(), files[type]->fileName()));
-					to->remove();
+				files[type]->setFileName(targetName);
+				if (!files[type]->open(mode | QIODevice::Append)) {
+					LOG(("Could not open '%1' file to start new logging: %2").arg(targetName, files[type]->errorString()));
+					return false;
+				}
+				LOG(("Moved logging from '%1' to '%2'!").arg(startName, files[type]->fileName()));
 
-					LogsStartIndexChosen = -1;
+				LogsStartIndexChosen = -1;
 
-					QDir working(cWorkingDir()); // delete all other log_startXX.txt that we can
-					QStringList oldlogs = working.entryList(QStringList("log_start*.txt"), QDir::Files);
-					for (QStringList::const_iterator i = oldlogs.cbegin(), e = oldlogs.cend(); i != e; ++i) {
-						QString oldlog = cWorkingDir() + *i, oldlogend = i->mid(u"log_start"_q.size());
-						if (oldlogend.size() == 1 + u".txt"_q.size() && oldlogend.at(0).isDigit() && base::StringViewMid(oldlogend, 1) == u".txt"_q) {
-							bool removed = QFile(oldlog).remove();
-							LOG(("Old start log '%1' found, deleted: %2").arg(*i, Logs::b(removed)));
-						}
+				QDir working(cWorkingDir()); // delete all other log_startXX.txt that we can
+				QStringList oldlogs = working.entryList(QStringList("log_start*.txt"), QDir::Files);
+				for (QStringList::const_iterator i = oldlogs.cbegin(), e = oldlogs.cend(); i != e; ++i) {
+					QString oldlog = cWorkingDir() + *i, oldlogend = i->mid(u"log_start"_q.size());
+					if (oldlogend.size() == 1 + u".txt"_q.size() && oldlogend.at(0).isDigit() && base::StringViewMid(oldlogend, 1) == u".txt"_q) {
+						bool removed = QFile(oldlog).remove();
+						LOG(("Old start log '%1' found, deleted: %2").arg(*i, Logs::b(removed)));
 					}
-
-					return true;
 				}
-				LOG(("Could not open '%1' file to start new logging: %2").arg(to->fileName(), to->errorString()));
-				return false;
+
+				return true;
 			} else {
 				bool found = false;
 				int32 oldest = -1; // find not existing log_startX.txt or pick the oldest one (by lastModified)


### PR DESCRIPTION
Replace the expensive file copy in Logs::instanceChecked() with an atomic rename. The old code copied log_startX.txt to log.txt then deleted the original, which took ~83ms of synchronous I/O. A simple rename on the same filesystem is nearly instant (~0.3ms).

Admittedly my logs were larger than usual because i added a ton of `PROFILE_LOG`'s