### PR TITLE
Disable 32-bit Qt 6 Windows action builds

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -54,6 +54,8 @@ jobs:
         exclude:
           - arch: arm64
             qt: ""
+          - arch: x64_x86
+            qt: qt6
 
     env:
       UPLOAD_ARTIFACT: "true"


### PR DESCRIPTION
They don't build anymore