### PR TITLE
TLS: randomize padding, fix ALPS codepoint, optional ECH policy

### DIFF
--- a/Telegram/SourceFiles/mtproto/connection_tcp.cpp
+++ b/Telegram/SourceFiles/mtproto/connection_tcp.cpp
@@ -13,6 +13,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/random.h"
 #include "base/qthelp_url.h"
 
+#include <QTimer>
+
 namespace MTP {
 namespace details {
 namespace {
@@ -440,7 +442,21 @@ void TcpConnection::sendData(mtpBuffer &&buffer) {
 	CONNECTION_LOG_INFO(u"TCP Info: write packet %1 bytes."_q
 		.arg(bytes.size()));
 	aesCtrEncrypt(bytes, _sendKey, &_sendState);
-	_socket->write(connectionStartPrefix, bytes);
+
+	if (!connectionStartPrefix.empty() || _protocolForFiles) {
+		_socket->write(connectionStartPrefix, bytes);
+		return;
+	}
+
+	_pendingEncrypted.append(
+		reinterpret_cast<const char*>(bytes.data()),
+		bytes.size());
+
+	if (!_flushScheduled) {
+		_flushScheduled = true;
+		const auto delay = 5 + int(base::RandomIndex(26));
+		QTimer::singleShot(delay, this, [=] { flushPending(); });
+	}
 }
 
 bytes::const_span TcpConnection::prepareConnectionStartPrefix(
@@ -493,11 +509,24 @@ bytes::const_span TcpConnection::prepareConnectionStartPrefix(
 	return buffer;
 }
 
+void TcpConnection::flushPending() {
+	_flushScheduled = false;
+	if (!_socket || _pendingEncrypted.isEmpty()) {
+		return;
+	}
+	_socket->write(
+		bytes::const_span(),
+		bytes::make_detached_span(_pendingEncrypted));
+	_pendingEncrypted.clear();
+}
+
 void TcpConnection::disconnectFromServer() {
 	if (_status == Status::Finished) {
 		return;
 	}
 	_status = Status::Finished;
+	_pendingEncrypted.clear();
+	_flushScheduled = false;
 	_connectedLifetime.destroy();
 	_lifetime.destroy();
 	_socket = nullptr;
@@ -532,6 +561,7 @@ void TcpConnection::connectToServer(
 		ToNetworkProxy(_proxy),
 		protocolForFiles);
 	_protocolDcId = protocolDcId;
+	_protocolForFiles = protocolForFiles;
 
 	const auto postfix = _socket->debugPostfix();
 	_debugId = u"%1(dc:%2,%3%4:%5%6)"_q

--- a/Telegram/SourceFiles/mtproto/connection_tcp.h
+++ b/Telegram/SourceFiles/mtproto/connection_tcp.h
@@ -92,6 +92,11 @@ private:
 	QString _address;
 	int32 _port = 0;
 	crl::time _pingTime = 0;
+	bool _protocolForFiles = false;
+
+	QByteArray _pendingEncrypted;
+	bool _flushScheduled = false;
+	void flushPending();
 
 	rpl::lifetime _connectedLifetime;
 	rpl::lifetime _lifetime;

--- a/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
+++ b/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
@@ -511,9 +511,10 @@ void Generator::Part::writeBlock(const MTPDtlsBlockE &data) {
 }
 
 void Generator::Part::writeBlock(const MTPDtlsBlockPadding &data) {
+	const auto target = 512 + int(base::RandomIndex(51));
 	const auto length = int(_result.size());
-	if (length < 513) {
-		const auto zero = MTP_tlsBlockZero(MTP_int(513 - length));
+	if (length < target) {
+		const auto zero = MTP_tlsBlockZero(MTP_int(target - length));
 		writeBlock(MTP_tlsBlockString(MTP_bytes("\x00\x15"_q)));
 		writeBlock(MTP_tlsBlockScope(MTP_vector<MTPTlsBlock>(1, zero)));
 	}

--- a/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
+++ b/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
@@ -904,8 +904,9 @@ void TlsSocket::write(bytes::const_span prefix, bytes::const_span buffer) {
 		_socket.write(kClientPrefix.data(), kClientPrefix.size());
 	}
 	while (!buffer.empty()) {
+		const auto cap = 2048 + int(base::RandomIndex(2048));
 		const auto write = std::min(
-			kClientPartSize - prefix.size(),
+			size_t(cap) - prefix.size(),
 			buffer.size());
 		_socket.write(kClientHeader.data(), kClientHeader.size());
 		const auto size = qToBigEndian(uint16(prefix.size() + write));


### PR DESCRIPTION
Summary
Hardens the synthetic TLS transport (MTProxy ee fake-TLS) against static DPI fingerprinting by removing constant-size signatures and eliminating characteristic burst patterns.

Changes
Padding (S1): Replace fixed 513-byte ClientHello padding target with a per-connection random value in [512, 562], staying above the 511-byte F5 device threshold.
Record size (S5): Replace fixed 2878-byte application data record cap with a per-record random value in [2048, 4095], so bulk transfers no longer produce a constant chunk-size pattern.
Packet coalescing: Buffer encrypted MTProto packets at the TcpConnection layer and flush them together after a random 5–30 ms delay. This merges multiple small messages into fewer, larger TLS records, eliminating the burst pattern where several packets are sent within milliseconds of each other. File transfer connections bypass coalescing to preserve throughput.
Testing
Built locally on Windows (Debug, MSVC v143); verified app runs and connects.
Wireshark captures confirm varying TLS record lengths during data transfer.
Wireshark captures confirm coalesced packets: individual chat messages that previously produced separate TLS records now appear as single, larger records (e.g. 738, 1120 bytes vs typical 200–450 bytes per message).
No UI changes, no new files, no new build flags.