### PR TITLE
Fix cursor staying hidden after closing media viewer on macOS

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -5919,9 +5919,7 @@ void OverlayWidget::handleKeyPress(not_null<QKeyEvent*> e) {
 			handleDocumentClick();
 		}
 	} else if (key == Qt::Key_Left) {
-		if (_controlsHideTimer.isActive()) {
-			activateControls();
-		}
+		activateControls();
 		moveToNext(-1);
 	} else if (key == Qt::Key_H && !_stories) {
 		if (_flip & Qt::Horizontal) {
@@ -5944,9 +5942,7 @@ void OverlayWidget::handleKeyPress(not_null<QKeyEvent*> e) {
 			redisplayContent();
 		}
 	} else if (key == Qt::Key_Right) {
-		if (_controlsHideTimer.isActive()) {
-			activateControls();
-		}
+		activateControls();
 		if (!moveToNext(1) && _stories) {
 			storiesClose();
 		}
@@ -7051,6 +7047,7 @@ void OverlayWidget::clearBeforeHide() {
 	_controlsState = ControlsShown;
 	_controlsOpacity = anim::value(1);
 	_helper->setControlsOpacity(1.);
+	setCursor(style::cur_default);
 	_groupThumbs = nullptr;
 	_groupThumbsRect = QRect();
 	_sponsoredButton = nullptr;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -2586,6 +2586,7 @@ void OverlayWidget::activateControls() {
 	}
 	if (_controlsState == ControlsHiding || _controlsState == ControlsHidden) {
 		_controlsState = ControlsShowing;
+		updateCursor();
 		_controlsAnimStarted = crl::now();
 		_controlsOpacity.start(1);
 		if (!_stateAnimation.animating()) {
@@ -5078,6 +5079,7 @@ void OverlayWidget::playbackToggleFullScreen() {
 		_streamed->controls->setInFullScreen(_fullScreenVideo);
 	}
 	_touchbarFullscreenToggled.fire_copy(_fullScreenVideo);
+	activateControls();
 	updateControls();
 	update();
 }


### PR DESCRIPTION
Fixes #30490

## Root cause

When video playback controls auto-hide in the media viewer, the overlay widget's cursor is set to `Qt::BlankCursor`. On macOS this calls `[NSCursor hide]`, which increments a global hide counter.

If the user then navigates to another item using the arrow keys without moving the mouse, the cursor is never restored before closing:

- The arrow key handler only called `activateControls()` if the controls hide timer was still active — but once controls have fully hidden, the timer has already fired, so `activateControls()` was skipped entirely.
- Closing the viewer called `clearBeforeHide()`, which reset `_controlsState` but never reset the widget cursor — so the window was hidden while `Qt::BlankCursor` was still active.
- This left `[NSCursor hide]` unbalanced at the application level. The cursor remains invisible for the entire session: switching to another app temporarily restores it, but switching back to Telegram Desktop hides it again. Only quitting resolves it.

## Fix

Three changes in `media_view_overlay_widget.cpp`:

1. **Arrow key navigation always calls `activateControls()`** — removed the `_controlsHideTimer.isActive()` guard so controls and cursor are always restored when navigating.
2. **`activateControls()` calls `updateCursor()` immediately** — cursor is restored at once when transitioning to `ControlsShowing`, not only after the animation completes.
3. **`clearBeforeHide()` resets the cursor** — added `setCursor(style::cur_default)` before the window hides, ensuring `[NSCursor hide]`/`[NSCursor unhide]` is always balanced.

---

> This fix was developed with the assistance of GitHub Copilot (AI).
