### PR TITLE
building-win: update .sln => .slnx

### DIFF
--- a/docs/building-win.md
+++ b/docs/building-win.md
@@ -58,7 +58,7 @@ For `win64` (64-bit):
 
     configure.bat x64 -D TDESKTOP_API_ID=YOUR_API_ID -D TDESKTOP_API_HASH=YOUR_API_HASH
 
-* Open ***BuildPath*\\tdesktop\\out\\Telegram.sln** in Visual Studio 2026
+* Open ***BuildPath*\\tdesktop\\out\\Telegram.slnx** in Visual Studio 2026
 * Select Telegram project and press Build > Build Telegram (Debug and Release configurations)
 * The result Telegram.exe will be located in **D:\TBuild\tdesktop\out\Debug** (and **Release**)
 


### PR DESCRIPTION
VS 2026 generates `.slnx` solution files, not `.sln`