### PR TITLE
Fix send-preview rename/spoiler behavior for media and document attachments before sending

### DIFF
--- a/Telegram/SourceFiles/boxes/edit_caption_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_caption_box.cpp
@@ -489,7 +489,9 @@ void EditCaptionBox::rebuildPreview() {
 			gifPaused,
 			file,
 			[=](Ui::AttachActionType type) {
-				return (type != Ui::AttachActionType::EditCover) || _isVideo;
+				return (type == Ui::AttachActionType::Rename)
+					? false
+					: (type != Ui::AttachActionType::EditCover) || _isVideo;
 			},
 			Ui::AttachControls::Type::EditOnly);
 		_isPhoto = (media && media->isPhoto());

--- a/Telegram/SourceFiles/boxes/send_files_box.cpp
+++ b/Telegram/SourceFiles/boxes/send_files_box.cpp
@@ -67,6 +67,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "styles/style_settings.h"
 #include "styles/style_menu_icons.h"
 
+#include <QtCore/QFileInfo>
 #include <QtCore/QMimeData>
 
 namespace {
@@ -460,6 +461,19 @@ rpl::producer<int> SendFilesBox::Block::itemModifyRequest() const {
 	}
 }
 
+rpl::producer<int> SendFilesBox::Block::itemRenameRequest() const {
+	using namespace rpl::mappers;
+
+	if (_isAlbum) {
+		const auto album = static_cast<Ui::AlbumPreview*>(_preview.get());
+		return album->thumbRenameRequested() | rpl::map(_1 + _from);
+	} else if (_isSingleMedia) {
+		const auto media = static_cast<Ui::SingleMediaPreview*>(_preview.get());
+		return media->renameRequests() | rpl::map_to(_from);
+	}
+	return rpl::never<int>();
+}
+
 rpl::producer<int> SendFilesBox::Block::itemEditCoverRequest() const {
 	using namespace rpl::mappers;
 
@@ -588,6 +602,10 @@ bool SendFilesBox::Block::setSingleFileDisplayName(
 	const auto single = static_cast<Ui::SingleFilePreview*>(_preview.get());
 	single->setDisplayName(displayName);
 	return true;
+}
+
+bool SendFilesBox::Block::handlesRenameByContextMenu() const {
+	return !_isAlbum && !_isSingleMedia;
 }
 
 bool SendFilesBox::Block::setSingleFileCaption(
@@ -1217,12 +1235,17 @@ void SendFilesBox::pushBlock(int from, int till) {
 		[=](const Ui::PreparedFile &file, Ui::AttachActionType type) {
 			return (type == Ui::AttachActionType::ToggleSpoiler)
 				? !hasPrice()
+				: (type == Ui::AttachActionType::Rename)
+				? (file.isVideoFile() || !_sendWay.current().sendImagesAsPhotos())
 				: (type == Ui::AttachActionType::EditCover)
-				? (file.isVideoFile()
+				? (_sendWay.current().sendImagesAsPhotos()
+					&& file.isVideoFile()
 					&& (_toPeer->isBroadcast() || _toPeer->isSelf()))
-				: (file.videoCover != nullptr);
+				: (_sendWay.current().sendImagesAsPhotos()
+					&& file.videoCover != nullptr);
 		});
 	auto &block = _blocks.back();
+	const auto handlesRenameByContextMenu = block.handlesRenameByContextMenu();
 	const auto widget = _inner->add(
 		block.takeWidget(),
 		QMargins(0, _inner->count() ? st::sendMediaRowSkip : 0, 0, 0));
@@ -1336,6 +1359,20 @@ void SendFilesBox::pushBlock(int from, int till) {
 	}, widget->lifetime());
 
 	const auto openedOnce = widget->lifetime().make_state<bool>(false);
+	block.itemRenameRequest(
+	) | rpl::on_next([=](int index) {
+		applyBlockChanges();
+
+		auto &file = _list.files[index];
+		_show->show(Box(RenameFileBox, file.displayName, [=](QString newName) {
+			const auto displayName = std::move(newName);
+			_list.files[index].displayName = displayName;
+			if (!setDisplayNameInSingleFilePreview(index, displayName)) {
+				refreshAllAfterChanges(from);
+			}
+		}));
+	}, widget->lifetime());
+
 	block.itemModifyRequest(
 	) | rpl::on_next([=, show = _show](int index) {
 		applyBlockChanges();
@@ -1440,7 +1477,9 @@ void SendFilesBox::pushBlock(int from, int till) {
 			not_null<QEvent*> e) {
 		if (e->type() == QEvent::ContextMenu) {
 			const auto mouse = static_cast<QContextMenuEvent*>(e.get());
-			if (from >= till || from >= _list.files.size()) {
+			if (!handlesRenameByContextMenu
+				|| from >= till
+				|| from >= _list.files.size()) {
 				return base::EventFilterResult::Continue;
 			}
 			auto fileIndex = from;

--- a/Telegram/SourceFiles/boxes/send_files_box.h
+++ b/Telegram/SourceFiles/boxes/send_files_box.h
@@ -171,6 +171,7 @@ private:
 		[[nodiscard]] rpl::producer<int> itemDeleteRequest() const;
 		[[nodiscard]] rpl::producer<int> itemReplaceRequest() const;
 		[[nodiscard]] rpl::producer<int> itemModifyRequest() const;
+		[[nodiscard]] rpl::producer<int> itemRenameRequest() const;
 		[[nodiscard]] rpl::producer<int> itemEditCoverRequest() const;
 		[[nodiscard]] rpl::producer<int> itemClearCoverRequest() const;
 		[[nodiscard]] rpl::producer<> orderUpdated() const;
@@ -182,6 +183,7 @@ private:
 		[[nodiscard]] QImage generatePriceTagBackground() const;
 		[[nodiscard]] bool setSingleFileDisplayName(
 			const QString &displayName);
+		[[nodiscard]] bool handlesRenameByContextMenu() const;
 		[[nodiscard]] bool setSingleFileCaption(
 			int index,
 			const TextWithTags &caption);

--- a/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.cpp
@@ -65,6 +65,10 @@ rpl::producer<> AbstractSingleMediaPreview::clearCoverRequests() const {
 	return _clearCoverRequests.events();
 }
 
+rpl::producer<> AbstractSingleMediaPreview::renameRequests() const {
+	return _renameRequests.events();
+}
+
 void AbstractSingleMediaPreview::setSendWay(SendFilesWay way) {
 	_sendWay = way;
 	update();
@@ -286,6 +290,11 @@ void AbstractSingleMediaPreview::showContextMenu(QPoint position) {
 		_st.tabbed.menu);
 
 	const auto &icons = _st.tabbed.icons;
+	if (_actionAllowed(AttachActionType::Rename)) {
+		_menu->addAction(tr::lng_rename_file(tr::now), [=] {
+			_renameRequests.fire({});
+		}, &st::menuIconEdit);
+	}
 	if (_actionAllowed(AttachActionType::ToggleSpoiler)
 		&& _sendWay.sendImagesAsPhotos()
 		&& supportsSpoilers()) {

--- a/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.h
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.h
@@ -38,6 +38,7 @@ public:
 	[[nodiscard]] rpl::producer<> modifyRequests() const override;
 	[[nodiscard]] rpl::producer<> editCoverRequests() const override;
 	[[nodiscard]] rpl::producer<> clearCoverRequests() const override;
+	[[nodiscard]] rpl::producer<> renameRequests() const;
 
 	[[nodiscard]] bool isPhoto() const;
 
@@ -91,6 +92,7 @@ private:
 	const int _minThumbH;
 	const base::unique_qptr<AttachControlsWidget> _controls;
 	rpl::event_stream<> _photoEditorRequests;
+	rpl::event_stream<> _renameRequests;
 	rpl::event_stream<> _editCoverRequests;
 	rpl::event_stream<> _clearCoverRequests;
 

--- a/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.cpp
@@ -623,6 +623,11 @@ void AlbumPreview::showContextMenu(
 		st::popupMenuWithIcons);
 
 	const auto index = orderIndex(thumb);
+	if (_actionAllowed(index, AttachActionType::Rename)) {
+		_menu->addAction(tr::lng_rename_file(tr::now), [=] {
+			_thumbRenameRequested.fire_copy(index);
+		}, &st::menuIconEdit);
+	}
 	if (_actionAllowed(index, AttachActionType::ToggleSpoiler)
 		&& _sendWay.sendImagesAsPhotos()) {
 		const auto spoilered = thumb->hasSpoiler();

--- a/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.h
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.h
@@ -52,6 +52,9 @@ public:
 	[[nodiscard]] rpl::producer<int> thumbModified() const {
 		return _thumbModified.events();
 	}
+	[[nodiscard]] rpl::producer<int> thumbRenameRequested() const {
+		return _thumbRenameRequested.events();
+	}
 	[[nodiscard]] rpl::producer<int> thumbEditCoverRequested() const {
 		return _thumbEditCoverRequested.events();
 	}
@@ -132,6 +135,7 @@ private:
 	rpl::event_stream<int> _thumbDeleted;
 	rpl::event_stream<int> _thumbChanged;
 	rpl::event_stream<int> _thumbModified;
+	rpl::event_stream<int> _thumbRenameRequested;
 	rpl::event_stream<int> _thumbEditCoverRequested;
 	rpl::event_stream<int> _thumbClearCoverRequested;
 	rpl::event_stream<> _orderUpdated;

--- a/Telegram/SourceFiles/ui/chat/attach/attach_item_single_media_preview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_item_single_media_preview.cpp
@@ -37,7 +37,9 @@ ItemSingleMediaPreview::ItemSingleMediaPreview(
 	not_null<HistoryItem*> item,
 	AttachControls::Type type)
 : AbstractSingleMediaPreview(parent, st, type, [=](AttachActionType type) {
-	if (type == AttachActionType::EditCover) {
+	if (type == AttachActionType::Rename) {
+		return false;
+	} else if (type == AttachActionType::EditCover) {
 		return _isVideoFile;
 	}
 	return true;

--- a/Telegram/SourceFiles/ui/chat/attach/attach_send_files_way.h
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_send_files_way.h
@@ -13,6 +13,7 @@ namespace Ui {
 
 enum class AttachActionType {
 	ToggleSpoiler,
+	Rename,
 	EditCover,
 	ClearCover,
 };


### PR DESCRIPTION
This commit fixes the send-preview rename/spoiler behavior for media and document attachments before sending.

### What was fixed

* Fixed the overlap issue (https://github.com/telegramdesktop/tdesktop/issues/30375): for media previews, actions now appear in a proper menu flow (instead of conflicting behavior);
* For **videos in media mode** (not “send as document”), the menu now supports both: **Rename file** and **Hide with Spoiler**;
* For **photos in media mode**, rename is not shown (as intended, because photos do not have a displayed name and are simply saved as "download_date.jpg".);
* For **photos/videos in document mode**, rename is available and works for both single items and albums;
* Improved default filename logic when source has no normal path/name (for example clipboard images), so rename dialog starts with a sensible name and keeps extension behavior.