### PR TITLE
Fix media viewer crash when seeking without duration

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -5348,18 +5348,31 @@ void OverlayWidget::flushPendingFrameStep() {
 void OverlayWidget::seekRelativeTime(crl::time time) {
 	Expects(_streamed != nullptr);
 
+	const auto &state = _streamed->instance.info().video.state;
+	const auto position = state.position;
+	const auto duration = state.duration;
+	if (position == kTimeUnknown
+		|| duration == kTimeUnknown
+		|| duration == kDurationUnavailable) {
+		return;
+	}
 	const auto newTime = std::clamp(
-		_streamed->instance.info().video.state.position + time,
+		position + time,
 		crl::time(0),
-		_streamed->instance.info().video.state.duration);
+		duration);
 	restartAtSeekPosition(newTime);
 }
 
 void OverlayWidget::restartAtProgress(float64 progress) {
 	Expects(_streamed != nullptr);
 
-	restartAtSeekPosition(_streamed->instance.info().video.state.duration
-		* std::clamp(progress, 0., 1.));
+	const auto duration = _streamed->instance.info().video.state.duration;
+	if (duration == kTimeUnknown
+		|| duration == kDurationUnavailable) {
+		return;
+	}
+	restartAtSeekPosition(
+		duration * std::clamp(progress, 0., 1.));
 }
 
 void OverlayWidget::restartAtSeekPosition(crl::time position) {


### PR DESCRIPTION
# Fix media viewer crash when seeking without duration

## Problem

The media viewer can handle keyboard seek actions before streamed track
information contains a usable duration. At that point
`video.state.duration` is `kTimeUnknown`, while the current position may
already be valid.

`seekRelativeTime()` passes that state to
`std::clamp(position + delta, 0, duration)`. This violates the clamp
precondition because the upper bound is below zero and aborts hardened
libstdc++ builds.

Two Telegram Desktop 6.9.3 core dumps reproduced the same path:

- Right Arrow: `position = 78533`, `delta = 5000`,
  `duration = kTimeUnknown`.
- Left Arrow: `position = 371933`, `delta = -5000`,
  `duration = kTimeUnknown`.

## Fix

- Ignore relative seeks until both position and duration are known and the
  duration is available.
- Ignore progress-based seeks while duration is unknown or unavailable.
- Keep `restartAtSeekPosition()` unchanged because it is also used to start
  playback before track information is ready.

Normal seeks retain the existing clamping behavior.

## Verification

- Verified both core-dump call sites against the v6.9.3 source and the
  Arch Linux binary disassembly.
- Verified the unknown-duration and unavailable-duration paths return before
  position arithmetic or playback restart.
- Verified normal lower- and upper-bound clamping is unchanged.
- `git diff --check` passes.
- A full local build was not run because no configured TDesktop build
  environment is available on this machine.

Possibly related: #26104 and #30847.
