### PR TITLE
Fix: ALT + mouse click opens context menu

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -3328,6 +3328,9 @@ void InnerWidget::contextMenuEvent(QContextMenuEvent *e) {
 	const auto fromMouse = e->reason() == QContextMenuEvent::Mouse;
 
 	if (fromMouse) {
+		if (e->modifiers() & Qt::AltModifier) {
+			return;
+		}
 		selectByMouse(e->globalPos());
 	}
 


### PR DESCRIPTION
Telegram has a shortcut ALT + mouse click when you click on a chat in the list. It opens the chat preview menu.

However there is currently a bug: when you press this shortcut, a context menu opens in addition to the preview menu and ~~this context menu is invisible~~ (I switched my wayland compositor since writing this, and now the context menu isn't invisible, it renders on top clearly).

This PR resolves this issue.

<img width="400" height="452" alt="image_2026-08-14_09-20-18" src="https://github.com/user-attachments/assets/dc0c0a1e-3cf0-4e3d-b3c2-c67a7970b84b" />
