### PR TITLE
Do not exit fullscreen mode when applying video quality

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -4817,11 +4817,14 @@ void OverlayWidget::applyVideoQuality(VideoQuality value) {
 	}
 	_streamingStartPaused = _streamedQualityChangeFinished
 		|| (_streamed && _streamed->instance.player().paused());
+	const auto wasFullScreen = _fullScreenVideo;
 	clearStreaming();
 	const auto time = _streamedPosition;
 	const auto startStreaming = StartStreaming(false, time);
 	if (!canInitStreaming() || !initStreaming(startStreaming)) {
 		redisplayContent();
+	} else {
+		_fullScreenVideo = wasFullScreen;
 	}
 }
 


### PR DESCRIPTION
Fixes a bug where the video player exits the fullscreen mode upon changing the video quality.

`applyVideoQuality()` calls `clearStreaming()` which sets `_fullScreenVideo = false` every time it's invoked

Steps to reproduce:
1) Open pretty much any video, i.e. https://t.me/ClashReport/73603
2) Go fullscreen
3) Try changing video quality
Immediate result: video stays "fullscreen", black borders disappear, now another double click is required to get back to the fullscreen mode.