### PR TITLE
Remove duplicate QT_NO_PRIVATE_MODULE_WARNING from root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ project(Telegram
 
 if (APPLE)
     enable_language(OBJC OBJCXX)
-    set(QT_NO_PRIVATE_MODULE_WARNING ON)
 endif()
 
 if (configuration_types_init


### PR DESCRIPTION
It now lives in cmake/external/qt/package.cmake