### PR TITLE
Fix startchannel/startgroup deeplinks not working for bots with Threaded Mode enabled.

### DIFF
--- a/Telegram/SourceFiles/window/window_session_controller.cpp
+++ b/Telegram/SourceFiles/window/window_session_controller.cpp
@@ -675,22 +675,6 @@ void SessionNavigation::showPeerByLinkResolved(
 		showPeerInfo(peer, params);
 	} else if (resolveType == ResolveType::HashtagSearch) {
 		searchMessages(info.text, peer->owner().history(peer));
-	} else if (peer->isForum() && resolveType != ResolveType::Boost) {
-		if (!msgId || !useRequestedMessageId) {
-			applyBotStartToken();
-			parentController()->showForum(peer->forum(), params, msgId);
-		} else if (const auto item = peer->owner().message(peer, msgId)) {
-			showMessageByLinkResolved(item, info);
-		} else {
-			const auto callback = crl::guard(this, [=] {
-				if (const auto item = peer->owner().message(peer, msgId)) {
-					showMessageByLinkResolved(item, info);
-				} else {
-					showPeerHistory(peer, params, msgId);
-				}
-			});
-			peer->session().api().requestMessageData(peer, msgId, callback);
-		}
 	} else if (info.storyParam == u"live"_q) {
 		parentController()->openPeerStories(peer->id, std::nullopt, true);
 	} else if (const auto storyId = info.storyParam.toInt()) {
@@ -754,6 +738,24 @@ void SessionNavigation::showPeerByLinkResolved(
 			scope,
 			info.startToken,
 			info.startAdminRights);
+	} else if (resolveType == ResolveType::Boost && peer->isChannel()) {
+		resolveBoostState(peer->asChannel());
+	} else if (peer->isForum()) {
+		if (!msgId || !useRequestedMessageId) {
+			applyBotStartToken();
+			parentController()->showForum(peer->forum(), params, msgId);
+		} else if (const auto item = peer->owner().message(peer, msgId)) {
+			showMessageByLinkResolved(item, info);
+		} else {
+			const auto callback = crl::guard(this, [=] {
+				if (const auto item = peer->owner().message(peer, msgId)) {
+					showMessageByLinkResolved(item, info);
+				} else {
+					showPeerHistory(peer, params, msgId);
+				}
+			});
+			peer->session().api().requestMessageData(peer, msgId, callback);
+		}
 	} else if (resolveType == ResolveType::Mention) {
 		if (bot || peer->isChannel()) {
 			crl::on_main(this, [=] {
@@ -762,8 +764,6 @@ void SessionNavigation::showPeerByLinkResolved(
 		} else {
 			showPeerInfo(peer, params);
 		}
-	} else if (resolveType == ResolveType::Boost && peer->isChannel()) {
-		resolveBoostState(peer->asChannel());
 	} else if (resolveType == ResolveType::ChannelDirect
 		&& !peer->isFullLoaded()) {
 		_waitingDirectChannel = peer;


### PR DESCRIPTION
When a bot has Threaded Mode (forum) enabled, the isForum() check in showPeerByLinkResolved() intercepts the flow before reaching the AddToGroup/AddToChannel handler, causing the app to open the bot's chat instead of showing the "add bot to channel/group" popup.

### Problem

When opening a ?startchannel (or ?startgroup) deeplink for a bot that has Threaded Mode (forum topics) enabled, the app opens the bot's chat instead of showing the "Add bot to channel/group" popup.

### Steps to reproduce:
1. Find a bot with Threaded Mode enabled (set via BotFather)
2. Open t.me/botusername?startchannel
3. Expected: "Choose a channel" popup appears
4. Actual: Bot's chat (forum view) opens instead

### Cause

In showPeerByLinkResolved(), the peer->isForum() branch (line 678) is evaluated before the AddToGroup/AddToChannel branch (line 741). For bots with Threaded Mode, isForum() returns true, so the forum branch intercepts the flow and the   add-to-channel popup is never reached.

The Boost resolve type was already excluded from this check, but AddToGroup and AddToChannel were not.

### Fix

Add AddToGroup and AddToChannel to the exclusion list alongside Boost, so these deeplinks correctly fall through to AddBotToGroupBoxController::Start().