### PR TITLE
Focus chat list on launch in screen reader mode

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -2202,6 +2202,10 @@ void Widget::setInnerFocus(bool unfocusSearch) {
 			|| _searchHasFocus
 			|| _searchSuggestionsLocked)) {
 		_search->setFocus();
+	} else if (Ui::ScreenReaderModeActive()) {
+		// Focus the chat list itself, so the screen reader announces the list
+		// and its selected chat, instead of the unnamed dialogs container.
+		_inner->setFocus();
 	} else {
 		setFocus();
 	}


### PR DESCRIPTION
On launch, focus landed on the unnamed Dialogs::Widget container, so screen readers (e.g. NVDA) read out the raw Qt class chain instead of anything useful.

This focuses the accessible chat list instead when screen reader mode is active, so the list and its selected chat are announced. Sighted behaviour is unchanged.