### PR TITLE
fix: use original stream's duration attribute for transcodes

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -5136,16 +5136,12 @@ void OverlayWidget::restartAtSeekPosition(crl::time position) {
 	}
 	const auto overrideDuration = _stories
 		|| (_chosenQuality && _chosenQuality != _document);
-	const auto durationDocument = (_chosenQuality && _chosenQuality != _document)
-		? _chosenQuality
-		: _document;
-
 	auto options = Streaming::PlaybackOptions{
 		.position = position,
 		.durationOverride = ((overrideDuration
-			&& durationDocument
-			&& durationDocument->hasDuration())
-			? durationDocument->duration()
+			&& _document
+			&& _document->hasDuration())
+			? _document->duration()
 			: crl::time(0)),
 		.hwAllowed = Core::App().settings().hardwareAcceleratedVideo(),
 		.seekable = !_stories,


### PR DESCRIPTION
Fixes #30616 by reverting the broken duration document selection behavior as it was before #30393 - transcodes rely on the original's duration attribute instead of their own

Core issue: the backend provides incorrect duration for slop streams both in attributes and in moov, so there's no fallback possible (unless you do something like packet-based duration, which would require actual effort)

This results in the correct duration in https://t.me/cursedvideofiles/11 but incorrect duration for slop steams in https://t.me/cursedvideofiles/8