### PR TITLE
Fix startchannel deeplink admin rights: add stories support and fallback to bot defaults selected in BotFather

### DIFF
--- a/Telegram/SourceFiles/boxes/peers/add_bot_to_chat_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/add_bot_to_chat_box.cpp
@@ -217,7 +217,7 @@ void AddBotToGroupBoxController::addBotToGroup(not_null<PeerData*> chat) {
 		controller->hideLayer();
 		controller->showPeerHistory(chat, Way::ClearStack, ShowAtUnreadMsgId);
 	};
-	const auto rights = requestedAddAdmin
+	const auto rights = (requestedAddAdmin && _requestedRights != 0)
 		? _requestedRights
 		: (chat->isBroadcast()
 			&& chat->asBroadcast()->canAddAdmins())

--- a/Telegram/SourceFiles/core/local_url_handlers.cpp
+++ b/Telegram/SourceFiles/core/local_url_handlers.cpp
@@ -460,7 +460,9 @@ bool ShowWallPaper(
 		const QString &value) {
 	auto result = ChatAdminRights();
 	for (const auto &element : value.split(QRegularExpression(u"[+ ]"_q))) {
-		if (element == u"change_info"_q) {
+		if (element.isEmpty()) {
+			continue;
+		} else if (element == u"change_info"_q) {
 			result |= ChatAdminRight::ChangeInfo;
 		} else if (element == u"post_messages"_q) {
 			result |= ChatAdminRight::PostMessages;
@@ -478,6 +480,12 @@ bool ShowWallPaper(
 			result |= ChatAdminRight::PinMessages;
 		} else if (element == u"promote_members"_q) {
 			result |= ChatAdminRight::AddAdmins;
+		} else if (element == u"post_stories"_q) {
+			result |= ChatAdminRight::PostStories;
+		} else if (element == u"edit_stories"_q) {
+			result |= ChatAdminRight::EditStories;
+		} else if (element == u"delete_stories"_q) {
+			result |= ChatAdminRight::DeleteStories;
 		} else if (element == u"manage_video_chats"_q) {
 			result |= ChatAdminRight::ManageCall;
 		} else if (element == u"manage_direct_messages"_q) {
@@ -487,7 +495,7 @@ bool ShowWallPaper(
 		} else if (element == u"manage_chat"_q) {
 			result |= ChatAdminRight::Other;
 		} else {
-			return {};
+			continue;
 		}
 	}
 	return result;


### PR DESCRIPTION
## Problem

The `?startchannel&admin` deeplink does not correctly pre-select admin rights when adding a bot to a channel. All checkboxes in the admin rights dialog appear unchecked, even though the bot has default admin rights configured via BotFather. The mobile clients handles this correctly.

<img width="441" height="532" alt="image" src="https://github.com/user-attachments/assets/c76bb92f-aab3-4342-9e2b-1d42b02b7d5e" />


Two separate issues contribute to this:

  ### 1. Missing admin right identifiers in URL parser

`ParseRequestedAdminRights` does not recognize `post_stories`, `edit_stories`, and `delete_stories` — all three are [documented](https://core.telegram.org/api/links#bot-links) as valid identifiers for the `admin` parameter. The corresponding `ChatAdminRight` enum values already exist in the codebase.

Since the parser returns empty rights (`{}`) on any unrecognized token (line 490), a URL like `admin=post_messages+post_stories` discards **all** parsed rights, not just the unrecognized one.

  ### 2. No fallback to bot default rights for `startchannel`

For `startchannel`, the scope is unconditionally set to `Scope::ChannelAdmin` ([window_session_controller.cpp:733](https://github.com/telegramdesktop/tdesktop/blob/dev/Telegram/SourceFiles/window/window_session_controller.cpp#L733)), which makes `requestedAddAdmin` always `true`. This causes `addBotToGroup` to always use the explicit URL rights (`_requestedRights`), never falling back to `bot->botInfo->channelAdminRights`.

When the `admin` parameter is present without a value (`?startchannel&admin`), the parsed rights are 0, so the admin dialog opens with all checkboxes unchecked.

Note: `startgroup` does not have this issue — when no admin rights are specified, the scope falls back to `Scope::All`, which correctly uses `bot->botInfo->groupAdminRights`. 

  ## Changes

  **`local_url_handlers.cpp` — `ParseRequestedAdminRights`:**
  - Added `post_stories`, `edit_stories`, `delete_stories` identifiers
  - Added empty element guard (`element.isEmpty() → continue`) to gracefully handle `admin=` with no value and trailing/leading `+` separators

  **`add_bot_to_chat_box.cpp` — `addBotToGroup`:**
  - Changed condition from `requestedAddAdmin` to `(requestedAddAdmin && _requestedRights != 0)` so that when explicit rights are empty, the code falls through to `bot->botInfo->channelAdminRights` / `bot->botInfo->groupAdminRights`