### PR TITLE
Show full title tooltip when chat name is truncated

### DIFF
--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
@@ -801,6 +801,57 @@ void TopBarWidget::mousePressEvent(QMouseEvent *e) {
 	}
 }
 
+bool TopBarWidget::event(QEvent *e) {
+	if (e->type() == QEvent::ToolTip) {
+		const auto pos = static_cast<QHelpEvent*>(e)->pos();
+		const auto nametop = st::topBarArrowPadding.top();
+		const auto nameheight = st::msgNameStyle.font->height;
+		const auto nameleft = _leftTaken;
+		const auto namewidth = width()
+			- _rightTaken
+			- nameleft
+			- st::topBarNameRightPadding;
+		const auto nameRect = QRect(
+			nameleft,
+			nametop,
+			namewidth,
+			nameheight);
+		_tooltipText = QString();
+		if (nameRect.contains(pos)) {
+			const auto topic = _activeChat.key.topic();
+			if (topic
+				&& _activeChat.section == Section::Replies) {
+				const auto &topicName = topic->chatListNameText();
+				if (topicName.maxWidth() > namewidth) {
+					_tooltipText = topicName.toString();
+				}
+			} else if (!_title.isEmpty()
+				&& _title.maxWidth() > namewidth) {
+				_tooltipText = _title.toString();
+			}
+		}
+		if (_tooltipText.isEmpty()) {
+			Ui::Tooltip::Hide();
+		} else {
+			Ui::Tooltip::Show(0, this);
+		}
+		return true;
+	}
+	return RpWidget::event(e);
+}
+
+QString TopBarWidget::tooltipText() const {
+	return _tooltipText;
+}
+
+QPoint TopBarWidget::tooltipPos() const {
+	return QCursor::pos();
+}
+
+bool TopBarWidget::tooltipWindowActive() const {
+	return Ui::AppInFocus() && Ui::InFocusChain(window());
+}
+
 void TopBarWidget::infoClicked() {
 	const auto key = _activeChat.key;
 	if (!key) {

--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.h
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "ui/rp_widget.h"
 #include "ui/unread_badge.h"
+#include "ui/widgets/tooltip.h"
 #include "ui/effects/animations.h"
 #include "base/timer.h"
 #include "base/object_ptr.h"
@@ -46,7 +47,9 @@ class SendActionPainter;
 
 [[nodiscard]] QString SwitchToChooseFromQuery();
 
-class TopBarWidget final : public Ui::RpWidget {
+class TopBarWidget final
+	: public Ui::RpWidget
+	, private Ui::AbstractTooltipShower {
 public:
 	struct SelectedState {
 		bool textSelected = false;
@@ -129,6 +132,7 @@ protected:
 	void paintEvent(QPaintEvent *e) override;
 	void mousePressEvent(QMouseEvent *e) override;
 	void resizeEvent(QResizeEvent *e) override;
+	bool event(QEvent *e) override;
 	bool eventFilter(QObject *obj, QEvent *e) override;
 
 	int resizeGetHeight(int newWidth) override;
@@ -184,6 +188,10 @@ private:
 	void updateOnlineDisplay();
 	void updateOnlineDisplayTimer();
 	void updateOnlineDisplayIn(crl::time timeout);
+
+	QString tooltipText() const override;
+	QPoint tooltipPos() const override;
+	bool tooltipWindowActive() const override;
 
 	void infoClicked();
 	void backClicked();
@@ -265,6 +273,8 @@ private:
 	rpl::event_stream<> _cancelChooseForReport;
 
 	rpl::lifetime _backLifetime;
+
+	QString _tooltipText;
 
 };
 


### PR DESCRIPTION
## Problem

When a chat title is too long, it gets truncated with ellipsis in the top bar. There is no way to view the full name without resizing the window — and even that doesn't always help.

## Solution

Added `QEvent::ToolTip` handling in `TopBarWidget`. When hovering over the title area, a tooltip with the full chat name is shown **only if the text is actually truncated** (`maxWidth() > availableWidth`).

Works for both regular chats and forum topics.

## Changes

- `history_view_top_bar_widget.h` — added `bool event(QEvent *e) override`
- `history_view_top_bar_widget.cpp` — tooltip logic in `event()`, added `<QtWidgets/QToolTip>` include

Fixes #1502