### PR TITLE
Fix possible packet loss 

### DIFF
--- a/Telegram/SourceFiles/tde2e/tde2e_api.cpp
+++ b/Telegram/SourceFiles/tde2e/tde2e_api.cpp
@@ -331,18 +331,18 @@ void Call::setId(CallId id) {
 }
 
 void Call::checkForOutboundMessages() {
-    Expects(_id);
+	Expects(_id);
 
-    const auto result = tde2e_api::call_pull_outbound_messages(libId());
-    if (!result.is_ok()) {
-        LOG_AND_FAIL(result.error(), CallFailure::Unknown);
-        return;
-    }
+	const auto result = tde2e_api::call_pull_outbound_messages(libId());
+	if (!result.is_ok()) {
+		LOG_AND_FAIL(result.error(), CallFailure::Unknown);
+		return;
+	}
 
-    for (const auto &message : result.value()) {
-        _outboundBlocks.fire(
-            QByteArray::fromStdString(message));
-    }
+	for (const auto &message : result.value()) {
+		_outboundBlocks.fire(
+			QByteArray::fromStdString(message));
+	}
 }
 
 void Call::apply(

--- a/Telegram/SourceFiles/tde2e/tde2e_api.cpp
+++ b/Telegram/SourceFiles/tde2e/tde2e_api.cpp
@@ -331,16 +331,18 @@ void Call::setId(CallId id) {
 }
 
 void Call::checkForOutboundMessages() {
-	Expects(_id);
+    Expects(_id);
 
-	const auto result = tde2e_api::call_pull_outbound_messages(libId());
-	if (!result.is_ok()) {
-		LOG_AND_FAIL(result.error(), CallFailure::Unknown);
-		return;
-	} else if (!result.value().empty()) {
-		_outboundBlocks.fire(
-			QByteArray::fromStdString(result.value().back()));
-	}
+    const auto result = tde2e_api::call_pull_outbound_messages(libId());
+    if (!result.is_ok()) {
+        LOG_AND_FAIL(result.error(), CallFailure::Unknown);
+        return;
+    }
+
+    for (const auto &message : result.value()) {
+        _outboundBlocks.fire(
+            QByteArray::fromStdString(message));
+    }
 }
 
 void Call::apply(


### PR DESCRIPTION
This fixes a possible outbound E2E packet loss issue in `Call::checkForOutboundMessages()`.

Previously, only the last message returned by `call_pull_outbound_messages()` was forwarded:

```cpp
result.value().back()
```

However, the API returns a collection of outbound messages, so multiple pending packets could be dropped if more than one message was queued between polls.

The updated implementation forwards all outbound messages in order instead of only the last one.
