### PR TITLE
Fix webauthn resident passkey not being saved locally

### DIFF
--- a/Telegram/SourceFiles/platform/win/webauthn_win.cpp
+++ b/Telegram/SourceFiles/platform/win/webauthn_win.cpp
@@ -160,7 +160,7 @@ void RegisterKey(
 	|| defined(WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_7) \
 	|| defined(WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_8) \
 	|| defined(WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_9)
-	options.bPreferResidentKey = FALSE;
+	options.bPreferResidentKey = TRUE;
 #endif
 
 	auto hwnd = (HWND)(nullptr);


### PR DESCRIPTION
Upon adding a passkey, a webauthn resident key is expected to be saved on a security key

Fixes #30083
Credit: https://github.com/telegramdesktop/tdesktop/issues/30083#issuecomment-3737006489

Seems to work fine for me, albeit tg asks for 2FA anyway