### PR TITLE
typo: Increase the `size` limit on compressed images...

### DIFF
--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -54,7 +54,7 @@ using Ui::ValidateThumbDimensions;
 base::options::toggle SendLargePhotos({
 	.id = kOptionSendLargePhotos,
 	.name = "Send large photos",
-	.description = "Increase the side limit on compressed images to 2560px.",
+	.description = "Increase the size limit on compressed images to 2560px.",
 });
 std::atomic<bool> SendLargePhotosAtomic/* = false*/;
 


### PR DESCRIPTION
A tiny typo that I've been seeing for quite a long time. Nobody probably noticed it, so here's the pr.

Just one character change. Won't be much of a thing to review.


**_Peace!_**