### PR TITLE
Fix personal photo hint shown when setting group/channel photo

### DIFF
--- a/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
@@ -1136,13 +1136,17 @@ void TopBar::setupUserpicButton(
 			: _peer->name();
 		const auto phrase = (type == ChosenType::Suggest)
 			? &tr::lng_profile_suggest_sure
-			: &tr::lng_profile_set_personal_sure;
+			: (user && !user->isSelf())
+			? &tr::lng_profile_set_personal_sure
+			: nullptr;
 		return Editor::EditorData{
-			.about = (*phrase)(
-				tr::now,
-				lt_user,
-				tr::bold(name),
-				tr::marked),
+			.about = (phrase
+				? (*phrase)(
+					tr::now,
+					lt_user,
+					tr::bold(name),
+					tr::marked)
+				: TextWithEntities()),
 			.confirm = ((type == ChosenType::Suggest)
 				? tr::lng_profile_suggest_button(tr::now)
 				: tr::lng_profile_set_photo_button(tr::now)),

--- a/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
@@ -1136,7 +1136,7 @@ void TopBar::setupUserpicButton(
 			: _peer->name();
 		const auto phrase = (type == ChosenType::Suggest)
 			? &tr::lng_profile_suggest_sure
-			: (user && !user->isSelf())
+			: (user && !user->isSelf() && !_peer->isBot())
 			? &tr::lng_profile_set_personal_sure
 			: nullptr;
 		return Editor::EditorData{


### PR DESCRIPTION
Fixes #30467

When you set a photo for a group or channel, a hint saying 
"Only you will see this photo..." was shown — which makes no 
sense for groups or channels, only for personal user photos.

The issue is in `editorData` lambda inside `setupUserpicButton` 
in `info_profile_top_bar.cpp`, where the hint phrase was always 
used unconditionally. Fixed by adding a null-check on the peer 
type, so the hint is only shown for non-self users — same as the 
existing logic in `userpic_button.cpp`.

**Before:** when setting a photo for a group or channel, the editor 
showed a hint intended only for personal user photos ("Only you will 
see this photo and it will replace any photo...").

**After:**
<img width="816" height="411" alt="image" src="https://github.com/user-attachments/assets/f447c24f-8113-424d-949b-eaea884bfbbd" />
