### PR TITLE
Fix Saved Messages name in folder add/remove toast

### DIFF
--- a/Telegram/SourceFiles/boxes/choose_filter_box.cpp
+++ b/Telegram/SourceFiles/boxes/choose_filter_box.cpp
@@ -171,7 +171,9 @@ void ChangeFilterById(
 			MTP_flags(MTPmessages_UpdateDialogFilter::Flag::f_filter),
 			MTP_int(filter.id()),
 			filter.tl()
-		)).done([=, chat = history->peer->name(), name = filter.title()] {
+		)).done([=, chat = (history->peer->isSelf()
+				? tr::lng_saved_messages(tr::now)
+				: history->peer->name()), name = filter.title()] {
 			const auto account = not_null(&history->session().account());
 			if (const auto controller = Core::App().windowFor(account)) {
 				const auto isStatic = name.isStatic;


### PR DESCRIPTION
When adding or removing "Saved Messages" from a chat folder, the toast shows the user's real name instead of "Saved Messages."

The `ChangeFilterById` callback in `choose_filter_box.cpp:174` captures `history->peer->name()` without checking `isSelf()`. This fix adds the same `isSelf()` guard used in `main_window.cpp:808-810`:

```cpp
// Before:
chat = history->peer->name()

// After:
chat = (history->peer->isSelf()
    ? tr::lng_saved_messages(tr::now)
    : history->peer->name())
```

Fixes #30383

This contribution was developed with AI assistance (Claude Code).