### PR TITLE
Support Shift+click to extend message text selection

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -1916,10 +1916,13 @@ void HistoryInner::mousePressEvent(QMouseEvent *e) {
 	}
 	_mouseActive = true;
 	registerReadMetricsActivity();
-	mouseActionStart(e->globalPos(), e->button());
+	mouseActionStart(e->globalPos(), e->button(), e->modifiers());
 }
 
-void HistoryInner::mouseActionStart(const QPoint &screenPos, Qt::MouseButton button) {
+void HistoryInner::mouseActionStart(
+		const QPoint &screenPos,
+		Qt::MouseButton button,
+		Qt::KeyboardModifiers modifiers) {
 	mouseActionUpdate(screenPos);
 	if (button != Qt::LeftButton) return;
 
@@ -1998,7 +2001,26 @@ void HistoryInner::mouseActionStart(const QPoint &screenPos, Qt::MouseButton but
 						}
 					}
 				}
-				if (uponSelected) {
+				const auto canShiftExtend = (modifiers & Qt::ShiftModifier)
+					&& (_selected.size() == 1)
+					&& (_selected.cbegin()->first == _mouseActionItem)
+					&& (_selected.cbegin()->second != FullSelection)
+					&& (_selected.cbegin()->second.from
+						!= _selected.cbegin()->second.to);
+				if (canShiftExtend) {
+					const auto symbol = dragState.afterSymbol
+						? uint16(_mouseTextSymbol + 1)
+						: _mouseTextSymbol;
+					const auto extended = HistoryView::ExtendTextSelectionTo(
+						_selected.cbegin()->second,
+						symbol);
+					_mouseTextSymbol = (extended.from == symbol)
+						? extended.to
+						: extended.from;
+					_selected.begin()->second = extended;
+					_mouseAction = MouseAction::Selecting;
+					repaintItem(_mouseActionItem);
+				} else if (uponSelected) {
 					_mouseAction = MouseAction::PrepareDrag; // start text drag
 				} else if (!_pressWasInactive) {
 					if (_mouseCursorState == CursorState::Date) {

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -345,7 +345,10 @@ private:
 	void scrollDateHideByTimer();
 	void scrollDateCheckDownward();
 	bool canHaveFromUserpics() const;
-	void mouseActionStart(const QPoint &screenPos, Qt::MouseButton button);
+	void mouseActionStart(
+		const QPoint &screenPos,
+		Qt::MouseButton button,
+		Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 	void mouseActionUpdate();
 	void mouseActionUpdate(const QPoint &screenPos);
 	void mouseActionFinish(const QPoint &screenPos, Qt::MouseButton button);

--- a/Telegram/SourceFiles/history/view/history_view_element.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_element.cpp
@@ -643,6 +643,17 @@ TextSelection ShiftItemSelection(
 	return ShiftItemSelection(selection, byText.length());
 }
 
+TextSelection ExtendTextSelectionTo(
+		TextSelection current,
+		uint16 symbol) {
+	const auto anchor = (symbol * 2 < current.from + current.to)
+		? current.to
+		: current.from;
+	return TextSelection(
+		std::min(symbol, anchor),
+		std::max(symbol, anchor));
+}
+
 QString DateTooltipText(not_null<Element*> view) {
 	const auto locale = QLocale();
 	const auto format = QLocale::LongFormat;

--- a/Telegram/SourceFiles/history/view/history_view_element.h
+++ b/Telegram/SourceFiles/history/view/history_view_element.h
@@ -245,6 +245,10 @@ TextSelection ShiftItemSelection(
 	TextSelection selection,
 	const Ui::Text::String &byText);
 
+[[nodiscard]] TextSelection ExtendTextSelectionTo(
+	TextSelection current,
+	uint16 symbol);
+
 QString DateTooltipText(not_null<Element*> view);
 
 // Any HistoryView::Element can have this Component for

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -3172,7 +3172,7 @@ void ListWidget::mousePressEvent(QMouseEvent *e) {
 	}
 	_mouseActive = true;
 	registerReadMetricsActivity();
-	mouseActionStart(e->globalPos(), e->button());
+	mouseActionStart(e->globalPos(), e->button(), e->modifiers());
 }
 
 void ListWidget::onTouchScrollTimer() {
@@ -3650,7 +3650,8 @@ void ListWidget::clearDragSelection() {
 
 void ListWidget::mouseActionStart(
 		const QPoint &globalPosition,
-		Qt::MouseButton button) {
+		Qt::MouseButton button,
+		Qt::KeyboardModifiers modifiers) {
 	mouseActionUpdate(globalPosition);
 	if (button != Qt::LeftButton) {
 		return;
@@ -3713,7 +3714,24 @@ void ListWidget::mouseActionStart(
 		}
 		if (_mouseSelectType != TextSelectType::Paragraphs) {
 			_mouseTextSymbol = dragState.symbol;
-			if (isPressInSelectedText(dragState)) {
+			const auto canShiftExtend = (modifiers & Qt::ShiftModifier)
+				&& (dragState.cursor == CursorState::Text)
+				&& (_selectedTextItem == pressElement->data())
+				&& (_selectedTextRange != FullSelection)
+				&& (_selectedTextRange.from != _selectedTextRange.to);
+			if (canShiftExtend) {
+				const auto symbol = dragState.afterSymbol
+					? uint16(_mouseTextSymbol + 1)
+					: _mouseTextSymbol;
+				const auto extended = ExtendTextSelectionTo(
+					_selectedTextRange,
+					symbol);
+				_mouseTextSymbol = (extended.from == symbol)
+					? extended.to
+					: extended.from;
+				setTextSelection(pressElement, extended);
+				_mouseAction = MouseAction::Selecting;
+			} else if (isPressInSelectedText(dragState)) {
 				_mouseAction = MouseAction::PrepareDrag; // start text drag
 			} else if (!_pressWasInactive) {
 				if (requiredToStartDragging(pressElement)

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -582,7 +582,8 @@ private:
 
 	void mouseActionStart(
 		const QPoint &globalPosition,
-		Qt::MouseButton button);
+		Qt::MouseButton button,
+		Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 	void mouseActionUpdate(const QPoint &globalPosition);
 	void mouseActionUpdate();
 	void mouseActionFinish(


### PR DESCRIPTION
When a message has selected text, `Shift+click` in the same message now extends the selection to the click point, just like in browsers. Previously, `Shift+click` simply dropped the old selection and started a new one.

Works in regular chats, channels, topics, replies, pinned, and scheduled messages.

How to try: select a few words in a message, then `Shift+click` somewhere else in the same message - the selection should extend to the click point.