### PR TITLE
Activate window on swipe-to-reply

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -762,6 +762,7 @@ void HistoryInner::setupSwipeReplyAndBack() {
 				if (!exact) {
 					return;
 				}
+				Window::ActivateWindow(_controller);
 				_widget->replyToMessage({
 					.messageId = exact->fullId(),
 					.quote = selected.highlight.quote,

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
@@ -1098,6 +1098,7 @@ void ChatWidget::setupSwipeReplyAndBack() {
 			if (!exact) {
 				return;
 			}
+			Window::ActivateWindow(controller());
 			_inner->replyToMessageRequestNotify({
 				.messageId = exact->fullId(),
 				.quote = selected.highlight.quote,


### PR DESCRIPTION
## Problem

A touchpad swipe-to-reply works on an *unfocused* window: compositors deliver scroll/gesture events to the window under the pointer without transferring keyboard focus (no click is involved). The swipe opens the reply bar and `setInnerFocus()` puts the caret into the message field, but the window itself stays unfocused — so everything typed goes to the previously focused application.

Reproduced on KDE Plasma 6.6 / Wayland (Kubuntu 26.04) with Telegram Desktop 6.9.1 beta running as a native Wayland client:

1. Focus another app (e.g. a text editor) with the Telegram window still visible.
2. Swipe left on a message in Telegram with the touchpad — the reply bar appears.
3. Type: the text lands in the editor, not in Telegram.

## Fix

Request window activation when a swipe gesture triggers a reply, using the existing `Window::ActivateWindow()` helper that other reply-adjacent flows in `history_widget.cpp` already use. Applied in both swipe-reply call sites: `HistoryInner::setupSwipeReplyAndBack()` and `ChatWidget::setupSwipeReplyAndBack()`.

On Wayland this maps to xdg-activation via Qt; since the user is actively interacting with the surface, the compositor grants the activation (verified against KWin with the default focus-stealing-prevention level). On X11/Windows/macOS the existing `raise()` + `activateWindow()` behavior applies as in the other call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)