### PR TITLE
Fix use-after-free when deleting multiple folders.

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_pinned_list.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_pinned_list.cpp
@@ -66,7 +66,7 @@ void PinnedList::setPinned(Key key, bool pinned) {
 		const auto index = int(it - begin(_data));
 		_data.erase(it);
 		key.entry()->cachePinnedIndex(_filterId, 0);
-		for (auto i = index, count = int(size(_data)); i != count; ++i) {
+		for (auto i = index; i < int(size(_data)); ++i) {
 			_data[i].entry()->cachePinnedIndex(_filterId, i + 1);
 		}
 	}


### PR DESCRIPTION
Telegram crashes when the user deletes more than 2 folders 
in the Settings -> Folders widget.

fixed