### PR TITLE
Show forwarded header for forwarded audio files

### DIFF
--- a/Telegram/SourceFiles/data/data_media_types.cpp
+++ b/Telegram/SourceFiles/data/data_media_types.cpp
@@ -1360,7 +1360,7 @@ bool MediaFile::forwardedBecomesUnread() const {
 }
 
 bool MediaFile::dropForwardedInfo() const {
-	return _document->isSong();
+	return false;
 }
 
 bool MediaFile::hasSpoiler() const {


### PR DESCRIPTION
### Motivation
- Forwarded attribution was intentionally suppressed for music/audio documents, which prevents the "Forwarded from" bar from appearing for forwarded songs and other audio files and reduces discoverability of source channels.
- Restore visible forwarded info for audio files so forwarded messages remain navigable to their original source when available.

### Description
- Changed `MediaFile::dropForwardedInfo()` to always return `false` so forwarded metadata is not hidden for audio/song documents in `Telegram/SourceFiles/data/data_media_types.cpp`.
- This removes the previous special-case that returned `true` for `isSong()` and re-enables the forwarded bar for forwarded audio files.

### Testing
- Attempted an automated build with `cmake --build out --config Debug --target Telegram`, but the build could not be started in this environment because the `out/` directory is missing; therefore no compilation was completed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed86e2f868832bbdb5e1b599e49f8e)