### PR TITLE
Update jom download link to version 1.1.7

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -497,7 +497,7 @@ win:
 
 stage('jom', """
 win:
-    powershell -Command "iwr -OutFile ./jom.zip https://master.qt.io/official_releases/jom/jom_1_1_3.zip"
+    powershell -Command "iwr -OutFile ./jom.zip https://master.qt.io/official_releases/jom/jom_1_1_7.zip"
     powershell -Command "Expand-Archive ./jom.zip"
     del jom.zip
 """, 'ThirdParty')


### PR DESCRIPTION
This is the changelog for jom 1.1.7, the parallel make tool.

Changes since jom 1.1.6
- Fixed a regression that was introduced in 1.1.4. Setting a variable on the command line did not set the corresponding environment variable anymore (QTCREATORBUG-34156).
- Fixed case-sensitive matching of inference rule extensions (QTCREATORBUG-34174).

Changes since jom 1.1.5
- Fixed a regression that led to inference rules not being applied if the target already had commands (QTCREATORBUG-33978).

Changes since jom 1.1.4
- Fixed compound defined() preprocessor expressions (QTCREATORBUG-24134).
- A leading hyphen in MAKEFLAGS is now ignored.
- Fixed !else if preprocessor expressions (QTCREATORBUG-32129).