### PR TITLE
RMB gear to toggle video speedup

### DIFF
--- a/Telegram/SourceFiles/media/media_common.h
+++ b/Telegram/SourceFiles/media/media_common.h
@@ -39,6 +39,7 @@ struct VideoQuality {
 
 inline constexpr auto kSpeedMin = 0.5;
 inline constexpr auto kSpeedMax = 2.5;
+inline constexpr auto kSpeedDefault = 1.0;
 inline constexpr auto kSpedUpDefault = 1.7;
 
 [[nodiscard]] inline bool EqualSpeeds(float64 a, float64 b) {

--- a/Telegram/SourceFiles/media/player/media_player_dropdown.cpp
+++ b/Telegram/SourceFiles/media/player/media_player_dropdown.cpp
@@ -779,6 +779,10 @@ void SpeedController::toggleDefault() {
 	_speedChanged.fire(speed());
 }
 
+void SpeedController::updateSpeedFromOutside(float64 newSpeed) {
+	setSpeed(newSpeed);
+}
+
 void SpeedController::setSpeed(float64 newSpeed) {
 	if (!(_isDefault = EqualSpeeds(newSpeed, 1.))) {
 		_speed = newSpeed;

--- a/Telegram/SourceFiles/media/player/media_player_dropdown.h
+++ b/Telegram/SourceFiles/media/player/media_player_dropdown.h
@@ -139,6 +139,8 @@ public:
 
 	[[nodiscard]] rpl::producer<> saved() const;
 	[[nodiscard]] rpl::producer<float64> realtimeValue() const;
+	void updateSpeedFromOutside(float64 newSpeed);
+	void toggleDefault();
 
 private:
 	void fillMenu(not_null<Ui::DropdownMenu*> menu) override;
@@ -146,7 +148,6 @@ private:
 	[[nodiscard]] float64 speed() const;
 	[[nodiscard]] bool isDefault() const;
 	[[nodiscard]] float64 lastNonDefaultSpeed() const;
-	void toggleDefault();
 	void setSpeed(float64 newSpeed);
 	void setQuality(VideoQuality quality);
 	void save();

--- a/Telegram/SourceFiles/media/view/media_view_playback_controls.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_playback_controls.cpp
@@ -75,10 +75,32 @@ PlaybackControls::PlaybackControls(
 		: 1.);
 	updateSpeedToggleQuality();
 
+	if (_speedToggle) {
+		_speedToggle->setAcceptBoth(true);
+		_speedToggle->setContextMenuPolicy(Qt::PreventContextMenu);
+		_speedToggle->clicks(
+		) | rpl::filter([](Qt::MouseButton button) {
+			return button == Qt::RightButton;
+		}) | rpl::on_next([=] {
+			if (_speedController) {
+				_speedController->toggleDefault();
+			} else {
+				updatePlaybackSpeed(Media::kSpeedDefault);
+			}
+		}, _speedToggle->lifetime());
+	}
+
 	if (const auto controller = _speedController.get()) {
 		controller->menuToggledValue(
 		) | rpl::on_next([=](bool toggled) {
 			_speedToggle->setActive(toggled);
+		}, _speedToggle->lifetime());
+
+		controller->realtimeValue(
+		) | rpl::on_next([=](float64 speed) {
+			_speedToggle->setSpeed(speed);
+			_delegate->playbackControlsSpeedChanged(speed);
+			resizeEvent(nullptr);
 		}, _speedToggle->lifetime());
 	}
 
@@ -229,6 +251,12 @@ void PlaybackControls::updateSpeedToggleQuality() {
 
 void PlaybackControls::updatePlaybackSpeed(float64 speed) {
 	DEBUG_LOG(("Media playback speed: update to %1.").arg(speed));
+	if (_speedToggle) {
+		_speedToggle->setSpeed(speed);
+	}
+	if (_speedController) {
+		_speedController->updateSpeedFromOutside(speed);
+	}
 	_delegate->playbackControlsSpeedChanged(speed);
 	resizeEvent(nullptr);
 }

--- a/Telegram/SourceFiles/media/view/media_view_playback_controls.h
+++ b/Telegram/SourceFiles/media/view/media_view_playback_controls.h
@@ -64,6 +64,7 @@ public:
 	void updatePlayback(const Player::TrackState &state);
 	void setLoadingProgress(int64 ready, int64 total);
 	void setInFullScreen(bool inFullScreen);
+	void updatePlaybackSpeed(float64 speed);
 	[[nodiscard]] bool hasMenu() const;
 	[[nodiscard]] bool dragging() const;
 
@@ -84,7 +85,6 @@ private:
 	[[nodiscard]] float64 countDownloadedTillPercent(
 		const Player::TrackState &state) const;
 
-	void updatePlaybackSpeed(float64 speed);
 	void updateVolumeToggleIcon();
 	void updateDownloadProgressPosition();
 


### PR DESCRIPTION
Clicking (LMB) the "gear" button used to toggle between normal speed (1x) and the last used custom speed (`kSpedUpDefault` by default). Apparently this was removed when the quality gear button was introduced. LMB now just opens/closes the dropdown quality/speed menu.

https://github.com/user-attachments/assets/68f2cd18-937a-4e70-8dc6-66963ddb82b6

Changing the speed via the slider (when the menu is filled with quality options) is a pain the ass.
We can restrore this functionality by using RMB to toggle between normal speed (1.0x) and the last used custom speed.


https://github.com/user-attachments/assets/1d4ac3a1-1268-46c2-b96e-6d6f4611c319

