### PR TITLE
CMakeLists: enable MSVC security flags

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -2144,7 +2144,7 @@ if (MSVC)
     target_link_options(Telegram
     PRIVATE
         /guard:cf
-        /CETCOMPAT
+        $<$<NOT:$<BOOL:${build_winarm}>>:/CETCOMPAT>
         /DYNAMICBASE
         /DELAYLOAD:secur32.dll
         /DELAYLOAD:winmm.dll

--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -2135,12 +2135,17 @@ endif()
 set_target_properties(Telegram PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${output_folder})
 
 if (MSVC)
+    target_compile_options(Telegram PRIVATE /guard:cf /sdl)
+
     target_link_libraries(Telegram
     PRIVATE
         delayimp
     )
     target_link_options(Telegram
     PRIVATE
+        /guard:cf
+        /CETCOMPAT
+        /DYNAMICBASE
         /DELAYLOAD:secur32.dll
         /DELAYLOAD:winmm.dll
         /DELAYLOAD:ws2_32.dll


### PR DESCRIPTION
Add /guard:cf and /sdl to compile options, and /guard:cf, /CETCOMPAT, /DYNAMICBASE to link options for Telegram target when building with MSVC. These flags improve control flow guarding, dynamic base relocation, and overall security hardening of the Windows build.