### PR TITLE
Update compress_certificate extension to match Chrome 119+ (add zlib support)

### DIFF
--- a/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
+++ b/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
@@ -179,7 +179,7 @@ using BigNumContext = openssl::Context;
 			S("\x00\x17\x00\x00"_q);
 		}
 		StartPermutationElement(); {
-			S("\x00\x1b\x00\x03\x02\x00\x02"_q);
+			S("\x00\x1b\x00\x05\x04\x00\x01\x00\x02"_q);
 		}
 		StartPermutationElement(); {
 			S("\x00\x23\x00\x00"_q);


### PR DESCRIPTION

Improve DPI resistance by mimic chrome behaviour.

FakeTLS ClientHello was fingerprint-detectable because compress_certificate (0x001b) only advertised brotli, while Chrome 119+ advertises both zlib and brotli (in that order).