### PR TITLE
Fix crash when finishing the appearing text animation

### DIFF
--- a/Telegram/SourceFiles/history/view/history_view_message.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_message.cpp
@@ -6598,7 +6598,12 @@ bool Message::textAppearCheckLine(not_null<TextAppearing*> appearing) {
 					|| (appearing->shownHeight < finalLineHeight))));
 	if (!use) {
 		if (data()->isRegular()) {
-			RemoveComponents(TextAppearing::Bit());
+			// We are inside these animations' tick, can't destroy them now.
+			crl::on_main(this, [=] {
+				if (Has<TextAppearing>() && !Get<TextAppearing>()->use) {
+					RemoveComponents(TextAppearing::Bit());
+				}
+			});
 			return false;
 		} else if (recount && lines) {
 			appearing->shownLine = lines - 1;


### PR DESCRIPTION
`Simple::value()` can read a null `_data` and crash (EXC_BAD_ACCESS at 0x0) when an appearing-text animation finishes.

`textAppearWidthCallback()` / `textAppearHeightCallback()` are the tick callbacks of the `TextAppearing` width/height animations. They go through `textAppearValidate()` -> `textAppearCheckLine()`, which removes the component once the reveal is done:

```cpp
RemoveComponents(TextAppearing::Bit());
```

The problem is that this runs while we're still inside the animation tick, so it destroys the `Simple` animations (and their `_data`) that the manager is currently iterating. The sibling animation, or the same one re-entered through `viewHeightAdjusted()`, then reads freed `_data` and we crash in `Simple::value()`.

Fix is to defer the removal to the next main loop iteration, after the tick has unwound:

```cpp
if (!use) {
    if (data()->isRegular()) {
        // We are inside these animations' tick, can't destroy them now.
        crl::on_main(this, [=] {
            if (Has<TextAppearing>() && !Get<TextAppearing>()->use) {
                RemoveComponents(TextAppearing::Bit());
            }
        });
        return false;
    }
    ...
}
```

`textAppearValidate()` still returns `false` (callers already drop the pointer in that case), and the deferred call is guarded by the element weak pointer and re-checks `Has<>()` / `use`, so the component is still removed exactly once, just outside the tick.

How I hit it: a bot that streams its message text. The reveal animations finish from incoming updates while Telegram is in the background, so it crashes with no user interaction (the backtrace has no input events, just the animations manager calling the tick).
