### PR TITLE
Fix stale macOS tray icon colors after appearance switches

### DIFF
--- a/Telegram/SourceFiles/platform/mac/tray_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/tray_mac.mm
@@ -174,12 +174,7 @@ void UpdateIcon(const NSStatusItem *status) {
 		return;
 	}
 
-	const auto appearance = [&] {
-		if (@available(macOS 10.14, *)) {
-			return [NSApp effectiveAppearance];
-		}
-		return status.button.effectiveAppearance;
-	}();
+	const auto appearance = status.button.effectiveAppearance;
 	const auto darkMode = [[appearance.name lowercaseString]
 		containsString:@"dark"];
 


### PR DESCRIPTION
Fixes #30527 

Summary:
Fix the macOS tray icon refresh path so the menu bar icon updates immediately after system light/dark appearance changes, even while Telegram stays unfocused in the background.

Changes:
The tray icon code was observing status button appearance changes but rendering against NSApp effectiveAppearance on macOS 10.14 and newer. Those two appearance sources do not update in lockstep while Telegram is unfocused, which caused the tray icon to redraw with a stale color until the app was focused. This change makes the renderer use status.button.effectiveAppearance directly so the icon color is derived from the same Cocoa object that emits the refresh signal.