### PR TITLE
Throttle concurrent proxy checks

### DIFF
--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -1996,48 +1996,67 @@ auto ProxiesBoxController::proxySettingsValue() const
 }
 
 void ProxiesBoxController::refreshChecker(Item &item) {
-	item.state = ItemState::Checking;
-	const auto id = item.id;
-	MTP::StartProxyCheck(
-		&_account->mtp(),
-		item.data,
-		Core::App().settings().proxy().tryIPv6(),
-		item.checker,
-		item.checkerv6,
-		[=](Connection *raw, int pingTime) {
-			const auto item = ranges::find(
-				_list,
-				id,
-				[](const Item &item) { return item.id; });
-			if (item == end(_list)) {
-				return;
-			}
-			MTP::DropProxyChecker(item->checker, item->checkerv6, raw);
-			MTP::ResetProxyCheckers(item->checker, item->checkerv6);
-			if (item->state == ItemState::Checking) {
-				item->state = ItemState::Available;
-				item->ping = pingTime;
-				updateView(*item);
-			}
-		},
-		[=](Connection *raw) {
-			const auto item = ranges::find(
-				_list,
-				id,
-				[](const Item &item) { return item.id; });
-			if (item == end(_list)) {
-				return;
-			}
-			MTP::DropProxyChecker(item->checker, item->checkerv6, raw);
-			if (!MTP::HasProxyCheckers(item->checker, item->checkerv6)
-				&& item->state == ItemState::Checking) {
-				item->state = ItemState::Unavailable;
-				updateView(*item);
-			}
-		});
-	if (!MTP::HasProxyCheckers(item.checker, item.checkerv6)) {
-		item.state = ItemState::Unavailable;
-	}
+    MTP::ResetProxyCheckers(item.checker, item.checkerv6);
+    item.state = ItemState::Checking;
+    updateView(item);
+    _pendingCheckQueue.push_back(item.id);
+    processCheckQueue();
+}
+
+void ProxiesBoxController::processCheckQueue() {
+    int activeCount = ranges::count_if(_list, [](const Item &item) {
+        return !item.deleted && MTP::HasProxyCheckers(item.checker, item.checkerv6);
+    });
+
+    while (activeCount < kMaxConcurrentChecks && !_pendingCheckQueue.empty()) {
+        int nextId = _pendingCheckQueue.front();
+        _pendingCheckQueue.pop_front();
+        
+        auto it = ranges::find(_list, nextId, [](const Item &item) { return item.id; });
+        
+        if (it != end(_list) && !it->deleted && it->state == ItemState::Checking && !MTP::HasProxyCheckers(it->checker, it->checkerv6)) {
+            
+            const auto id = it->id;
+            MTP::StartProxyCheck(
+                &_account->mtp(),
+                it->data,
+                Core::App().settings().proxy().tryIPv6(),
+                it->checker,
+                it->checkerv6,
+                [=](Connection *raw, int pingTime) {
+                    const auto item = ranges::find(_list, id, [](const Item &item) { return item.id; });
+                    if (item != end(_list)) {
+                        MTP::DropProxyChecker(item->checker, item->checkerv6, raw);
+                        MTP::ResetProxyCheckers(item->checker, item->checkerv6);
+                        if (item->state == ItemState::Checking) {
+                            item->state = ItemState::Available;
+                            item->ping = pingTime;
+                            updateView(*item);
+                        }
+                    }
+                    processCheckQueue(); 
+                },
+                [=](Connection *raw) {
+                    const auto item = ranges::find(_list, id, [](const Item &item) { return item.id; });
+                    if (item != end(_list)) {
+                        MTP::DropProxyChecker(item->checker, item->checkerv6, raw);
+                        if (!MTP::HasProxyCheckers(item->checker, item->checkerv6)
+                            && item->state == ItemState::Checking) {
+                            item->state = ItemState::Unavailable;
+                            updateView(*item);
+                        }
+                    }
+                    processCheckQueue();
+                });
+                
+            if (!MTP::HasProxyCheckers(it->checker, it->checkerv6)) {
+                it->state = ItemState::Unavailable;
+                updateView(*it);
+            } else {
+                activeCount++;
+            }
+        }
+    }
 }
 
 object_ptr<Ui::BoxContent> ProxiesBoxController::CreateOwningBox(

--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -66,6 +66,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace {
 
 constexpr auto kSaveSettingsDelayedTimeout = crl::time(1000);
+constexpr auto kMaxConcurrentChecks = 50;
 
 using ProxyData = MTP::ProxyData;
 
@@ -2009,12 +2010,22 @@ void ProxiesBoxController::processCheckQueue() {
     });
 
     while (activeCount < kMaxConcurrentChecks && !_pendingCheckQueue.empty()) {
-        int nextId = _pendingCheckQueue.front();
+        const auto nextId = _pendingCheckQueue.front();
         _pendingCheckQueue.pop_front();
         
-        auto it = ranges::find(_list, nextId, [](const Item &item) { return item.id; });
-        
-        if (it != end(_list) && !it->deleted && it->state == ItemState::Checking && !MTP::HasProxyCheckers(it->checker, it->checkerv6)) {
+        const auto it = ranges::find(
+			_list,
+			nextId,
+			[](const Item &item) {
+				return item.id;
+			});
+
+		if (it != end(_list)
+			&& !it->deleted
+			&& it->state == ItemState::Checking
+			&& !MTP::HasProxyCheckers(
+				it->checker,
+				it->checkerv6)) {
             
             const auto id = it->id;
             MTP::StartProxyCheck(

--- a/Telegram/SourceFiles/boxes/connection_box.h
+++ b/Telegram/SourceFiles/boxes/connection_box.h
@@ -10,6 +10,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/timer.h"
 #include "base/object_ptr.h"
 #include "core/core_settings_proxy.h"
+#include <deque>
 #include "mtproto/connection_abstract.h"
 #include "mtproto/mtproto_proxy_data.h"
 
@@ -101,6 +102,9 @@ public:
 
 private:
 	using Checker = MTP::details::ConnectionPointer;
+	static constexpr int kMaxConcurrentChecks = 50;
+    std::deque<int> _pendingCheckQueue;
+    void processCheckQueue();
 	struct Item {
 		int id = 0;
 		ProxyData data;

--- a/Telegram/SourceFiles/boxes/connection_box.h
+++ b/Telegram/SourceFiles/boxes/connection_box.h
@@ -10,7 +10,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/timer.h"
 #include "base/object_ptr.h"
 #include "core/core_settings_proxy.h"
-#include <deque>
 #include "mtproto/connection_abstract.h"
 #include "mtproto/mtproto_proxy_data.h"
 
@@ -73,7 +72,6 @@ public:
 		bool supportsShare = false;
 		bool supportsCalls = false;
 		ItemState state = ItemState::Checking;
-
 	};
 
 	void deleteItem(int id);
@@ -102,9 +100,7 @@ public:
 
 private:
 	using Checker = MTP::details::ConnectionPointer;
-	static constexpr int kMaxConcurrentChecks = 50;
-    std::deque<int> _pendingCheckQueue;
-    void processCheckQueue();
+	
 	struct Item {
 		int id = 0;
 		ProxyData data;
@@ -113,9 +109,9 @@ private:
 		Checker checkerv6;
 		ItemState state = ItemState::Checking;
 		int ping = 0;
-
 	};
 
+	void processCheckQueue();
 	std::vector<Item>::iterator findById(int id);
 	std::vector<Item>::iterator findByProxy(const ProxyData &proxy);
 	void setDeleted(int id, bool deleted);
@@ -131,6 +127,7 @@ private:
 		std::vector<Item>::iterator which,
 		const ProxyData &proxy);
 
+	std::deque<int> _pendingCheckQueue;
 	const not_null<Main::Account*> _account;
 	Core::SettingsProxy &_settings;
 	int _idCounter = 0;


### PR DESCRIPTION
Fixes #30776 

Introduces an application-level queue in `ProxiesBoxController` to limit the number of concurrent proxy availability checks.

### Changes

* Added `_pendingCheckQueue` to defer proxy checks instead of starting them immediately.
* Limited concurrent checks with `kMaxConcurrentChecks = 50`.
* Duplicate queue entries are ignored when dispatched if the proxy is already being checked.
* Uses lazy deletion: deleted items remain in the queue and are discarded when popped, avoiding expensive queue modifications during bulk deletion.

### Testing (macOS)

While I could not reproduce the original Wayland-specific crash on macOS, I tested the behavior with approximately 3000 imported proxies.

**Unmodified build**

* Application became noticeably unresponsive.
* Open file descriptors reached approximately 218 during testing.

**Patched build**

* Open file descriptors remained bounded (observed peak ~188, settling around ~153 as checks completed).
* Application remained responsive while processing the proxy list.
* Successfully handled bulk imports of approximately 3000 proxies without crashes.

**Additional stress test**

* Launched Telegram under `ulimit -n 128`.
* Imported approximately 3000 proxies.
* Application remained stable, and file descriptor usage stayed below the imposed limit.

The current implementation appears to start proxy checks immediately for every imported proxy. By limiting the number of simultaneous checks and queueing the remainder, resource usage remains bounded even when very large proxy lists are imported.