### PR TITLE
Add an accessibility option to disable animated avatars

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -963,6 +963,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_power_chat_effects" = "Effects in messages";
 "lng_settings_power_calls" = "Animations in Calls";
 "lng_settings_power_ui" = "Interface animations";
+"lng_settings_power_animated_avatars" = "Animated avatars";
 "lng_settings_power_auto" = "Save Power on Low Battery";
 "lng_settings_power_auto_about" = "Automatically disable all animations when your laptop is in a battery saving mode.";
 "lng_settings_power_turn_off" = "Please turn off Save Power on Low Battery to change these settings.";

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -36,6 +36,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/dynamic_thumbnails.h"
 #include "ui/vertical_list.h"
 #include "ui/painter.h"
+#include "ui/power_saving.h"
 #include "ui/rect.h"
 #include "ui/screen_reader_mode.h"
 #include "ui/ui_utility.h"
@@ -331,6 +332,11 @@ InnerWidget::InnerWidget(
 	session().downloaderTaskFinished(
 	) | rpl::on_next([=] {
 		invalidateLoadedUserpics();
+		update();
+	}, lifetime());
+
+	PowerSaving::OnValue(PowerSaving::kAnimatedUserpics) | rpl::on_next([=] {
+		_videoUserpics.clear();
 		update();
 	}, lifetime());
 
@@ -1745,7 +1751,8 @@ Ui::VideoUserpic *InnerWidget::validateVideoUserpic(not_null<Row*> row) {
 Ui::VideoUserpic *InnerWidget::validateVideoUserpic(
 		not_null<History*> history) {
 	const auto peer = history->peer;
-	if (!peer->isPremium()
+	if (PowerSaving::On(PowerSaving::kAnimatedUserpics)
+		|| !peer->isPremium()
 		|| peer->userpicPhotoUnknown()
 		|| !peer->userpicHasVideo()
 		|| peer->isSelf()

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_video_userpic.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_video_userpic.cpp
@@ -16,6 +16,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "dialogs/dialogs_entry.h"
 #include "dialogs/ui/dialogs_layout.h"
 #include "ui/painter.h"
+#include "ui/power_saving.h"
 #include "styles/style_dialogs.h"
 
 namespace Dialogs::Ui {
@@ -165,7 +166,7 @@ void PaintUserpic(
 		int outerWidth,
 		int size,
 		bool paused) {
-	if (videoUserpic) {
+	if (videoUserpic && !PowerSaving::On(PowerSaving::kAnimatedUserpics)) {
 		videoUserpic->paintLeft(p, view, x, y, outerWidth, size, paused);
 	} else {
 		peer->paintUserpicLeft(p, view, x, y, outerWidth, size);

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -59,6 +59,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/controls/swipe_handler.h"
 #include "ui/inactive_press.h"
 #include "ui/painter.h"
+#include "ui/power_saving.h"
 #include "ui/rect.h"
 #include "ui/screen_reader_mode.h"
 #include "ui/ui_utility.h"
@@ -429,6 +430,10 @@ HistoryInner::HistoryInner(
 		if (!elementAnimationsPaused()) {
 			update();
 		}
+	}, lifetime());
+	PowerSaving::OnValue(PowerSaving::kAnimatedUserpics) | rpl::on_next([=] {
+		_videoUserpics.clear();
+		update();
 	}, lifetime());
 
 	using PlayRequest = ChatHelpers::EmojiInteractionPlayRequest;
@@ -1861,7 +1866,8 @@ int HistoryInner::SelectionViewOffset(
 
 HistoryInner::VideoUserpic *HistoryInner::validateVideoUserpic(
 		not_null<PeerData*> peer) {
-	if (!peer->isPremium()
+	if (PowerSaving::On(PowerSaving::kAnimatedUserpics)
+		|| !peer->isPremium()
 		|| peer->userpicPhotoUnknown()
 		|| !peer->userpicHasVideo()) {
 		_videoUserpics.remove(peer);

--- a/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
@@ -81,6 +81,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/layers/generic_box.h"
 #include "ui/painter.h"
 #include "ui/peer/video_userpic_player.h"
+#include "ui/power_saving.h"
 #include "ui/rect.h"
 #include "ui/effects/numbers_animation.h"
 #include "ui/text/text_utilities.h"
@@ -551,6 +552,10 @@ TopBar::TopBar(
 			[=] { update(); });
 	} else if (!_savedMessages) {
 		updateVideoUserpic();
+		PowerSaving::OnValue(PowerSaving::kAnimatedUserpics) | rpl::on_next([=] {
+			updateVideoUserpic();
+			update();
+		}, lifetime());
 	}
 
 	rpl::merge(
@@ -2776,7 +2781,9 @@ void TopBar::paintUserpic(QPainter &p, const QRect &geometry) {
 		p.drawImage(geometry, _cachedUserpic);
 		return;
 	}
-	if (_videoUserpicPlayer && _videoUserpicPlayer->ready()) {
+	if (_videoUserpicPlayer
+		&& _videoUserpicPlayer->ready()
+		&& !PowerSaving::On(PowerSaving::kAnimatedUserpics)) {
 		const auto size = st::infoProfileTopBarPhotoSize;
 		const auto frame = _videoUserpicPlayer->frame(Size(size), _peer);
 		if (!frame.isNull()) {
@@ -3175,6 +3182,9 @@ void TopBar::fillTopBarMenu(
 
 void TopBar::updateVideoUserpic() {
 	if (width() <= 0) {
+		return;
+	} else if (PowerSaving::On(PowerSaving::kAnimatedUserpics)) {
+		_videoUserpicPlayer = nullptr;
 		return;
 	}
 	const auto id = _peer->userpicPhotoId();

--- a/Telegram/SourceFiles/settings/settings_power_saving.cpp
+++ b/Telegram/SourceFiles/settings/settings_power_saving.cpp
@@ -179,6 +179,11 @@ EditFlagsDescriptor<PowerSaving::Flags> PowerSavingLabels() {
 			tr::lng_settings_power_ui(tr::now),
 			&st::menuIconStartStream,
 		},
+		{
+			kAnimatedUserpics,
+			tr::lng_settings_power_animated_avatars(tr::now),
+			&st::menuIconProfile,
+		},
 	};
 	return { .labels = {
 		{ tr::lng_settings_power_stickers(), std::move(stickers) },

--- a/Telegram/SourceFiles/ui/power_saving.h
+++ b/Telegram/SourceFiles/ui/power_saving.h
@@ -21,8 +21,9 @@ enum Flag : uint32 {
 	kCalls = (1U << 8),
 	kEmojiStatus = (1U << 9),
 	kChatEffects = (1U << 10),
+	kAnimatedUserpics = (1U << 11),
 
-	kAll = (1U << 11) - 1,
+	kAll = (1U << 12) - 1,
 };
 inline constexpr bool is_flag_type(Flag) { return true; }
 using Flags = base::flags<Flag>;


### PR DESCRIPTION
Fixes https://github.com/telegramdesktop/tdesktop/issues/24658

Please note the comments in the linked thread this fixes, and comments [such as these](https://bugs.telegram.org/c/18322/4) on older issues for other platforms where this autoplay is no longer the case, as for the reasoning why this accessibility toggle is necessary.

---

This PR adds an `Animated avatars` accessibility toggle into the `Battery and Animations` view:

<img width="349" height="344" alt="image" src="https://github.com/user-attachments/assets/8438339e-8b50-4697-9a04-1d7b1a2920fa" />

Result of which can be seen here (left side is unmodified TG, right side is this PR):
[Screencast_20260617_123747.webm](https://github.com/user-attachments/assets/cd46b3b7-085b-46ae-983b-916b059f81f1)

*Disclaimer: This PR was assisted by an LLM*

---

I have read the [CONTRIBUTING.md](https://github.com/telegramdesktop/tdesktop/blob/61caec4b30e4ea5bce9477117ef82cb337c55e2c/.github/CONTRIBUTING.md), so I am aware that new UI elements are forbidden from being in PRs.

If you consider adding this option as such, let me know, and I can rework it to be under the existing `Interface animations` toggle (which I do actually otherwise want to be on), and after the PR is merged I shall open a new issue about separating it into two.