### PR TITLE
Add PSK extension to MTProxy ClientHello

### DIFF
--- a/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
+++ b/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
@@ -21,7 +21,7 @@ namespace MTP::details {
 namespace {
 
 constexpr auto kMaxGrease = 8;
-constexpr auto kClientHelloLimit = 2048;
+constexpr auto kClientHelloLimit = 4096;
 constexpr auto kHelloDigestLength = 32;
 constexpr auto kLengthSize = sizeof(uint16);
 const auto kServerHelloPart1 = qstr("\x16\x03\x03");
@@ -324,6 +324,7 @@ private:
 		[[nodiscard]] QByteArray take();
 
 	private:
+		void writeSyntheticPskExtension();
 		void writeDigest(bytes::const_span key);
 		void injectTimestamp();
 
@@ -517,6 +518,49 @@ void Generator::Part::writeBlock(const MTPDtlsBlockPadding &data) {
 		writeBlock(MTP_tlsBlockString(MTP_bytes("\x00\x15"_q)));
 		writeBlock(MTP_tlsBlockScope(MTP_vector<MTPTlsBlock>(1, zero)));
 	}
+	// psk lives here: padding is last, so parent lengths still backpatch.
+	writeSyntheticPskExtension();
+}
+
+void Generator::Part::writeSyntheticPskExtension() {
+	const auto identityLengths = std::array{ 32, 105, 256 };
+	const auto binderLengths = std::array{ 32, 48 };
+	const auto identityLength = identityLengths[
+		base::RandomIndex(identityLengths.size())];
+	const auto binderLength = binderLengths[
+		base::RandomIndex(binderLengths.size())];
+	const auto identitiesLength = identityLength + 6;
+	const auto bindersLength = binderLength + 1;
+	const auto extensionLength = identitiesLength + bindersLength + 4;
+	const auto write16 = [&](uint16 value) {
+		const auto big = qToBigEndian(value);
+		const auto storage = grow(sizeof(big));
+		if (storage.empty()) {
+			return;
+		}
+		bytes::copy(storage, bytes::object_as_span(&big));
+	};
+	const auto random = [&](int length) {
+		const auto storage = grow(length);
+		if (storage.empty()) {
+			return;
+		}
+		bytes::set_random(storage);
+	};
+
+	write16(uint16(0x0029));
+	write16(uint16(extensionLength));
+	write16(uint16(identitiesLength));
+	write16(uint16(identityLength));
+	random(identityLength);
+	random(4);
+	write16(uint16(bindersLength));
+	const auto binderPrefix = grow(1);
+	if (binderPrefix.empty()) {
+		return;
+	}
+	binderPrefix[0] = bytes::type(binderLength);
+	random(binderLength);
 }
 
 void Generator::Part::finalize(bytes::const_span key) {


### PR DESCRIPTION
The current MTProxy masquerade already mimics Chrome almost completely, but it's still missing a few details. This PR adds a `pre_shared_key` extension to the fakeTLS `ClientHello` used by the MTProxy transport.

This does not implement real TLS session resumption. Telegram does not store TLS tickets, does not resume TLS sessions, and does not use the PSK for any cryptography. It is purely imitation: the fakeTLS `ClientHello` gets a well-formed PSK, similar to what modern browsers often send on repeat TLS connections.

### Why this matters

Right now in Russia, MTProxy fakeTLS is being blocked at the TLS handshake stage. This is caused by the mass of Chrome `ClientHello`s that have no `pre_shared_key` — which can also be reproduced with an ordinary browser.

When you reopen a site in a normal browser, it also sends `pre_shared_key`, and most likely that's why the DPI is less strict and lets a large number of `ClientHello`s through.

### How it's implemented

A `pre_shared_key` extension is added:
- extension type: 0x0029
- PSK identity length: a few random values taken from a real capture
- binder length: random 32 or 48
- obfuscated_ticket_age: 4 random bytes
- identity and binder payload: random bytes
- extension is emitted last, as required by TLS 1.3

### Does this break anything?

In TLS 1.3 a client may offer a PSK identity. The server is not required to accept that PSK. If the server doesn't select an identity, the handshake can simply proceed as a normal full handshake.

I also wondered whether a DPI could track the fake PSK. In my opinion this would be extremely expensive: a PSK can live for a very long time, and storing that volume of keys would simply become too costly.

### Summary

This is not a full browser model, and it may be only a temporary patch, but to me it's very cheap and safe. Among other options that could bypass TSPU (Russia's DPI system), I found:
- using `ALPN=http/1.1`;
- using a different fingerprint, e.g. Firefox-like;
- reducing the burst of parallel TLS connections (probably the hardest one).

But IMO the other options also look like temporary patches. Let me know if you have any suggestions for improvement.