### PR TITLE
Fix inverted touchpad swipe gestures on Linux

### DIFF
--- a/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
+++ b/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
@@ -359,7 +359,11 @@ void SetupSwipeHandler(SwipeHandlerArgs &&args) {
 			if (cancel) {
 				processEnd();
 			} else {
-				const auto invert = (w->inverted() ? -1 : 1);
+				const auto isTouchpad = !w->pixelDelta().isNull();
+				const auto invert = (w->inverted()
+					|| (base::Platform::IsLinux() && isTouchpad))
+					? -1
+					: 1;
 				const auto delta = Ui::ScrollDeltaF(w) * invert;
 				updateWith({
 					.globalCursor = w->globalPosition().toPoint(),


### PR DESCRIPTION
Linux touchpad swipes are left/right reversed vs macOS.

`swipe_handler.cpp` flips wheel delta only when `QWheelEvent::inverted()` is true. Qt on Linux often leaves it false for touchpads even with natural scrolling (default on GNOME/KDE).

Fix: invert `pixelDelta` wheel events on Linux.

Fixes #29573