### PR TITLE
Add top player seeking for voice and round video messages

### DIFF
--- a/Telegram/SourceFiles/media/player/media_player_widget.cpp
+++ b/Telegram/SourceFiles/media/player/media_player_widget.cpp
@@ -109,16 +109,10 @@ Widget::Widget(
 		_playbackSlider->setValue(value);
 	});
 	_playbackSlider->setChangeProgressCallback([=](float64 value) {
-		if (_type != AudioMsgId::Type::Song) {
-			return; // Round video seek is not supported for now :(
-		}
 		_playbackProgress->setValue(value, false);
 		handleSeekProgress(value);
 	});
 	_playbackSlider->setChangeFinishedCallback([=](float64 value) {
-		if (_type != AudioMsgId::Type::Song) {
-			return; // Round video seek is not supported for now :(
-		}
 		_playbackProgress->setValue(value, false);
 		handleSeekFinished(value);
 	});
@@ -292,7 +286,7 @@ void Widget::setShadowGeometryToLeft(int x, int y, int w, int h) {
 
 void Widget::showShadowAndDropdowns() {
 	_shadow->show();
-	_playbackSlider->setVisible(_type == AudioMsgId::Type::Song);
+	_playbackSlider->show();
 	if (_volumeHidden) {
 		_volumeHidden = false;
 		_volume->show();
@@ -612,9 +606,6 @@ void Widget::updateControlsVisibility() {
 	_repeatToggle->setVisible(_type == AudioMsgId::Type::Song);
 	_orderToggle->setVisible(_type == AudioMsgId::Type::Song);
 	_speedToggle->setVisible(hasPlaybackSpeedControl());
-	if (!_shadow->isHidden()) {
-		_playbackSlider->setVisible(_type == AudioMsgId::Type::Song);
-	}
 	updateControlsGeometry();
 }
 


### PR DESCRIPTION
Fixes #28889

This enables the top media player progress slider for voice and round video messages and lets it use the existing seek path.

The top media player already has a seekable progress slider for music. The same control is useful for voice and round video messages when playback continues while the user is in another chat. For example, when listening to a long voice message or watching a video message in the background from a different chat, the top player should still allow seeking within the currently playing message.

Based on the existing Materialgram implementation:
  - kukuruzka165/materialgram@76a5c1384f
  - kukuruzka165/materialgram@7bf0c6abdc
