### PR TITLE
fix: clickable timestamps in blockquote

### DIFF
--- a/Telegram/SourceFiles/history/view/media/history_view_media.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_media.cpp
@@ -161,9 +161,13 @@ TextWithEntities AddTimestampLinks(
 			from,
 			std::less<>(),
 			&EntityInText::offset);
+		const auto allowsTimestampLink = [](const EntityInText &entity) {
+			return (entity.type() == EntityType::Spoiler)
+				|| (entity.type() == EntityType::Blockquote);
+		};
 		while (i != entities.end()
 			&& i->offset() < till
-			&& i->type() == EntityType::Spoiler) {
+			&& allowsTimestampLink(*i)) {
 			++i;
 		}
 		if (i != entities.end() && i->offset() < till) {
@@ -172,7 +176,7 @@ TextWithEntities AddTimestampLinks(
 
 		const auto intersects = [&](const EntityInText &entity) {
 			return (entity.offset() + entity.length() > from)
-				&& (entity.type() != EntityType::Spoiler);
+				&& !allowsTimestampLink(entity);
 		};
 		auto j = std::make_reverse_iterator(i);
 		const auto e = std::make_reverse_iterator(entities.begin());


### PR DESCRIPTION
Fixes #30163

<img width="450" height="187" alt="{48242FD3-627A-4A5D-B8EA-DEC86D3E45F6}" src="https://github.com/user-attachments/assets/987acc87-383f-4cf1-b269-675767d8a3ec" />
