### PR TITLE
Hide the main menu hit-area button from screen readers

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -114,6 +114,20 @@ base::options::toggle OptionForumHideChatsList({
 	.description = "Don't keep a narrow column of chat list.",
 });
 
+// An invisible, larger hit-area stacked under the main menu toggle so a mouse
+// click near the toggle still opens the menu. It duplicates the toggle's action
+// and carries no label, so it reports no accessible role - that keeps the screen
+// reader's FocusManager from turning it into a second, unnamed Tab stop, while
+// mouse clicks keep working.
+class MenuUnderButton final : public Ui::AbstractButton {
+public:
+	using Ui::AbstractButton::AbstractButton;
+
+	QAccessible::Role accessibilityRole() override {
+		return QAccessible::NoRole;
+	}
+};
+
 [[nodiscard]] bool RedirectTextToSearch(const QString &text) {
 	for (const auto &ch : text) {
 		if (ch.unicode() >= 32) {
@@ -353,7 +367,7 @@ Widget::Widget(
 	.toggle = object_ptr<Ui::IconButton>(
 		_searchControls,
 		st::dialogsMenuToggle),
-	.under = object_ptr<Ui::AbstractButton>(_searchControls),
+	.under = object_ptr<MenuUnderButton>(_searchControls),
 })
 , _searchForNarrowLayout(_searchControls, st::dialogsSearchForNarrowFilters)
 , _search(_searchControls, st::dialogsFilter, tr::lng_dlg_filter())


### PR DESCRIPTION
The main menu has an invisible, larger hit-area button stacked under the toggle so a mouse click near the icon still opens the menu. It has no label, so in screen reader mode it became a second, unnamed Tab stop next to the real "Main menu" button and read out the raw Qt class chain.

Give that hit-area no accessible role, so keyboard/screen-reader navigation skips it while mouse clicks keep opening the menu.