### PR TITLE
Change proxy share link from t.me to tg:// deeplink

### DIFF
--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -76,7 +76,7 @@ using ProxyData = MTP::ProxyData;
 
 [[nodiscard]] QString ProxyDataToString(const ProxyData &proxy) {
 	using Type = ProxyData::Type;
-	return u"https://t.me/"_q
+	return u"tg://"_q
 		+ (proxy.type == Type::Socks5 ? "socks" : "proxy")
 		+ "?server=" + proxy.host + "&port=" + QString::number(proxy.port)
 		+ ((proxy.type == Type::Socks5 && !proxy.user.isEmpty())


### PR DESCRIPTION
Currently, when the client tries to share a proxy link (including via QR code), it generates it via `https://t.me/proxy?...`
This is inconvenient - because if I want to share a link, it means Telegram is blocked in my country and it won't open. The same applies to QR scanners on mobile devices.

TelegramSwift on macOS already shares links via deeplink, I suggest unifying the client behavior.