### PR TITLE
fix: honor date range in chat/topic export, skip pre-from history

### DIFF
--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
@@ -2607,7 +2607,7 @@ bool SingleMessageAfter(
 		const MTPmessages_Messages &data,
 		TimeId date) {
 	const auto single = SingleMessageDate(data);
-	return (single > 0 && single > date);
+	return (single > 0 && single >= date);
 }
 
 bool SkipMessageByDate(const Message &message, const Settings &settings) {

--- a/Telegram/SourceFiles/export/export_api_wrap.cpp
+++ b/Telegram/SourceFiles/export/export_api_wrap.cpp
@@ -1469,6 +1469,7 @@ void ApiWrap::requestMessagesCount(int localSplitIndex) {
 		0, // offset_id
 		0, // add_offset
 		1, // limit
+		0, // offset_date
 		[=](const MTPmessages_Messages &result) {
 		Expects(_chatProcess != nullptr);
 
@@ -1513,6 +1514,7 @@ void ApiWrap::checkFirstMessageDate(int localSplitIndex, int count) {
 		1, // offset_id
 		-1, // add_offset
 		1, // limit
+		0, // offset_date
 		[=](const MTPmessages_Messages &result) {
 		Expects(_chatProcess != nullptr);
 
@@ -1875,11 +1877,47 @@ void ApiWrap::requestMessagesSlice() {
 		loadMessagesFiles({});
 		return;
 	}
+	if (_chatProcess->largestIdPlusOne == 1
+		&& _settings->singlePeerFrom > 0) {
+		requestChatMessages(
+			_chatProcess->info.splits[_chatProcess->localSplitIndex],
+			0, // offset_id
+			-1, // add_offset
+			1, // limit
+			_settings->singlePeerFrom - 1, // offset_date
+			[=](const MTPmessages_Messages &result) {
+			Expects(_chatProcess != nullptr);
+
+			const auto firstId = result.match([](
+					const MTPDmessages_messagesNotModified &) {
+				return 0;
+			}, [](const auto &data) {
+				const auto &list = data.vmessages().v;
+				if (list.isEmpty()) {
+					return 0;
+				}
+				return list[0].match([](const MTPDmessageEmpty &) {
+					return 0;
+				}, [](const auto &data) {
+					return data.vid().v;
+				});
+			});
+			if (!firstId) {
+				_chatProcess->lastSlice = true;
+				loadMessagesFiles({});
+				return;
+			}
+			_chatProcess->largestIdPlusOne = firstId;
+			requestMessagesSlice();
+		});
+		return;
+	}
 	requestChatMessages(
 		_chatProcess->info.splits[_chatProcess->localSplitIndex],
 		_chatProcess->largestIdPlusOne,
 		-kMessagesSliceLimit,
 		kMessagesSliceLimit,
+		0, // offset_date
 		[=](const MTPmessages_Messages &result) {
 		Expects(_chatProcess != nullptr);
 
@@ -1889,12 +1927,18 @@ void ApiWrap::requestMessagesSlice() {
 			if constexpr (MTPDmessages_messages::Is<decltype(data)>()) {
 				_chatProcess->lastSlice = true;
 			}
-			loadMessagesFiles(Data::ParseMessagesSlice(
+			auto slice = Data::ParseMessagesSlice(
 				_chatProcess->context,
 				data.vmessages(),
 				data.vusers(),
 				data.vchats(),
-				_chatProcess->info.relativePath));
+				_chatProcess->info.relativePath);
+			if (_settings->singlePeerTill > 0
+				&& !slice.list.empty()
+				&& slice.list.back().date >= _settings->singlePeerTill) {
+				_chatProcess->lastSlice = true;
+			}
+			loadMessagesFiles(std::move(slice));
 		});
 	});
 }
@@ -1904,6 +1948,7 @@ void ApiWrap::requestChatMessages(
 		int offsetId,
 		int addOffset,
 		int limit,
+		int offsetDate,
 		FnMut<void(MTPmessages_Messages&&)> done) {
 	Expects(_chatProcess != nullptr);
 
@@ -1924,6 +1969,10 @@ void ApiWrap::requestChatMessages(
 		? splitIndex
 		: (splitsCount + splitIndex);
 	if (_chatProcess->info.onlyMyMessages) {
+		const auto minDate = _settings->singlePeerFrom;
+		const auto maxDate = (_settings->singlePeerTill > 0)
+			? (_settings->singlePeerTill - 1)
+			: 0;
 		splitRequest(realSplitIndex, MTPmessages_Search(
 			MTP_flags(MTPmessages_Search::Flag::f_from_id),
 			realPeerInput,
@@ -1933,8 +1982,8 @@ void ApiWrap::requestChatMessages(
 			MTPVector<MTPReaction>(), // saved_reaction
 			MTPint(), // top_msg_id
 			MTP_inputMessagesFilterEmpty(),
-			MTP_int(0), // min_date
-			MTP_int(0), // max_date
+			MTP_int(minDate), // min_date
+			MTP_int(maxDate), // max_date
 			MTP_int(offsetId),
 			MTP_int(addOffset),
 			MTP_int(limit),
@@ -1946,7 +1995,7 @@ void ApiWrap::requestChatMessages(
 		splitRequest(realSplitIndex, MTPmessages_GetHistory(
 			realPeerInput,
 			MTP_int(offsetId),
-			MTP_int(0), // offset_date
+			MTP_int(offsetDate),
 			MTP_int(addOffset),
 			MTP_int(limit),
 			MTP_int(0), // max_id
@@ -1967,6 +2016,7 @@ void ApiWrap::requestChatMessages(
 						offsetId,
 						addOffset,
 						limit,
+						offsetDate,
 						base::take(_chatProcess->requestDone));
 					return true;
 				}
@@ -2376,6 +2426,7 @@ void ApiWrap::requestTopicMessages(
 			0,
 			0,
 			kMessagesSliceLimit,
+			0, // offset_date
 			[=](const MTPmessages_Messages &result) {
 				Expects(_topicProcess != nullptr);
 
@@ -2414,6 +2465,40 @@ void ApiWrap::requestTopicMessages(
 void ApiWrap::requestTopicMessagesSlice() {
 	Expects(_topicProcess != nullptr);
 
+	if (_topicProcess->offsetId == 0
+		&& _settings->singlePeerFrom > 0) {
+		requestTopicReplies(
+			0, // offset_id
+			-1, // add_offset
+			1, // limit
+			_settings->singlePeerFrom - 1, // offset_date
+			[=](const MTPmessages_Messages &result) {
+			Expects(_topicProcess != nullptr);
+
+			const auto firstId = result.match([](
+					const MTPDmessages_messagesNotModified &) {
+				return 0;
+			}, [](const auto &data) {
+				const auto &list = data.vmessages().v;
+				if (list.isEmpty()) {
+					return 0;
+				}
+				return list[0].match([](const MTPDmessageEmpty &) {
+					return 0;
+				}, [](const auto &data) {
+					return data.vid().v;
+				});
+			});
+			if (!firstId) {
+				_topicProcess->lastSlice = true;
+				loadTopicMessagesFiles({});
+				return;
+			}
+			_topicProcess->offsetId = firstId - 1;
+			requestTopicMessagesSlice();
+		});
+		return;
+	}
 	const auto offsetId = (_topicProcess->offsetId == 0)
 		? 1
 		: (_topicProcess->offsetId + 1);
@@ -2421,6 +2506,7 @@ void ApiWrap::requestTopicMessagesSlice() {
 		offsetId,
 		-kMessagesSliceLimit,
 		kMessagesSliceLimit,
+		0, // offset_date
 		[=](const MTPmessages_Messages &result) {
 			Expects(_topicProcess != nullptr);
 
@@ -2439,6 +2525,11 @@ void ApiWrap::requestTopicMessagesSlice() {
 				if (slice.list.empty()) {
 					_topicProcess->lastSlice = true;
 				}
+				if (_settings->singlePeerTill > 0
+					&& !slice.list.empty()
+					&& slice.list.back().date >= _settings->singlePeerTill) {
+					_topicProcess->lastSlice = true;
+				}
 				loadTopicMessagesFiles(std::move(slice));
 			});
 		});
@@ -2448,6 +2539,7 @@ void ApiWrap::requestTopicReplies(
 		int offsetId,
 		int addOffset,
 		int limit,
+		int offsetDate,
 		FnMut<void(MTPmessages_Messages&&)> done) {
 	Expects(_topicProcess != nullptr);
 
@@ -2461,7 +2553,7 @@ void ApiWrap::requestTopicReplies(
 		_topicProcess->inputPeer,
 		MTP_int(_topicProcess->topicRootId),
 		MTP_int(offsetId),
-		MTP_int(0),
+		MTP_int(offsetDate),
 		MTP_int(addOffset),
 		MTP_int(limit),
 		MTP_int(0),
@@ -2552,6 +2644,9 @@ void ApiWrap::loadNextTopicMessageFile() {
 		; _topicProcess->fileIndex < list.size()
 		; ++_topicProcess->fileIndex) {
 		auto &message = list[_topicProcess->fileIndex];
+		if (Data::SkipMessageByDate(message, *_settings)) {
+			continue;
+		}
 		if (!messageCustomEmojiReady(message)) {
 			return;
 		}

--- a/Telegram/SourceFiles/export/export_api_wrap.h
+++ b/Telegram/SourceFiles/export/export_api_wrap.h
@@ -212,12 +212,14 @@ private:
 		int offsetId,
 		int addOffset,
 		int limit,
+		int offsetDate,
 		FnMut<void(MTPmessages_Messages&&)> done);
 	void requestTopicMessagesSlice();
 	void requestTopicReplies(
 		int offsetId,
 		int addOffset,
 		int limit,
+		int offsetDate,
 		FnMut<void(MTPmessages_Messages&&)> done);
 	void collectMessagesCustomEmoji(const Data::MessagesSlice &slice);
 	void resolveCustomEmoji();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 6.7.7 beta (20.04.26)
 
+- Honor date range when exporting chat history (no full scan).
 - Proxy auto-rotation option.
 - Allow seeking in video messages.
 - Styled text items with emoji support in image editor.


### PR DESCRIPTION
## Summary

Fixes the export-date-range bug reported in [#30412](https://github.com/telegramdesktop/tdesktop/issues/30412) and [#25139](https://github.com/telegramdesktop/tdesktop/issues/25139): selecting a date range in *Export chat history* causes the client to fetch the **entire** chat history from the oldest message before producing output. The date range is currently only applied at write time via `SkipMessageByDate`, so on large channels (millions of msgs) the export appears stuck for hours and consumes massive bandwidth even when the user only wants a few days of msgs.

This PR adds server-side skip-ahead so only msgs in the requested `[singlePeerFrom, singlePeerTill)` range are ever transferred.

## Approach (canonical, GetHistory-based)

1. **`offsetDate` parameter** threaded through `requestChatMessages` → `MTPmessages_GetHistory`. All call sites updated. Default `0` preserves prior behavior.
2. **First-call probe per split** in `requestMessagesSlice`: when `largestIdPlusOne == 1` and `singlePeerFrom > 0`, fires a single `getHistory(offset_id=0, offset_date=singlePeerFrom-1, add_offset=-1, limit=1)` to find the first msg id at-or-after `singlePeerFrom`. Sets `largestIdPlusOne = result.id` and re-enters slice fetching from there. Mirrors the canonical pattern at `apiwrap.cpp:3088` (`requestMessageAfterDate`).
3. **Till-stop in slice callback**: when `slice.list.back().date >= singlePeerTill`, sets `lastSlice = true` to terminate the split early instead of paginating to its end.
4. **`SingleMessageAfter > date` → `>= date`** in `export_data_types.cpp` — splits whose latest msg date equals `singlePeerFrom` exactly were being skipped erroneously by the existing pre-iteration filter.
5. **Topic path parity** — same probe + till-stop in `requestTopicReplies` / `requestTopicMessagesSlice` / `finishTopicMessagesSlice` (the date-range UI surfaces for topic exports too, per `export_view_settings.cpp:268-271`).
6. **Topic `loadNextMessageFile` SkipMessageByDate** added so the file loader respects the date filter on topic msgs.
7. **`onlyMyMessages` Search fallback** (kicked-from-channel mid-export) now passes `min_date = singlePeerFrom` and `max_date = (singlePeerTill > 0 ? singlePeerTill - 1 : 0)` for correct inclusive-lower / exclusive-upper boundaries matching `SkipMessageByDate`.

## Network savings

| Scenario (1M-msg channel, last 7 days) | Before | After |
|---|---|---|
| API calls | ~10,000 (`getHistory` per 100-msg batch across all msgs) | ~10 (1 probe + ~9 slice fetches for ~1k msgs) |

~1000× reduction in request volume for the typical narrow-range case.

## Backwards compatibility

- New `offsetDate` parameter defaults to `0` at every existing call site → unchanged behavior when no date range is set.
- All existing branches (`onlyMyMessages` Search, CHANNEL_PRIVATE fallback, migrated supergroup splits via negative `splitIndex`) are preserved.
- No public-API changes outside the export module.

## Test plan

- [x] Built with `centos_env` Docker image (`CONFIG=Release`, GCC 15) — clean build, 393 MB binary.
- [x] Manually tested: export channel history with date range *last 7 days* on a busy channel — output produced in seconds, msgs limited to range, file content matches the date filter.
- [x] Manually tested: export with no date range — unchanged behavior.

Fixes #30412
Fixes #25139