### PR TITLE
Engage chat search on typing instead of focus in screen reader mode

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -44,6 +44,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/controls/swipe_handler.h"
 #include "ui/painter.h"
 #include "ui/rect.h"
+#include "ui/screen_reader_mode.h"
 #include "ui/ui_utility.h"
 #include "lang/lang_keys.h"
 #include "mainwindow.h"
@@ -1773,8 +1774,12 @@ void Widget::processSearchFocusChange() {
 	updateSuggestions(anim::type::normal);
 }
 
+bool Widget::searchActive() const {
+	return Ui::ScreenReaderModeActive() ? _searchEngaged : _searchHasFocus;
+}
+
 void Widget::updateSuggestions(anim::type animated) {
-	const auto suggest = (_searchHasFocus || _searchSuggestionsLocked)
+	const auto suggest = (searchActive() || _searchSuggestionsLocked)
 		&& !_searchState.inChat
 		&& (_inner->state() == WidgetState::Default);
 	if (anim::Disabled() || !session().data().chatsListLoaded()) {
@@ -3363,7 +3368,7 @@ void Widget::listScrollUpdated() {
 void Widget::updateCancelSearch() {
 	const auto shown = !_searchState.query.isEmpty()
 		|| (!_searchState.inChat
-			&& (_searchHasFocus || _searchSuggestionsLocked));
+			&& (searchActive() || _searchSuggestionsLocked));
 	_cancelSearch->toggle(shown, anim::type::normal);
 	if (_searchState.inChat) {
 		_cancelSearch->setAccessibleName(shown
@@ -3400,6 +3405,9 @@ QString Widget::validateSearchQuery() {
 void Widget::applySearchUpdate() {
 	auto copy = _searchState;
 	copy.query = validateSearchQuery();
+	if (Ui::ScreenReaderModeActive() && !copy.query.isEmpty()) {
+		_searchEngaged = true;
+	}
 	applySearchState(std::move(copy));
 
 	if (_chooseFromUser->toggled()
@@ -4173,7 +4181,8 @@ void Widget::keyPressEvent(QKeyEvent *e) {
 		//} else {
 		//	e->ignore();
 		//}
-	} else if ((e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Tab)
+	} else if ((e->key() == Qt::Key_Backspace
+			|| (e->key() == Qt::Key_Tab && !Ui::ScreenReaderModeActive()))
 		&& _searchHasFocus
 		&& !_searchState.inChat
 		&& _searchState.query.isEmpty()) {
@@ -4404,6 +4413,7 @@ void Widget::setSearchQuery(const QString &query, int cursorPosition) {
 }
 
 bool Widget::cancelSearch(CancelSearchOptions options) {
+	_searchEngaged = false;
 	const auto clearingSuggestionsQuery = _suggestions
 		&& _suggestions->consumeSearchQuery(QString());
 	if (clearingSuggestionsQuery) {

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.h
@@ -291,6 +291,7 @@ private:
 	void updateSuggestions(anim::type animated);
 	void processSearchFocusChange();
 	void closeSuggestions();
+	[[nodiscard]] bool searchActive() const;
 
 	[[nodiscard]] bool redirectToSearchPossible() const;
 	[[nodiscard]] bool redirectKeyToSearch(QKeyEvent *e) const;
@@ -373,6 +374,7 @@ private:
 	QString _lastSearchText;
 	bool _searchSuggestionsLocked = false;
 	bool _searchHasFocus = false;
+	bool _searchEngaged = false;
 	bool _processingSearch = false;
 
 	rpl::event_stream<rpl::producer<Stories::Content>> _storiesContents;


### PR DESCRIPTION
## Summary

In **screen reader mode** (`Ui::ScreenReaderModeActive()`), the chat-list (dialogs) search field becomes **engagement-driven** instead of **focus-driven**:

- Focusing the search field alone does **nothing** — no suggestions panel (recent / top peers), no cancel-search button, the chat list is undisturbed.
- Search **engages** when the user types the first character.
- It **stays engaged** even if the user deletes all typed text back to empty.
- It **disengages only** on an explicit **Escape** or the **cancel-search button**.
- **Tab / Backspace** on an empty query no longer exit search in this mode, so they no longer tear down the search state on the way out.

For sighted / mouse users (screen reader not active) the behavior is **unchanged** — focusing the field still activates suggestions and the cancel button exactly as before.

## Motivation

With keyboard / screen-reader navigation, focus and content are separate events. The previous focus-driven activation made the entire left panel react to merely *landing* on the search field while Tab-navigating, and then tear back down as Tab moved past it (the field is the first focusable child, so it is unavoidably traversed). Tying activation to typed content removes that churn for screen-reader users while leaving the mouse experience untouched.

## Implementation

- New `bool _searchEngaged` member and a `searchActive()` helper returning `Ui::ScreenReaderModeActive() ? _searchEngaged : _searchHasFocus`.
- `updateSuggestions()` and `updateCancelSearch()` now consult `searchActive()` instead of `_searchHasFocus` (the `_searchSuggestionsLocked` and query-non-empty terms are unchanged).
- `_searchEngaged` is set in `applySearchUpdate()` on a non-empty query, and reset at the top of `cancelSearch()` (the single funnel for both Escape, via `escape()`, and the cancel-search button).
- The Tab/Backspace "exit on empty query" branch in `keyPressEvent()` is guarded with `!Ui::ScreenReaderModeActive()`.

No behavior changes outside screen reader mode; the non-screen-reader code paths are equivalent to before.