### PR TITLE
Speed up app startup (cache Webview::Availability)

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -482,6 +482,7 @@ PRIVATE
     chat_helpers/ttl_media_layer_widget.h
     core/application.cpp
     core/application.h
+    core/cached_webview_availability.h
     core/bank_card_click_handler.cpp
     core/bank_card_click_handler.h
     core/base_integration.cpp

--- a/Telegram/SourceFiles/core/application.cpp
+++ b/Telegram/SourceFiles/core/application.cpp
@@ -88,7 +88,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "boxes/premium_limits_box.h"
 #include "ui/accessible/ui_accessible_factory.h"
 #include "ui/boxes/confirm_box.h"
-#include "ui/controls/location_picker.h"
+#include "core/cached_webview_availability.h"
 #include "styles/style_window.h"
 
 #include <QtCore/QStandardPaths>
@@ -326,9 +326,8 @@ void Application::run() {
 	QMimeDatabase().mimeTypeForName(u"text/plain"_q);
 
 	// Check now to avoid re-entrance later.
-	[[maybe_unused]] const auto ivSupported = Iv::ShowButton();
-	[[maybe_unused]] const auto lpAvailable = Ui::LocationPicker::Available(
-		{});
+	[[maybe_unused]] const auto &webviewAvailability
+		= Core::CachedWebviewAvailability();
 
 	_windows.emplace(nullptr, std::make_unique<Window::Controller>());
 	setLastActiveWindow(_windows.front().second.get());

--- a/Telegram/SourceFiles/core/cached_webview_availability.h
+++ b/Telegram/SourceFiles/core/cached_webview_availability.h
@@ -1,0 +1,19 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include "webview/webview_interface.h"
+
+namespace Core {
+
+[[nodiscard]] inline const Webview::Available &CachedWebviewAvailability() {
+	static const auto result = Webview::Availability();
+	return result;
+}
+
+} // namespace Core

--- a/Telegram/SourceFiles/iv/iv_data.cpp
+++ b/Telegram/SourceFiles/iv/iv_data.cpp
@@ -8,7 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "iv/iv_data.h"
 
 #include "iv/iv_prepare.h"
-#include "webview/webview_interface.h"
+#include "core/cached_webview_availability.h"
 
 #include <QtCore/QRegularExpression>
 #include <QtCore/QUrl>
@@ -102,12 +102,9 @@ QString SiteNameFromUrl(const QString &url) {
 }
 
 bool ShowButton() {
-	static const auto Supported = [&] {
-		const auto availability = Webview::Availability();
-		return availability.customSchemeRequests
-			&& availability.customRangeRequests;
-	}();
-	return Supported;
+	const auto &availability = Core::CachedWebviewAvailability();
+	return availability.customSchemeRequests
+		&& availability.customRangeRequests;
 }
 
 void RecordShowFailure() {

--- a/Telegram/SourceFiles/ui/controls/location_picker.cpp
+++ b/Telegram/SourceFiles/ui/controls/location_picker.cpp
@@ -38,6 +38,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "webview/webview_data_stream_memory.h"
 #include "webview/webview_embed.h"
 #include "webview/webview_interface.h"
+#include "core/cached_webview_availability.h"
 #include "window/themes/window_theme.h"
 #include "styles/style_chat_helpers.h"
 #include "styles/style_dialogs.h"
@@ -772,12 +773,10 @@ std::shared_ptr<Main::SessionShow> LocationPicker::uiShow() {
 }
 
 bool LocationPicker::Available(const LocationPickerConfig &config) {
-	static const auto Supported = [&] {
-		const auto availability = Webview::Availability();
-		return availability.customSchemeRequests
-			&& availability.customReferer;
-	}();
-	return Supported && !config.mapsToken.isEmpty();
+	const auto &availability = Core::CachedWebviewAvailability();
+	return availability.customSchemeRequests
+		&& availability.customReferer
+		&& !config.mapsToken.isEmpty();
 }
 
 void LocationPicker::setup(const Descriptor &descriptor) {


### PR DESCRIPTION
Iv::ShowButton() and LocationPicker::Available() each called Webview::Availability() separately (~200ms each on Linux). Replace the per-caller static caches with a single shared cache in Core::CachedWebviewAvailability(), reducing startup from two ~200ms calls to one.

Previous failed attempt at this: https://github.com/desktop-app/lib_webview/pull/136 + https://github.com/telegramdesktop/tdesktop/pull/30310