### PR TITLE
Update libheif version to v1.23.0

### DIFF
--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -947,7 +947,7 @@ mac:
 """)
 
 stage('libheif', """
-    git clone -b v1.21.2 https://github.com/strukturag/libheif.git
+    git clone -b v1.23.0 https://github.com/strukturag/libheif.git
     cd libheif
 win:
     %THIRDPARTY_DIR%\\msys64\\usr\\bin\\sed.exe -i 's/LIBHEIF_EXPORTS/LIBDE265_STATIC_BUILD/g' libheif/CMakeLists.txt


### PR DESCRIPTION
This is a smaller release that adds API functions to read and write metadata:

ambient viewing environment
nominal diffuse white luminance
It also adds a output_image_nclx_profile_passthrough option to heif_decoding_options to pass through the input image NCLX without doing any internal color conversion.