### PR TITLE
Update jom and zlib versions in prepare.py

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -497,7 +497,7 @@ win:
 
 stage('jom', """
 win:
-    powershell -Command "iwr -OutFile ./jom.zip https://master.qt.io/official_releases/jom/jom_1_1_3.zip"
+    powershell -Command "iwr -OutFile ./jom.zip https://master.qt.io/official_releases/jom/jom_1_1_7.zip"
     powershell -Command "Expand-Archive ./jom.zip"
     del jom.zip
 """, 'ThirdParty')
@@ -541,7 +541,7 @@ stage('xz', """
 """)
 
 stage('zlib', """
-    git clone -b v1.3.1 https://github.com/madler/zlib.git
+    git clone -b v1.3.2 https://github.com/madler/zlib.git
     cd zlib
 win:
     cmake . ^


### PR DESCRIPTION
Version 1.3.2 has these key changes:

Address the findings of the just-completed 7ASecurity audit Completely rewrite the cmake support (thanks to @Vollstrecker) Support non-blocking devices with the gz* functions Many other enhancements, fixes, and portability improvements