### PR TITLE
Fix back-stack behavior for forum/topic navigation from chat search

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -906,7 +906,7 @@ void Widget::chosenRow(const ChosenRow &row) {
 			controller()->showThread(
 				topicJump,
 				ShowAtUnreadMsgId,
-				Window::SectionShow::Way::ClearStack);
+				Window::SectionShow::Way::Forward);
 		}
 		return;
 	} else if (sublistJump) {
@@ -920,8 +920,7 @@ void Widget::chosenRow(const ChosenRow &row) {
 		}
 		return;
 	} else if (const auto topic = row.key.topic()) {
-		auto params = Window::SectionShow(
-			Window::SectionShow::Way::ClearStack);
+		auto params = Window::SectionShow(Window::SectionShow::Way::Forward);
 		params.highlight = Window::SearchHighlightId(_searchState.query);
 		if (row.newWindow) {
 			controller()->showInNewWindow(
@@ -956,13 +955,13 @@ void Widget::chosenRow(const ChosenRow &row) {
 			controller()->showForum(
 				forum,
 				Window::SectionShow(
-					Window::SectionShow::Way::ClearStack).withChildColumn());
+					Window::SectionShow::Way::Forward).withChildColumn());
 			if (controller()->shownForum().current() == forum
 				&& forum->peer()->viewForumAsMessages()) {
 				controller()->showThread(
 					history,
 					ShowAtUnreadMsgId,
-					Window::SectionShow::Way::ClearStack);
+					Window::SectionShow::Way::Forward);
 			}
 		}
 		return;
@@ -3422,7 +3421,9 @@ void Widget::showForum(
 		changeOpenedForum(forum, params.animated);
 		return;
 	}
-	cancelSearch({ .forceFullCancel = true });
+	if (_searchState.query.isEmpty()) {
+		cancelSearch({ .forceFullCancel = true });
+	}
 	openChildList(forum, params);
 }
 


### PR DESCRIPTION
Updated forum/topic navigation from search results to use forward navigation instead of stack reset in relevant paths (`showThread` / `SectionShow` / `showForum`), so Back can return step-by-step instead of dropping to the root dialogs state. 

Changed `showForum(...)` behavior to avoid unconditional full search cancel: `cancelSearch({ .forceFullCancel = true })` is now called only when the search query is empty, preserving active search context while opening forum child lists. 