### PR TITLE
Add Chats accessibility automation id to the chat list

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -300,6 +300,7 @@ InnerWidget::InnerWidget(
 , _freezeTimer([=] { _shownList->unfreeze(); update(); }) {
 	setAttribute(Qt::WA_OpaquePaintEvent, true);
 	setAccessibleName(tr::lng_recent_chats(tr::now));
+	setObjectName(u"Chats"_q);
 
 	style::PaletteChanged(
 	) | rpl::on_next([=] {


### PR DESCRIPTION
﻿## Summary

Sets the object name of the dialogs chat list (`Dialogs::InnerWidget`, accessibility role `List`) to `Chats`, so it is exposed with a stable UI Automation **AutomationId** of `Chats`.

Without an explicit object name the chat list has no AutomationId at all (Qt builds it from the object-name chain, and the list own object name is unset), so UI automation and accessibility tooling have no stable handle for it. A fixed AutomationId gives them a reliable, language-independent way to locate the chat list. (To be precise: the AutomationId is not derived from the localized accessible name - this is about giving the list a stable id, not replacing its name.)

### Why this is useful

Screen-reader users rely on add-ons that bind a hotkey to jump straight to a region of the app - e.g. the UnigramPlus NVDA add-on uses ALT+1 for the chat list, ALT+2 for the message list, etc. Because Unigram exposes no stable ids, that add-on matches localized UI names, and its README warns it "may not work in some localizations" and asks the user to select their interface language. A fixed `Chats` AutomationId lets an equivalent Telegram Desktop add-on locate the chat list regardless of language.

## Implementation

- One line in the `InnerWidget` constructor: `setObjectName(u"Chats"_q);`, alongside the existing `setAccessibleName(...)`.

On the default Windows build (Qt 5.15.19), Qt UIA provider builds the AutomationId by walking the object from itself up through its parents and returning the accumulated name; since the list own object is named `Chats` and its ancestors are unnamed, the resulting AutomationId is exactly `Chats`. On Qt 6 the id is computed differently (an explicit identifier, else a dotted object-name/class-name path), so it would be a path ending in `Chats`. No behavior change for end users.
