### PR TITLE
fix: follow links in timestamps in blockquote

### DIFF
--- a/Telegram/SourceFiles/history/view/media/history_view_media.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_media.cpp
@@ -156,32 +156,28 @@ TextWithEntities AddTimestampLinks(
 		}
 
 		auto &entities = text.entities;
+		const auto allowsTimestampLink = [](const EntityInText &entity) {
+			return (entity.type() == EntityType::Spoiler)
+				|| (entity.type() == EntityType::Blockquote);
+		};
+		const auto intersectsTimestamp = [&](const EntityInText &entity) {
+			return (entity.offset() < till)
+				&& (entity.offset() + entity.length() > from);
+		};
+		if (ranges::any_of(entities, [&](const EntityInText &entity) {
+			return intersectsTimestamp(entity) && !allowsTimestampLink(entity);
+		})) {
+			continue;
+		}
 		auto i = ranges::lower_bound(
 			entities,
 			from,
 			std::less<>(),
 			&EntityInText::offset);
-		const auto allowsTimestampLink = [](const EntityInText &entity) {
-			return (entity.type() == EntityType::Spoiler)
-				|| (entity.type() == EntityType::Blockquote);
-		};
 		while (i != entities.end()
 			&& i->offset() < till
 			&& allowsTimestampLink(*i)) {
 			++i;
-		}
-		if (i != entities.end() && i->offset() < till) {
-			continue;
-		}
-
-		const auto intersects = [&](const EntityInText &entity) {
-			return (entity.offset() + entity.length() > from)
-				&& !allowsTimestampLink(entity);
-		};
-		auto j = std::make_reverse_iterator(i);
-		const auto e = std::make_reverse_iterator(entities.begin());
-		if (std::find_if(j, e, intersects) != e) {
-			continue;
 		}
 
 		entities.insert(


### PR DESCRIPTION
Found a small issue in #30713

If a timestamp is in a blockquote and has an embedded link, clicking it should follow the link instead of the timestamp.
This is how it currently works for timestamps with embedded links located outside of a quote.

<img width="453" height="143" alt="{CB5F3B54-1BB2-4322-B252-C89557CD12FC}" src="https://github.com/user-attachments/assets/ab4f4bb9-0c39-4465-95bc-dfba215cfc0f" />

