### PR TITLE
Fixed a warning by removing unused function.

### DIFF
--- a/Telegram/SourceFiles/iv/markdown/iv_markdown_view.cpp
+++ b/Telegram/SourceFiles/iv/markdown/iv_markdown_view.cpp
@@ -44,6 +44,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Iv::Markdown {
 namespace {
 
+#ifndef NDEBUG
 [[nodiscard]] QString PrepareTerminalFailureName(
 		PrepareTerminalFailure failure) {
 	switch (failure) {
@@ -67,6 +68,7 @@ namespace {
 		? failure.debugReason
 		: PrepareTerminalFailureName(failure.terminal);
 }
+#endif
 
 [[nodiscard]] QVariant CurrentClickHandlerContext(const OpenOptions &options) {
 	return options.clickHandlerContextRef


### PR DESCRIPTION
/wrkdirs/usr/ports/net-im/telegram-desktop/work/tdesktop-6.8.3-full/Telegram/SourceFiles/iv/markdown/iv_markdown_view.cpp:64:23: warning: unused function 'PrepareFailureReasonText' [-Wunused-function]
   64 | [[nodiscard]] QString PrepareFailureReasonText(
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.