### PR TITLE
Allow downloading files in screen reader mode.

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -643,7 +643,6 @@ void HistoryInner::setupSwipeReplyAndBack() {
 	if (!_peer) {
 		return;
 	}
-	const auto peer = _peer;
 
 	auto update = [=, history = _history](
 			Ui::Controls::SwipeContextData data) {

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -4124,8 +4124,8 @@ void HistoryInner::keyPressEvent(QKeyEvent *e) {
 		if (e->key() == Qt::Key_Space) {
 			if (hasSelectedItems()) {
 				toggleMessageSelection();
-			} else {
-				playPauseFocusedMedia();
+			} else if (!playPauseFocusedMedia()) {
+				downloadFocusedMedia();
 			}
 			e->accept();
 			return;
@@ -5784,7 +5784,39 @@ void HistoryInner::toggleMessageSelection() {
 	accessibilityChildNameChanged(_accessibilityFocusedIndex);
 }
 
-void HistoryInner::playPauseFocusedMedia() {
+bool HistoryInner::playPauseFocusedMedia() {
+	if (_accessibilityFocusedIndex < 0) {
+		return false;
+	}
+	const auto barIndex = accessibilityUnreadBarIndex();
+	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
+		return false;
+	}
+	const auto elements = accessibleElements();
+	const auto elementIndex = (barIndex >= 0
+		&& _accessibilityFocusedIndex > barIndex)
+		? (_accessibilityFocusedIndex - 1)
+		: _accessibilityFocusedIndex;
+	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
+		return false;
+	}
+	const auto item = elements[elementIndex]->data();
+	if (const auto media = item->media()) {
+		if (const auto document = media->document()) {
+			if (document->isVoiceMessage()
+				|| document->isSong()
+				|| document->isAudioFile()
+				|| document->isVideoMessage()) {
+				::Media::Player::instance()->playPause(
+					{ document, item->fullId() });
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+void HistoryInner::downloadFocusedMedia() {
 	if (_accessibilityFocusedIndex < 0) {
 		return;
 	}
@@ -5801,17 +5833,24 @@ void HistoryInner::playPauseFocusedMedia() {
 		return;
 	}
 	const auto item = elements[elementIndex]->data();
-	if (const auto media = item->media()) {
-		if (const auto document = media->document()) {
-			if (document->isVoiceMessage()
-				|| document->isSong()
-				|| document->isAudioFile()
-				|| document->isVideoMessage()) {
-				::Media::Player::instance()->playPause(
-					{ document, item->fullId() });
-			}
-		}
+	const auto media = item->media();
+	const auto document = media ? media->document() : nullptr;
+	if (!document
+		|| document->loading()
+		|| !document->filepath(true).isEmpty()
+		|| document->loadedInMediaCache()) {
+		return;
 	}
+	DocumentSaveClickHandler::SaveAndTrack(item->fullId(), document);
+
+	const auto index = _accessibilityFocusedIndex;
+	const auto focused = _accessibilityFocusedItem;
+	InvokeQueued(this, [=] {
+		if (_accessibilityFocusedIndex == index
+			&& _accessibilityFocusedItem == focused) {
+			accessibilityChildNameChanged(index);
+		}
+	});
 }
 
 void HistoryInner::forwardItem(FullMsgId itemId) {

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -5757,13 +5757,13 @@ void HistoryInner::announceAccessibilityFocus(int index) {
 	accessibilityChildFocused(index);
 }
 
-void HistoryInner::toggleMessageSelection() {
-	if (!hasSelectedItems() || _accessibilityFocusedIndex < 0) {
-		return;
+HistoryView::Element *HistoryInner::resolveFocusedView() const {
+	if (_accessibilityFocusedIndex < 0) {
+		return nullptr;
 	}
 	const auto barIndex = accessibilityUnreadBarIndex();
 	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
-		return;
+		return nullptr;
 	}
 	const auto elements = accessibleElements();
 	const auto elementIndex = (barIndex >= 0
@@ -5771,9 +5771,20 @@ void HistoryInner::toggleMessageSelection() {
 		? (_accessibilityFocusedIndex - 1)
 		: _accessibilityFocusedIndex;
 	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
+		return nullptr;
+	}
+	return elements[elementIndex];
+}
+
+void HistoryInner::toggleMessageSelection() {
+	if (!hasSelectedItems()) {
 		return;
 	}
-	const auto item = elements[elementIndex]->data();
+	const auto view = resolveFocusedView();
+	if (!view) {
+		return;
+	}
+	const auto item = view->data();
 	clearTextSelection();
 	changeSelectionAsGroup(&_selected, item, SelectAction::Invert);
 	repaintItem(item);
@@ -5785,22 +5796,11 @@ void HistoryInner::toggleMessageSelection() {
 }
 
 bool HistoryInner::playPauseFocusedMedia() {
-	if (_accessibilityFocusedIndex < 0) {
+	const auto view = resolveFocusedView();
+	if (!view) {
 		return false;
 	}
-	const auto barIndex = accessibilityUnreadBarIndex();
-	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
-		return false;
-	}
-	const auto elements = accessibleElements();
-	const auto elementIndex = (barIndex >= 0
-		&& _accessibilityFocusedIndex > barIndex)
-		? (_accessibilityFocusedIndex - 1)
-		: _accessibilityFocusedIndex;
-	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
-		return false;
-	}
-	const auto item = elements[elementIndex]->data();
+	const auto item = view->data();
 	if (const auto media = item->media()) {
 		if (const auto document = media->document()) {
 			if (document->isVoiceMessage()
@@ -5817,22 +5817,11 @@ bool HistoryInner::playPauseFocusedMedia() {
 }
 
 void HistoryInner::downloadFocusedMedia() {
-	if (_accessibilityFocusedIndex < 0) {
+	const auto view = resolveFocusedView();
+	if (!view) {
 		return;
 	}
-	const auto barIndex = accessibilityUnreadBarIndex();
-	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
-		return;
-	}
-	const auto elements = accessibleElements();
-	const auto elementIndex = (barIndex >= 0
-		&& _accessibilityFocusedIndex > barIndex)
-		? (_accessibilityFocusedIndex - 1)
-		: _accessibilityFocusedIndex;
-	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
-		return;
-	}
-	const auto item = elements[elementIndex]->data();
+	const auto item = view->data();
 	const auto media = item->media();
 	const auto document = media ? media->document() : nullptr;
 	if (!document

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -299,7 +299,8 @@ private:
 	[[nodiscard]] std::vector<Element*> accessibleElements() const;
 	[[nodiscard]] int accessibilityUnreadBarIndex() const;
 	void toggleMessageSelection();
-	void playPauseFocusedMedia();
+	bool playPauseFocusedMedia();
+	void downloadFocusedMedia();
 	void setAccessibilityFocusedItem(int index, HistoryItem *item);
 	void announceAccessibilityFocus(int index);
 	[[nodiscard]] auto computeActiveColumns(int row) const

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -298,8 +298,9 @@ protected:
 private:
 	[[nodiscard]] std::vector<Element*> accessibleElements() const;
 	[[nodiscard]] int accessibilityUnreadBarIndex() const;
+	[[nodiscard]] Element *resolveFocusedView() const;
 	void toggleMessageSelection();
-	bool playPauseFocusedMedia();
+	[[nodiscard]] bool playPauseFocusedMedia();
 	void downloadFocusedMedia();
 	void setAccessibilityFocusedItem(int index, HistoryItem *item);
 	void announceAccessibilityFocus(int index);

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -5095,13 +5095,13 @@ void ListWidget::announceAccessibilityFocus(int index) {
 	accessibilityChildFocused(index);
 }
 
-void ListWidget::toggleMessageSelection() {
-	if (!hasSelectedItems() || _accessibilityFocusedIndex < 0) {
-		return;
+HistoryView::Element *ListWidget::resolveFocusedView() const {
+	if (_accessibilityFocusedIndex < 0) {
+		return nullptr;
 	}
 	const auto barIndex = accessibilityUnreadBarIndex();
 	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
-		return;
+		return nullptr;
 	}
 	const auto elements = accessibleElements();
 	const auto elementIndex = (barIndex >= 0
@@ -5109,9 +5109,19 @@ void ListWidget::toggleMessageSelection() {
 		? (_accessibilityFocusedIndex - 1)
 		: _accessibilityFocusedIndex;
 	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
+		return nullptr;
+	}
+	return elements[elementIndex];
+}
+
+void ListWidget::toggleMessageSelection() {
+	if (!hasSelectedItems()) {
 		return;
 	}
-	const auto view = elements[elementIndex];
+	const auto view = resolveFocusedView();
+	if (!view) {
+		return;
+	}
 	const auto item = view->data();
 	clearTextSelection();
 	changeSelectionAsGroup(_selected, item, SelectAction::Invert);
@@ -5124,22 +5134,11 @@ void ListWidget::toggleMessageSelection() {
 }
 
 bool ListWidget::playPauseFocusedMedia() {
-	if (_accessibilityFocusedIndex < 0) {
+	const auto view = resolveFocusedView();
+	if (!view) {
 		return false;
 	}
-	const auto barIndex = accessibilityUnreadBarIndex();
-	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
-		return false;
-	}
-	const auto elements = accessibleElements();
-	const auto elementIndex = (barIndex >= 0
-		&& _accessibilityFocusedIndex > barIndex)
-		? (_accessibilityFocusedIndex - 1)
-		: _accessibilityFocusedIndex;
-	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
-		return false;
-	}
-	const auto item = elements[elementIndex]->data();
+	const auto item = view->data();
 	if (const auto media = item->media()) {
 		if (const auto document = media->document()) {
 			if (document->isVoiceMessage()
@@ -5156,22 +5155,11 @@ bool ListWidget::playPauseFocusedMedia() {
 }
 
 void ListWidget::downloadFocusedMedia() {
-	if (_accessibilityFocusedIndex < 0) {
+	const auto view = resolveFocusedView();
+	if (!view) {
 		return;
 	}
-	const auto barIndex = accessibilityUnreadBarIndex();
-	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
-		return;
-	}
-	const auto elements = accessibleElements();
-	const auto elementIndex = (barIndex >= 0
-		&& _accessibilityFocusedIndex > barIndex)
-		? (_accessibilityFocusedIndex - 1)
-		: _accessibilityFocusedIndex;
-	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
-		return;
-	}
-	const auto item = elements[elementIndex]->data();
+	const auto item = view->data();
 	const auto media = item->media();
 	const auto document = media ? media->document() : nullptr;
 	if (!document

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -3107,8 +3107,8 @@ void ListWidget::keyPressEvent(QKeyEvent *e) {
 		if (key == Qt::Key_Space) {
 			if (hasSelectedItems()) {
 				toggleMessageSelection();
-			} else {
-				playPauseFocusedMedia();
+			} else if (!playPauseFocusedMedia()) {
+				downloadFocusedMedia();
 			}
 			e->accept();
 			return;
@@ -5123,7 +5123,39 @@ void ListWidget::toggleMessageSelection() {
 	accessibilityChildNameChanged(_accessibilityFocusedIndex);
 }
 
-void ListWidget::playPauseFocusedMedia() {
+bool ListWidget::playPauseFocusedMedia() {
+	if (_accessibilityFocusedIndex < 0) {
+		return false;
+	}
+	const auto barIndex = accessibilityUnreadBarIndex();
+	if (barIndex >= 0 && _accessibilityFocusedIndex == barIndex) {
+		return false;
+	}
+	const auto elements = accessibleElements();
+	const auto elementIndex = (barIndex >= 0
+		&& _accessibilityFocusedIndex > barIndex)
+		? (_accessibilityFocusedIndex - 1)
+		: _accessibilityFocusedIndex;
+	if (elementIndex < 0 || elementIndex >= int(elements.size())) {
+		return false;
+	}
+	const auto item = elements[elementIndex]->data();
+	if (const auto media = item->media()) {
+		if (const auto document = media->document()) {
+			if (document->isVoiceMessage()
+				|| document->isSong()
+				|| document->isAudioFile()
+				|| document->isVideoMessage()) {
+				::Media::Player::instance()->playPause(
+					{ document, item->fullId() });
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+void ListWidget::downloadFocusedMedia() {
 	if (_accessibilityFocusedIndex < 0) {
 		return;
 	}
@@ -5140,17 +5172,24 @@ void ListWidget::playPauseFocusedMedia() {
 		return;
 	}
 	const auto item = elements[elementIndex]->data();
-	if (const auto media = item->media()) {
-		if (const auto document = media->document()) {
-			if (document->isVoiceMessage()
-				|| document->isSong()
-				|| document->isAudioFile()
-				|| document->isVideoMessage()) {
-				::Media::Player::instance()->playPause(
-					{ document, item->fullId() });
-			}
-		}
+	const auto media = item->media();
+	const auto document = media ? media->document() : nullptr;
+	if (!document
+		|| document->loading()
+		|| !document->filepath(true).isEmpty()
+		|| document->loadedInMediaCache()) {
+		return;
 	}
+	DocumentSaveClickHandler::SaveAndTrack(item->fullId(), document);
+
+	const auto index = _accessibilityFocusedIndex;
+	const auto focused = _accessibilityFocusedItem;
+	InvokeQueued(this, [=] {
+		if (_accessibilityFocusedIndex == index
+			&& _accessibilityFocusedItem == focused) {
+			accessibilityChildNameChanged(index);
+		}
+	});
 }
 
 int ListWidget::accessibilityChildCount() const {

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -544,8 +544,9 @@ private:
 
 	[[nodiscard]] std::vector<Element*> accessibleElements() const;
 	[[nodiscard]] int accessibilityUnreadBarIndex() const;
+	[[nodiscard]] Element *resolveFocusedView() const;
 	void toggleMessageSelection();
-	bool playPauseFocusedMedia();
+	[[nodiscard]] bool playPauseFocusedMedia();
 	void downloadFocusedMedia();
 	void setAccessibilityFocusedItem(int index, HistoryItem *item);
 	void announceAccessibilityFocus(int index);

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -545,7 +545,8 @@ private:
 	[[nodiscard]] std::vector<Element*> accessibleElements() const;
 	[[nodiscard]] int accessibilityUnreadBarIndex() const;
 	void toggleMessageSelection();
-	void playPauseFocusedMedia();
+	bool playPauseFocusedMedia();
+	void downloadFocusedMedia();
 	void setAccessibilityFocusedItem(int index, HistoryItem *item);
 	void announceAccessibilityFocus(int index);
 	[[nodiscard]] auto computeActiveColumns(int row) const

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ parts:
         version="$version-beta"
       fi
 
-      version="${version}$(git describe --tags | sed 's,^v[^-]\+,,')"
+      version="${version}$(git describe --tags 2>/dev/null | sed 's,^v[^-]\+,,' || true)"
 
       craftctl set version="$version"
     override-build: |


### PR DESCRIPTION
Pressing Space on a focused message that holds a not-yet-downloaded file now starts the download, mirroring the play/pause action for audio and video.
Currently limitation: Only the first file in the message(like 2 or 3 file message), only the first one can be downloaded.