### PR TITLE
Reload web view when reopening different inline button

### DIFF
--- a/Telegram/SourceFiles/api/api_bot.cpp
+++ b/Telegram/SourceFiles/api/api_bot.cpp
@@ -505,7 +505,10 @@ void ActivateBotCommand(ClickHandlerContext context, int row, int column) {
 				.bot = bot,
 				.context = { .controller = controller },
 				.button = { .text = button->text, .url = button->data },
-				.source = InlineBots::WebViewSourceButton{ .simple = false },
+				.source = InlineBots::WebViewSourceButton{
+					.url = button->data,
+					.simple = false,
+				},
 			});
 		}
 	} break;
@@ -516,7 +519,10 @@ void ActivateBotCommand(ClickHandlerContext context, int row, int column) {
 				.bot = bot,
 				.context = { .controller = controller },
 				.button = { .text = button->text, .url = button->data },
-				.source = InlineBots::WebViewSourceButton{ .simple = true },
+				.source = InlineBots::WebViewSourceButton{
+					.url = button->data,
+					.simple = true,
+				},
 			});
 		}
 	} break;

--- a/Telegram/SourceFiles/inline_bots/bot_attach_web_view.h
+++ b/Telegram/SourceFiles/inline_bots/bot_attach_web_view.h
@@ -84,11 +84,12 @@ struct AttachWebViewBot {
 };
 
 struct WebViewSourceButton {
+	QByteArray url;
 	bool simple = false;
 
 	friend inline bool operator==(
-		WebViewSourceButton,
-		WebViewSourceButton) = default;
+		const WebViewSourceButton &,
+		const WebViewSourceButton &) = default;
 };
 
 struct WebViewSourceSwitch {


### PR DESCRIPTION
## Problem

Fixes #29475.

When two inline keyboard buttons in the same chat point to different web app URLs of the same bot, clicking the second one while the first web app panel is still open silently does nothing — the new URL is not loaded and no event (`themeChanged`, `viewportChanged`, etc.) is fired inside the running web app.

## Root cause

`AttachWebView::open()` deduplicates by `(bot, source)`:

```cpp
for (const auto &instance : _instances) {
    if (instance->bot() == descriptor.bot
        && instance->source() == descriptor.source) {
        instance->activate();
        return;
    }
}
```

For inline buttons the source is built in `api/api_bot.cpp` as

```cpp
.source = InlineBots::WebViewSourceButton{ .simple = false },
```

`WebViewSourceButton` only stores the `simple` flag, so two different inline buttons of the same bot always compare equal. The match succeeds and `activate()` just calls `_panel->requestActivate()` on the existing panel, ignoring the new URL entirely.

## Fix

Include the button URL in `WebViewSourceButton` so distinct URLs produce distinct sources, and a fresh `WebViewInstance` is created (matching how, e.g., MainMenu and InlineButton already coexist for the same bot).

* `Telegram/SourceFiles/inline_bots/bot_attach_web_view.h` — add `QByteArray url` to `WebViewSourceButton`, switch the defaulted `operator==` to by-const-ref since the struct is no longer trivial enough to pass by value cleanly.
* `Telegram/SourceFiles/api/api_bot.cpp` — pass `button->data` as the new `url` field in both `ButtonType::WebView` and `ButtonType::SimpleWebView` paths.

Clicking the same button twice still hits the dedup path (URL is identical) and only re-activates the existing panel — previous behavior preserved.

## Out of scope

The original issue also mentions the `deactivated` event not firing when tapping outside the panel. That lives in `Ui::BotWebView::Panel` and is a separate change.

## Test plan

- [ ] Open inline web app A from bot, then click inline button opening web app B of the same bot — B should load in its own panel.
- [ ] Click the same inline button twice — second click should just re-focus the existing panel, no reload.
- [ ] Regression: open Main Menu web app, then open inline button web app of the same bot — both should keep working independently as before.