### PR TITLE
Fix system accent color Windows option condition

### DIFF
--- a/Telegram/SourceFiles/window/themes/window_themes_embedded.cpp
+++ b/Telegram/SourceFiles/window/themes/window_themes_embedded.cpp
@@ -181,7 +181,7 @@ style::colorizer ColorizerFrom(
 
 std::optional<QColor> SystemAccentColor() {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	if (Platform::IsWindows() && !Platform::IsWindows8OrGreater()) {
+	if (Platform::IsWindows() && Platform::IsWindows8OrGreater()) {
 		return std::nullopt;
 	}
 #endif // Qt < 6.0.0


### PR DESCRIPTION
It actually works only on Windows 7 with Qt 5

Regression was introduced in 786e8999e18fc44baaf96162c82f2cfddfd766d2