### PR TITLE
Fix: Prevent top bar action buttons from receiving focus after selection is cancelled

### DIFF
--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
@@ -1181,10 +1181,12 @@ void TopBarWidget::updateControlsVisibility() {
 		hideChildren();
 		return;
 	}
-	_clear->show();
-	_delete->setVisible(_canDelete);
-	_forward->setVisible(_canForward);
-	_sendNow->setVisible(_canSendNow);
+	const auto visible = showSelectedState() || _selectedShown.animating();
+	_clear->setVisible(visible);
+	_delete->setVisible(_canDelete && visible);
+	_forward->setVisible(_canForward && visible);
+	_sendNow->setVisible(_canSendNow && visible);
+
 
 	const auto isOneColumn = _controller->adaptive().isOneColumn();
 	const auto backVisible = !rootChatsListBar()
@@ -1591,6 +1593,9 @@ bool TopBarWidget::showSelectedActions() const {
 }
 
 void TopBarWidget::slideAnimationCallback() {
+	if (!_selectedShown.animating() && !_searchShown.animating()) {
+		updateControlsVisibility();
+	}
 	updateControlsGeometry();
 	update();
 }


### PR DESCRIPTION
Description: This PR fixes an accessibility bug where the top bar action buttons (Delete, Forward, Clear, Send Now) could still receive screen reader and keyboard focus even after the user cancelled their message selection.

Cause: Previously, when the user cleared a selection, `history_view_top_bar_widget.cpp`
 would animate the action buttons sliding off-screen smoothly. As a result, the buttons remained "visible" (but positioned off screen), allowing accessibility tools to continue traversing and focusing them.

Changes: Modified `toggleSelectedControls(bool shown)` to explicitly check if the sliding animation has finished `(!_selectedShown.animating())`.When the deselect animation ends, we trigger `updateControlsVisibility()`, fully removing them from the widget tree's accessibility footprint.