### PR TITLE
Fix duplicate subtitle widget in group call panel

### DIFF
--- a/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
+++ b/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
@@ -2792,6 +2792,9 @@ void Panel::refreshTitle() {
 	}
 	refreshTitleGeometry();
 	if (!_subtitle && mode() == PanelMode::Default) {
+		if (!_members) {
+			setupMembers();
+		}
 		_subtitle.create(
 			widget(),
 			rpl::single(


### PR DESCRIPTION
The `_subtitle.create()` rpl chain calls `setupMembers()` synchronously during the FlatLabel constructor. `setupMembers()` triggers geometry updates that re-enter `refreshTitle()` while `object_ptr::create()` has not yet assigned the new widget to `_subtitle`, so a second subtitle is created and left as an orphaned visible child.

Moving `setupMembers()` before `_subtitle.create()` ensures `_members` exists before the rpl chain fires, preventing the re-entrancy.