### PR TITLE
Add accessible name to search button in narrow layout

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -609,6 +609,7 @@ Widget::Widget(
 		setupStories();
 	}
 
+	_searchForNarrowLayout->setAccessibleName(tr::lng_dlg_filter(tr::now));
 	_searchForNarrowLayout->setClickedCallback([=] {
 		_search->setFocusFast();
 		if (_childList) {


### PR DESCRIPTION
## Summary

- The search icon button shown when the filters sidebar is active had no accessible name, making it appear as an unnamed button to screen readers.
- Sets `lng_dlg_filter` ("Search") as the accessible name for `_searchForNarrowLayout`.

## Test plan
- [x] Enable filters sidebar (create a folder)
- [x] Navigate with Tab using a screen reader — the search button should announce "Search" instead of just "button"