### PR TITLE
Redirect chat list typing to the search field in screen reader mode

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -5829,6 +5829,8 @@ void InnerWidget::keyPressEvent(QKeyEvent *e) {
 		chooseRow();
 		return;
 	}
+	// Leave unhandled keys (e.g. typed characters) for the parent
+	// Dialogs::Widget, whose keyPressEvent redirects them to search.
 	RpWidget::keyPressEvent(e);
 }
 

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -4240,7 +4240,7 @@ bool Widget::redirectToSearchPossible() const {
 		&& !_childList
 		&& _search->isVisible()
 		&& !_search->hasFocus()
-		&& hasFocus();
+		&& (hasFocus() || _inner->hasFocus());
 }
 
 bool Widget::redirectKeyToSearch(QKeyEvent *e) const {


### PR DESCRIPTION
﻿> **Depends on desktop-app/lib_ui#308** - please merge that first. Without it the typed key is swallowed by `ElasticScroll` before it can reach `Dialogs::Widget`.

## Summary

In screen reader mode the chat list (`InnerWidget`) takes keyboard focus so rows can be navigated with the arrow keys. Typing a printable character there previously did nothing. This makes such a keystroke redirect into the search field (focusing it and inserting the character), so the user no longer has to Tab into the search field first.

Nothing changes for sighted/mouse users: the chat list does not take keyboard focus, so this path is not reached.

## Implementation

- `InnerWidget::keyPressEvent` simply leaves unhandled keys to its parent (the existing `RpWidget::keyPressEvent` ignores them), so a typed character propagates up to `Dialogs::Widget`.
- `Dialogs::Widget::keyPressEvent` already routes such keys through `redirectKeyToSearch()`; the only change needed is widening `redirectToSearchPossible()` to also allow the redirect when the list has focus (`hasFocus() || _inner->hasFocus()`).

The propagation works because of the companion lib_ui change (desktop-app/lib_ui#308), which makes `ElasticScroll` ignore keys it does not handle instead of silently accepting them.
