### PR TITLE
Speed up app startup (build emoji replaces in bg thread)

### DIFF
--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -92,6 +92,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "styles/style_window.h"
 
 #include <QtCore/QStandardPaths>
+#include "ui/widgets/fields/input_field.h"
+
 #include <QtCore/QMimeDatabase>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QScreen>
@@ -324,6 +326,9 @@ void Application::run() {
 
 	// Create mime database, so it won't be slow later.
 	QMimeDatabase().mimeTypeForName(u"text/plain"_q);
+
+	// Pre-warm InstantReplaces trie on background thread.
+	crl::async([] { Ui::InstantReplaces::Default(); });
 
 	// Check now to avoid re-entrance later.
 	[[maybe_unused]] const auto ivSupported = Iv::ShowButton();


### PR DESCRIPTION
Move InstantReplaces::Default() trie construction off the main thread by dispatching it via crl::async.

I checked it locally with a bunch of `PROFILE_LOG`s: https://github.com/telegramdesktop/tdesktop/compare/dev...futpib:faster-startup?expand=1

This is a ~29ms startup speedup in my setup which takes ~600ms in total on futpib:faster-startup branch