### PR TITLE
Storage: show specific error for insufficient disk space

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1125,6 +1125,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_download_path_choose" = "Choose download path";
 "lng_download_path_failed" = "File download could not be started.\n\nThis might be because your selected download location is invalid. Try changing it in Settings > Advanced > Download Path.";
 "lng_download_finish_failed" = "File download could not be completed.\n\nWould you like to try again?";
+"lng_download_no_disk_space_failed" = "Not enough disk space to download this file.\n\nWould you like to try again?";
 
 "lng_settings_section_privacy" = "Privacy and Security";
 

--- a/Telegram/SourceFiles/data/data_document.cpp
+++ b/Telegram/SourceFiles/data/data_document.cpp
@@ -1286,10 +1286,17 @@ void DocumentData::handleLoaderUpdates() {
 				Ui::hideLayer();
 				save(origin, failedFileName);
 			};
-			Ui::show(Ui::MakeConfirmBox({
-				tr::lng_download_finish_failed(),
-				crl::guard(&session(), retry)
-			}));
+			if (error.failureReason == FailureReason::NoDiskSpaceFailure) {
+				Ui::show(Ui::MakeConfirmBox({
+					tr::lng_download_no_disk_space_failed(),
+					crl::guard(&session(), retry)
+				}));
+			} else {
+				Ui::show(Ui::MakeConfirmBox({
+					tr::lng_download_finish_failed(),
+					crl::guard(&session(), retry)
+				}));
+			}
 		} else if (error.failureReason == FailureReason::FileWriteFailure) {
 			if (!Core::App().settings().downloadPath().isEmpty()) {
 				Core::App().settings().setDownloadPathBookmark(QByteArray());

--- a/Telegram/SourceFiles/storage/file_download.cpp
+++ b/Telegram/SourceFiles/storage/file_download.cpp
@@ -376,8 +376,23 @@ bool FileLoader::writeResultPart(int64 offset, bytes::const_span buffer) {
 			_skippedBytes += offset - fsize;
 		}
 		_file.seek(offset);
-		if (_file.write(reinterpret_cast<const char*>(buffer.data()), buffer.size()) != qint64(buffer.size())) {
-			cancel(FailureReason::FileWriteFailure);
+		auto result = _file.write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+		auto writtenBytes = result;
+		while (writtenBytes != qint64(buffer.size()) && result > 0) {
+			if (_file.error() == QFile::ResourceError) {
+				cancel(FailureReason::NoDiskSpaceFailure);
+				return false;
+			} else if (_file.error() != QFile::NoError) {
+				cancel(FailureReason::FileWriteFailure);
+				return false;
+			}
+			result = _file.write(reinterpret_cast<const char*>(buffer.data()) + writtenBytes, buffer.size() - writtenBytes);
+			writtenBytes += result;
+		}
+		if (writtenBytes != qint64(buffer.size())) {
+			cancel(_file.error() == QFile::ResourceError
+				? FailureReason::NoDiskSpaceFailure
+				: FailureReason::FileWriteFailure);
 			return false;
 		}
 		return true;

--- a/Telegram/SourceFiles/storage/file_download.h
+++ b/Telegram/SourceFiles/storage/file_download.h
@@ -55,6 +55,7 @@ public:
 	enum class FailureReason {
 		NoFailure,
 		FileWriteFailure,
+		NoDiskSpaceFailure,
 		OtherFailure,
 	};
 


### PR DESCRIPTION
**Summary**

Previously, all file write failures sent a `FailureReason::FileWriteFailure`. This PR adds a specific `FailureReason::NoDiskSpaceFailure` failure reason for out-of-disk-space scenarios and displays a dedicated error message box to the user.

**Related Issues:**

Fix [#30668](https://github.com/telegramdesktop/tdesktop/issues/30668)

Before:
<img width="329" height="158" alt="download_error" src="https://github.com/user-attachments/assets/6f855051-b7ad-412b-850e-970db80fa5cc" />

After:
<img width="331" height="183" alt="no_disk_error" src="https://github.com/user-attachments/assets/f36439eb-ae5d-453d-a923-06a5b379bc87" />
