### PR TITLE
Restore Home/End navigation in the chat list

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -5807,6 +5807,18 @@ bool InnerWidget::processKeyDispatch(QKeyEvent *e) {
 		selectSkipPage(_visibleBottom - _visibleTop, -1);
 	} else if (e->key() == Qt::Key_PageDown) {
 		selectSkipPage(_visibleBottom - _visibleTop, 1);
+	} else if (e->key() == Qt::Key_Home || e->key() == Qt::Key_End) {
+		// Jump to the first/last row. selectSkip() clamps the target, so
+		// skipping by more than the total row count lands on the edge in both
+		// the default and the filtered (search) list.
+		const auto rows = int(_collapsedRows.size())
+			+ _shownList->size()
+			+ int(_hashtagResults.size())
+			+ int(_filterResults.size())
+			+ int(_peerSearchResults.size())
+			+ int(_previewResults.size())
+			+ int(_searchResults.size());
+		selectSkip((e->key() == Qt::Key_End) ? rows : -rows);
 	} else {
 		return false;
 	}


### PR DESCRIPTION
## Summary
Restores **Home/End** navigation in the chat (dialogs) list.

Home/End used to jump to the first/last chat (added with the chat-list accessibility support), but were dropped when `InnerWidget`'s key handling was refactored from a `switch` to an `if / else if` chain in *"Extract chats list accessibility, fix build"* — only Up/Down and Page Up/Down were carried over, ending in `else { return false; }`.

This re-adds the two cases. It skips by the actual total row count (which `selectSkip()` already clamps), so it lands on the first/last row in both the default list and the filtered/search results — slightly more robust than the previous `1 << 20` constant.
