### PR TITLE
Report multi-selection state on message history lists

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -6429,6 +6429,18 @@ QString HistoryInner::accessibilityChildName(int index) const {
 		_history);
 }
 
+Ui::AccessibilityState HistoryInner::accessibilityState() const {
+	// The list allows selecting multiple messages (Ctrl+Space, plain
+	// Space while the selection is not empty, Shift+arrows for ranges)
+	// and the selection may be emptied again, so the UIA selection
+	// pattern must report CanSelectMultiple and must not claim
+	// IsSelectionRequired once something got selected.
+	return {
+		.extSelectable = true,
+		.multiSelectable = true,
+	};
+}
+
 QAccessible::State HistoryInner::accessibilityChildState(int index) const {
 	QAccessible::State state;
 	state.focusable = true;

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -123,6 +123,7 @@ public:
 	Qt::FocusPolicy accessibilityFocusPolicy() override {
 		return Qt::TabFocus;
 	}
+	Ui::AccessibilityState accessibilityState() const override;
 	int accessibilityChildCount() const override;
 	QString accessibilityChildName(int index) const override;
 	QAccessible::State accessibilityChildState(int index) const override;

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -5389,6 +5389,18 @@ QString ListWidget::accessibilityChildName(int index) const {
 		view->data()->history());
 }
 
+Ui::AccessibilityState ListWidget::accessibilityState() const {
+	// The list allows selecting multiple messages (Ctrl+Space, plain
+	// Space while the selection is not empty, Shift+arrows for ranges)
+	// and the selection may be emptied again, so the UIA selection
+	// pattern must report CanSelectMultiple and must not claim
+	// IsSelectionRequired once something got selected.
+	return {
+		.extSelectable = true,
+		.multiSelectable = true,
+	};
+}
+
 QAccessible::State ListWidget::accessibilityChildState(int index) const {
 	QAccessible::State state;
 	state.focusable = true;

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -499,6 +499,7 @@ public:
 	Qt::FocusPolicy accessibilityFocusPolicy() override {
 		return Qt::TabFocus;
 	}
+	Ui::AccessibilityState accessibilityState() const override;
 	int accessibilityChildCount() const override;
 	QString accessibilityChildName(int index) const override;
 	QAccessible::State accessibilityChildState(int index) const override;


### PR DESCRIPTION
﻿Requires desktop-app/lib_ui#319 (adds the `extSelectable` / `multiSelectable` fields to `AccessibilityState`) - this PR does not compile without it.

The message history reports the List role, so the Windows UIA bridge already exposes the Selection pattern on it - and currently answers wrong: `CanSelectMultiple` = false (the list supports selecting multiple messages) and, once anything is selected, `IsSelectionRequired` = true (Qt computes it as `anySelected && !multiSelectable && !extSelectable`, while Escape empties the selection just fine).

`HistoryInner` and `HistoryView::ListWidget` now report `multiSelectable` + `extSelectable`, so the pattern answers `CanSelectMultiple` = true and `IsSelectionRequired` = false.

Verified with NVDA UIA property queries (30060/30061) before and after, and with JAWS: it now identifies the control as a multi-select list and offers the Shift/Ctrl selection usage hints (Insert+Tab / Insert+F1). Regular screen reader announcements are unaffected.
