### PR TITLE
Fix swipe reply target for grouped media

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
+++ b/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
@@ -561,12 +561,12 @@ void TabbedSelector::reinstallSwipe(not_null<Ui::RpWidget*> widget) {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
 		if (!_tabsSlider) {
 			return Ui::Controls::SwipeHandlerFinishData();
 		}
 		const auto activeSection = _tabsSlider->activeSection();
-		const auto isToLeft = direction == Qt::RightToLeft;
+		const auto isToLeft = data.direction == Qt::RightToLeft;
 		if ((isToLeft && activeSection > 0)
 			|| (!isToLeft && activeSection < _tabs.size() - 1)) {
 			return Ui::Controls::DefaultSwipeBackHandlerFinishData([=] {

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -771,14 +771,14 @@ void Widget::setupSwipeBack() {
 		}
 	};
 
-	auto init = [=](int top, Qt::LayoutDirection direction) {
-		top -= _inner->y();
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		const auto top = data.cursorPosition.y() - _inner->y();
 		_swipeBackIconMirrored = false;
 		_swipeBackMirrored = false;
 		if (_childListShown.current()) {
 			return Ui::Controls::SwipeHandlerFinishData();
 		}
-		const auto isRightToLeft = direction == Qt::RightToLeft;
+		const auto isRightToLeft = data.direction == Qt::RightToLeft;
 		const auto action = Core::App().settings().quickDialogAction();
 		const auto isDisabled = action == Ui::QuickDialogAction::Disabled;
 		if (_inner) {

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
@@ -1633,12 +1633,12 @@ Ui::Controls::SwipeHandlerArgs Suggestions::generateIncompleteSwipeArgs() {
 			_swipeBackData = {};
 		}
 	};
-	auto init = [=](int, Qt::LayoutDirection direction) {
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
 		if (!_tabs) {
 			return Ui::Controls::SwipeHandlerFinishData();
 		}
 		const auto activeSection = _tabs->activeSection();
-		const auto isToLeft = direction == Qt::RightToLeft;
+		const auto isToLeft = data.direction == Qt::RightToLeft;
 		if ((isToLeft && activeSection > 0)
 			|| (!isToLeft && activeSection < _tabKeys.size() - 1)) {
 			return Ui::Controls::DefaultSwipeBackHandlerFinishData([=] {

--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
+++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
@@ -452,8 +452,8 @@ void Widget::setupSwipeReply() {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		if (direction == Qt::RightToLeft) {
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		if (data.direction == Qt::RightToLeft) {
 			return Ui::Controls::DefaultSwipeBackHandlerFinishData([=] {
 				controller()->showBackFromStack();
 			});
@@ -576,4 +576,3 @@ void Widget::applyFilter(FilterValue &&value) {
 }
 
 } // namespace AdminLog
-

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -658,9 +658,8 @@ void HistoryInner::setupSwipeReplyAndBack() {
 	};
 
 	auto init = [=, show = _controller->uiShow()](
-			int cursorTop,
-			Qt::LayoutDirection direction) {
-		if (direction == Qt::RightToLeft) {
+			Ui::Controls::SwipeHandlerInitData data) {
+		if (data.direction == Qt::RightToLeft) {
 			auto good = true;
 			enumerateItems<EnumItemsDirection::BottomToTop>([&](
 					not_null<Element*> view,
@@ -689,14 +688,14 @@ void HistoryInner::setupSwipeReplyAndBack() {
 				not_null<Element*> view,
 				int itemtop,
 				int itembottom) {
-			if ((cursorTop < itemtop)
-				|| (cursorTop > itembottom)
+			if ((data.cursorPosition.y() < itemtop)
+				|| (data.cursorPosition.y() > itembottom)
 				|| !view->data()->isRegular()
 				|| view->data()->showSimilarChannels()
 				|| view->data()->isService()) {
 				return true;
 			}
-			const auto item = view->data();
+			const auto item = lookupItemByPoint(data.cursorPosition, view);
 			const auto canSendReply = CanSendReply(item);
 			const auto canReply = (canSendReply || item->allowsForward());
 			if (!canReply) {
@@ -705,13 +704,24 @@ void HistoryInner::setupSwipeReplyAndBack() {
 			if (_overlayHost) {
 				_overlayHost->hide();
 			}
-			result.msgBareId = item->fullId().msg.bare;
-			result.callback = [=, itemId = item->fullId()] {
-				const auto still = show->session().data().message(itemId);
-				const auto selected = selectedQuote(still);
-				const auto replyToItemId = (selected.item
-					? selected.item
-					: still)->fullId();
+			const auto viewItemId = view->data()->fullId();
+			const auto itemId = item->fullId();
+			result.msgBareId = viewItemId.msg.bare;
+			result.callback = [=] {
+				const auto still = show->session().data().message(viewItemId);
+				const auto selected = still
+					? selectedQuote(still)
+					: HistoryView::SelectedQuote();
+				const auto replyToItemId = [&]() -> FullMsgId {
+					if (selected.item) {
+						return selected.item->fullId();
+					}
+					const auto exact = show->session().data().message(itemId);
+					return exact ? exact->fullId() : FullMsgId();
+				}();
+				if (!replyToItemId) {
+					return;
+				}
 				_widget->replyToMessage({
 					.messageId = replyToItemId,
 					.quote = selected.highlight.quote,
@@ -1892,6 +1902,20 @@ QPoint HistoryInner::mapPointToItem(
 		return mapPointToItem(p, view);
 	}
 	return QPoint();
+}
+
+HistoryItem *HistoryInner::lookupItemByPoint(
+		QPoint point,
+		not_null<Element*> view) const {
+	point -= QPoint(SelectionViewOffset(this, view), 0);
+	const auto itemPoint = mapPointToItem(point, view);
+	if (view->pointState(itemPoint) == HistoryView::PointState::GroupPart) {
+		const auto state = view->textState(itemPoint, {});
+		if (const auto item = session().data().message(state.itemId)) {
+			return item;
+		}
+	}
+	return view->data().get();
 }
 
 void HistoryInner::mousePressEvent(QMouseEvent *e) {

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -361,6 +361,9 @@ private:
 
 	QPoint mapPointToItem(QPoint p, const Element *view) const;
 	QPoint mapPointToItem(QPoint p, const HistoryItem *item) const;
+	[[nodiscard]] HistoryItem *lookupItemByPoint(
+		QPoint point,
+		not_null<Element*> view) const;
 	[[nodiscard]] HistoryView::SelectedQuote selectedQuote(
 		not_null<HistoryItem*> item) const;
 

--- a/Telegram/SourceFiles/history/history_view_swipe_back_session.cpp
+++ b/Telegram/SourceFiles/history/history_view_swipe_back_session.cpp
@@ -43,8 +43,8 @@ void SetupSwipeBackSection(
 			(*swipeBackData) = {};
 		}
 	};
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		if (direction != Qt::RightToLeft) {
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		if (data.direction != Qt::RightToLeft) {
 			return Ui::Controls::SwipeHandlerFinishData();
 		}
 		return Ui::Controls::DefaultSwipeBackHandlerFinishData([=] {

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
@@ -1049,9 +1049,8 @@ void ChatWidget::setupSwipeReplyAndBack() {
 	};
 
 	auto init = [=, show = controller()->uiShow()](
-			int cursorTop,
-			Qt::LayoutDirection direction) {
-		if (direction == Qt::RightToLeft) {
+			Ui::Controls::SwipeHandlerInitData data) {
+		if (data.direction == Qt::RightToLeft) {
 			return Ui::Controls::DefaultSwipeBackHandlerFinishData([=] {
 				controller()->showBackFromStack();
 			});
@@ -1060,27 +1059,41 @@ void ChatWidget::setupSwipeReplyAndBack() {
 		if (_inner->elementInSelectionMode(nullptr).inSelectionMode) {
 			return result;
 		}
-		const auto view = _inner->lookupItemByY(cursorTop);
+		const auto view = _inner->lookupItemByY(data.cursorPosition.y());
 		if (!view
 			|| !view->data()->isRegular()
 			|| view->data()->isService()) {
 			return result;
 		}
-		if (!can(view->data())) {
+		const auto item = _inner->lookupItemByPoint(
+			data.cursorPosition,
+			view);
+		if (!can(item)) {
 			return result;
 		}
 
 		_inner->hideElementOverlay();
-		result.msgBareId = view->data()->fullId().msg.bare;
-		result.callback = [=, itemId = view->data()->fullId()] {
-			const auto still = show->session().data().message(itemId);
-			const auto view = _inner->viewByPosition(still->position());
-			const auto selected = view
+		const auto viewItemId = view->data()->fullId();
+		const auto itemId = item->fullId();
+		result.msgBareId = viewItemId.msg.bare;
+		result.callback = [=] {
+			const auto still = show->session().data().message(viewItemId);
+			const auto view = still
+				? _inner->viewByPosition(still->position())
+				: nullptr;
+			const auto selected = (still && view)
 				? view->selectedQuote(_inner->getSelectedTextRange(still))
 				: SelectedQuote();
-			const auto replyToItemId = (selected.item
-				? selected.item
-				: still)->fullId();
+			const auto replyToItemId = [&]() -> FullMsgId {
+				if (selected.item) {
+					return selected.item->fullId();
+				}
+				const auto exact = show->session().data().message(itemId);
+				return exact ? exact->fullId() : FullMsgId();
+			}();
+			if (!replyToItemId) {
+				return;
+			}
 			_inner->replyToMessageRequestNotify({
 				.messageId = replyToItemId,
 				.quote = selected.highlight.quote,

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -1737,6 +1737,20 @@ Element *ListWidget::lookupItemByY(int y) const {
 	return strictFindItemByY(y);
 }
 
+HistoryItem *ListWidget::lookupItemByPoint(
+		QPoint point,
+		not_null<Element*> view) const {
+	point -= QPoint(SelectionViewOffset(this, view), 0);
+	const auto itemPoint = mapPointToItem(point, view);
+	if (view->pointState(itemPoint) == PointState::GroupPart) {
+		const auto state = view->textState(itemPoint, {});
+		if (const auto item = session().data().message(state.itemId)) {
+			return item;
+		}
+	}
+	return view->data().get();
+}
+
 auto ListWidget::findViewForPinnedTracking(int top) const
 -> std::pair<Element*, int> {
 	const auto findScrollTopItem = [&](int top)

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -363,6 +363,9 @@ public:
 	[[nodiscard]] bool showCopyRestrictionForSelected();
 	[[nodiscard]] bool hasSelectRestriction() const;
 	[[nodiscard]] Element *lookupItemByY(int y) const;
+	[[nodiscard]] HistoryItem *lookupItemByPoint(
+		QPoint point,
+		not_null<Element*> view) const;
 
 	[[nodiscard]] std::pair<Element*, int> findViewForPinnedTracking(
 		int top) const;

--- a/Telegram/SourceFiles/info/info_content_widget.cpp
+++ b/Telegram/SourceFiles/info/info_content_widget.cpp
@@ -517,8 +517,8 @@ void ContentWidget::setupSwipeHandler(not_null<Ui::RpWidget*> widget) {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		return (direction == Qt::RightToLeft && _controller->hasBackButton())
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		return (data.direction == Qt::RightToLeft && _controller->hasBackButton())
 			? Ui::Controls::DefaultSwipeBackHandlerFinishData([=] {
 				checkBeforeClose(crl::guard(this, [=] {
 					_controller->parentController()->hideLayer();

--- a/Telegram/SourceFiles/settings/sections/settings_business.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_business.cpp
@@ -739,8 +739,8 @@ void Business::setupSwipeBack() {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		return (direction == Qt::RightToLeft)
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		return (data.direction == Qt::RightToLeft)
 			? DefaultSwipeBackHandlerFinishData([=] {
 				_showBack.fire({});
 			})

--- a/Telegram/SourceFiles/settings/sections/settings_credits.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_credits.cpp
@@ -463,8 +463,8 @@ void Credits::setupSwipeBack() {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		return (direction == Qt::RightToLeft)
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		return (data.direction == Qt::RightToLeft)
 			? DefaultSwipeBackHandlerFinishData([=] {
 				_showBack.fire({});
 			})

--- a/Telegram/SourceFiles/settings/sections/settings_premium.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_premium.cpp
@@ -1425,8 +1425,8 @@ void Premium::setupSwipeBack() {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		return (direction == Qt::RightToLeft)
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		return (data.direction == Qt::RightToLeft)
 			? DefaultSwipeBackHandlerFinishData([=] {
 				_showBack.fire({});
 			})

--- a/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
+++ b/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
@@ -86,6 +86,7 @@ void SetupSwipeHandler(SwipeHandlerArgs &&args) {
 		int directionInt = 1.;
 		QPointF startAt;
 		QPointF delta;
+		QPoint cursorPosition;
 		int cursorTop = 0;
 		bool dontStart = false;
 		bool started = false;
@@ -197,9 +198,10 @@ void SetupSwipeHandler(SwipeHandlerArgs &&args) {
 			state->directionInt = (state->direction == Qt::LeftToRight)
 				? 1
 				: -1;
-			state->finishByTopData = generateFinish(
-				state->cursorTop,
-				*state->direction);
+			state->finishByTopData = generateFinish({
+				.cursorPosition = state->cursorPosition,
+				.direction = *state->direction,
+			});
 			state->threshold = style::ConvertFloatScale(kThresholdWidth)
 				* state->finishByTopData.speedRatio;
 			if (!state->finishByTopData.callback
@@ -213,7 +215,8 @@ void SetupSwipeHandler(SwipeHandlerArgs &&args) {
 			state->data.reachRatio = 0.;
 			state->touch = args.touch;
 			state->startAt = args.position;
-			state->cursorTop = widget->mapFromGlobal(args.globalCursor).y();
+			state->cursorPosition = widget->mapFromGlobal(args.globalCursor);
+			state->cursorTop = state->cursorPosition.y();
 			if (!state->touch) {
 				// args.delta already is valid.
 				fillFinishByTop();

--- a/Telegram/SourceFiles/ui/controls/swipe_handler.h
+++ b/Telegram/SourceFiles/ui/controls/swipe_handler.h
@@ -7,6 +7,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #pragma once
 
+#include <QtCore/QPoint>
+
 namespace Ui {
 class ElasticScroll;
 class RpWidget;
@@ -27,6 +29,11 @@ struct SwipeHandlerFinishData {
 	bool provideReachOutRatio = false;
 };
 
+struct SwipeHandlerInitData final {
+	QPoint cursorPosition;
+	Qt::LayoutDirection direction = Qt::LeftToRight;
+};
+
 using Scroll = std::variant<
 	v::null_t,
 	not_null<Ui::ScrollArea*>,
@@ -36,7 +43,7 @@ struct SwipeHandlerArgs {
 	not_null<Ui::RpWidget*> widget;
 	Scroll scroll;
 	Fn<void(SwipeContextData)> update;
-	Fn<SwipeHandlerFinishData(int, Qt::LayoutDirection)> init;
+	Fn<SwipeHandlerFinishData(SwipeHandlerInitData)> init;
 	rpl::producer<bool> dontStart = nullptr;
 	rpl::lifetime *onLifetime = nullptr;
 };

--- a/Telegram/SourceFiles/window/window_main_menu.cpp
+++ b/Telegram/SourceFiles/window/window_main_menu.cpp
@@ -1004,8 +1004,8 @@ void MainMenu::setupSwipe() {
 		}
 	};
 
-	auto init = [=](int, Qt::LayoutDirection direction) {
-		if (direction != Qt::LeftToRight) {
+	auto init = [=](Ui::Controls::SwipeHandlerInitData data) {
+		if (data.direction != Qt::LeftToRight) {
 			return Ui::Controls::SwipeHandlerFinishData();
 		}
 		if (_emojiStatusPanel && _emojiStatusPanel->hasFocus()) {


### PR DESCRIPTION
Swipe reply now targets the exact grouped media item under the cursor/finger instead of always replying to the first item in the group.
