### PR TITLE
[img-editor] Fixed std::clamp() crash in photo editor

### DIFF
--- a/Telegram/SourceFiles/editor/scene/scene_item_canvas.cpp
+++ b/Telegram/SourceFiles/editor/scene/scene_item_canvas.cpp
@@ -78,6 +78,8 @@ void ItemCanvas::computeContentRect(const QPointF &p) {
 	const auto sceneSize = scene()->sceneRect().size();
 	const auto contentLeft = std::max(0., _contentRect.x());
 	const auto contentTop = std::max(0., _contentRect.y());
+	const auto contentRight = contentLeft + _contentRect.width();
+	const auto contentBottom = contentTop + _contentRect.height();
 	_contentRect = QRectF(
 		QPointF(
 			std::clamp(p.x() - _brushMargins.left(), 0., contentLeft),
@@ -85,11 +87,11 @@ void ItemCanvas::computeContentRect(const QPointF &p) {
 		QPointF(
 			std::clamp(
 				p.x() + _brushMargins.right(),
-				contentLeft + _contentRect.width(),
+				std::min(contentRight, sceneSize.width()),
 				sceneSize.width()),
 			std::clamp(
 				p.y() + _brushMargins.bottom(),
-				contentTop + _contentRect.height(),
+				std::min(contentBottom, sceneSize.height()),
 				sceneSize.height())));
 }
 


### PR DESCRIPTION
There is a bug in the photo editor. When starting drawing near the bottom or right border of the image, the brush padding extends outside the frame boundaries. This causes a crash due to a violation in `std::clamp` where the lower bound ( lo ) becomes greater than the upper bound ( hi ).

This PR resolves the crash by using `std::min` to ensure the lower limit passed to `std::clamp` is never greater than the upper limit:
- Clamping the right boundary using `std::min(contentRight, sceneSize.width())` as the lower bound.
- Clamping the bottom boundary using `std::min(contentBottom, sceneSize.height())` as the lower bound.

Potentially closes #30921