### PR TITLE
Fix duplicate Todo List item IDs (TODO_ITEM_DUPLICATE)

### DIFF
--- a/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
@@ -564,7 +564,7 @@ std::vector<TodoListItem> Tasks::toTodoListItems() const {
 	auto usedId = 0;
 	for (const auto &task : _list) {
 		if (const auto id = task->id()) {
-			usedId = id;
+			usedId = id > usedId ? id : usedId;
 		} else if (task->isGood()) {
 			++usedId;
 		}


### PR DESCRIPTION
## Fix duplicate Todo List item IDs (`TODO_ITEM_DUPLICATE`)

This PR fixes an issue in Todo List item ID generation that could lead to duplicate IDs being produced and rejected by Telegram with the `TODO_ITEM_DUPLICATE` error.

### Problem

Previously, `usedId` was directly overwritten whenever a task already had an ID:

```cpp
if (const auto id = task->id()) {
    usedId = id;
}
```

This caused a regression scenario when tasks were not strictly ordered by ascending IDs.
For example, if a task with a smaller existing ID appeared after a larger one, `usedId` would move backwards, allowing newly generated IDs to collide with already used IDs.

### Fix

The new logic ensures that `usedId` always keeps the highest ID encountered so far:

```cpp
if (const auto id = task->id()) {
    usedId = id > usedId ? id : usedId;
}
```

This guarantees that auto-generated IDs continue monotonically and prevents duplicate Todo List item IDs from being generated.
