### PR TITLE
Fix accessibility for PeerList (NVDA Screen Reader)

### DIFF
--- a/Telegram/SourceFiles/boxes/peer_list_box.cpp
+++ b/Telegram/SourceFiles/boxes/peer_list_box.cpp
@@ -2334,6 +2334,11 @@ void PeerListContent::setSelected(Selected selected) {
 	setCursor(_selected.element ? style::cur_pointer : style::cur_default);
 
 	_selectedIndex = _selected.index.value;
+
+	if (_selectedIndex >= 0) {
+		accessibilityChildNameChanged(_selectedIndex);
+		accessibilityChildFocused(_selectedIndex);
+	}
 }
 
 void PeerListContent::setContexted(Selected contexted) {
@@ -2530,6 +2535,61 @@ void PeerListContent::handleNameChanged(not_null<PeerData*> peer) {
 PeerListContent::~PeerListContent() {
 	if (_contextMenu) {
 		_contextMenu->setDestroyedCallback(nullptr);
+	}
+}
+
+QAccessible::Role PeerListContent::accessibilityRole() {
+	return QAccessible::List;
+}
+
+Qt::FocusPolicy PeerListContent::accessibilityFocusPolicy() {
+	return Qt::TabFocus;
+}
+
+QAccessible::Role PeerListContent::accessibilityChildRole() const {
+	return QAccessible::ListItem;
+}
+
+QAccessible::State PeerListContent::accessibilityChildState(
+		int index) const {
+	QAccessible::State state;
+	state.selectable = true;
+	state.focusable = true;
+	if (index == _selected.index.value) {
+		state.selected = true;
+		state.active = true;
+		if (hasFocus()) {
+			state.focused = true;
+		}
+	}
+	return state;
+}
+
+int PeerListContent::accessibilityChildCount() const {
+	return shownRowsCount();
+}
+
+QString PeerListContent::accessibilityChildName(int index) const {
+	if (auto row = const_cast<PeerListContent*>(this)->getRow(RowIndex(index))) {
+		return row->name().toString();
+	}
+	return QString();
+}
+
+QRect PeerListContent::accessibilityChildRect(int index) const {
+	if (index >= 0 && index < shownRowsCount()) {
+		return QRect(0, getRowTop(RowIndex(index)), width(), _rowHeight);
+	}
+	return QRect();
+}
+
+void PeerListContent::focusInEvent(QFocusEvent *e) {
+	if (_selected.index.value < 0 && shownRowsCount() > 0) {
+		setSelected(Selected(0, 0));
+	}
+	RpWidget::focusInEvent(e);
+	if (_selected.index.value >= 0 && hasFocus()) {
+		accessibilityChildFocused(_selected.index.value);
 	}
 }
 

--- a/Telegram/SourceFiles/boxes/peer_list_box.h
+++ b/Telegram/SourceFiles/boxes/peer_list_box.h
@@ -752,7 +752,16 @@ public:
 		return _noSearchSubmits.events();
 	}
 
+	QAccessible::Role accessibilityRole() override;
+	Qt::FocusPolicy accessibilityFocusPolicy() override;
+	QAccessible::Role accessibilityChildRole() const override;
+	QAccessible::State accessibilityChildState(int index) const override;
+	int accessibilityChildCount() const override;
+	QString accessibilityChildName(int index) const override;
+	QRect accessibilityChildRect(int index) const override;
+
 	~PeerListContent();
+
 
 protected:
 	int resizeGetHeight(int newWidth) override;
@@ -761,6 +770,7 @@ protected:
 		int visibleBottom) override;
 
 	void paintEvent(QPaintEvent *e) override;
+	void focusInEvent(QFocusEvent *e) override;
 	void enterEventHook(QEnterEvent *e) override;
 	void leaveEventHook(QEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;


### PR DESCRIPTION
This PR fixes a critical accessibility issue where NVDA and other screen readers fail to read the names of contacts, blocked users, and group members in the application.

It implements the missing QAccessible overrides for PeerListContent, allowing it to announce its ListItem children's name and status, and emit focus events when the selection changes via keyboard arrows or mouse.

Tested locally with NVDA and Windows accessibility features.