### PR TITLE
Land on the chat list on entry for screen readers

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -44,6 +44,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/controls/swipe_handler.h"
 #include "ui/painter.h"
 #include "ui/rect.h"
+#include "ui/screen_reader_mode.h"
 #include "ui/ui_utility.h"
 #include "lang/lang_keys.h"
 #include "mainwindow.h"
@@ -2222,6 +2223,14 @@ void Widget::setInnerFocus(bool unfocusSearch) {
 			|| _searchHasFocus
 			|| _searchSuggestionsLocked)) {
 		_search->setFocus();
+	} else if (Ui::ScreenReaderModeActive()
+		&& _inner
+		&& !_screenReaderListFocused) {
+		// Land on the chat list once, when first entering, for screen
+		// readers - later focus requests (e.g. returning from a section)
+		// keep the default behaviour so they don't steal the focus.
+		_screenReaderListFocused = true;
+		_inner->setFocus();
 	} else {
 		setFocus();
 	}

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.h
@@ -373,6 +373,7 @@ private:
 	QString _lastSearchText;
 	bool _searchSuggestionsLocked = false;
 	bool _searchHasFocus = false;
+	bool _screenReaderListFocused = false;
 	bool _processingSearch = false;
 
 	rpl::event_stream<rpl::producer<Stories::Content>> _storiesContents;


### PR DESCRIPTION
## Summary
When a screen reader is active, focus lands on the chat list (`_inner`) when first entering Telegram, instead of the search field — so the user starts on their conversations. Typing still engages search; it happens **once**, on entry, and later focus requests are unchanged. Scoped to `Ui::ScreenReaderModeActive()`, so sighted users are unaffected.