### PR TITLE
Prevent periodic updater instantiation with autoupdates disabled

### DIFF
--- a/Telegram/SourceFiles/window/window_connecting_widget.cpp
+++ b/Telegram/SourceFiles/window/window_connecting_widget.cpp
@@ -310,7 +310,8 @@ void ConnectionState::refreshState() {
 		const auto exposed = _parent->window()->windowHandle()
 			&& _parent->window()->windowHandle()->isExposed();
 		const auto under = _widget && _widget->isOver();
-		const auto ready = (Checker().state() == Checker::State::Ready);
+		const auto ready = !Core::UpdaterDisabled()
+			&& (Checker().state() == Checker::State::Ready);
 		const auto state = _account->mtp().dcstate();
 		const auto proxy = Core::App().settings().proxy().isEnabled();
 		if (state == MTP::ConnectingState


### PR DESCRIPTION
When autoupdates are disabled, there's no permanent updater reference making each UpdateChecker call create an Updater instance with make_shared just to destruct it immediately