### PR TITLE
Paste Excel selections as article tables

### DIFF
--- a/Telegram/SourceFiles/iv/editor/iv_editor_clipboard.cpp
+++ b/Telegram/SourceFiles/iv/editor/iv_editor_clipboard.cpp
@@ -11,6 +11,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include <QtCore/QMimeData>
 #include <QtCore/QPointer>
+#include <QtCore/QStringList>
+
+#include <array>
 
 namespace Iv::Editor {
 namespace {
@@ -59,6 +62,80 @@ struct ClipboardStorage {
 	}, std::move(data));
 }
 
+[[nodiscard]] QString QtWindowsMimeName(const QString &name) {
+	return u"application/x-qt-windows-mime;value=\"%1\""_q.arg(name);
+}
+
+[[nodiscard]] bool HasNativeFormat(
+		const QMimeData *mimeData,
+		const QString &name) {
+	return mimeData->hasFormat(name)
+		|| mimeData->hasFormat(QtWindowsMimeName(name));
+}
+
+[[nodiscard]] bool HasExcelNativeFormat(const QMimeData *mimeData) {
+	const auto names = std::array{
+		u"Biff12"_q,
+		u"Biff8"_q,
+		u"Biff5"_q,
+		u"XML Spreadsheet"_q,
+	};
+	for (const auto &name : names) {
+		if (HasNativeFormat(mimeData, name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+[[nodiscard]] bool IsExcelHtml(const QString &html) {
+	const auto folded = html.toCaseFolded();
+	if (!folded.contains(u"<table"_q)) {
+		return false;
+	}
+	const auto excelGenerator = folded.contains(u"generator"_q)
+		&& folded.contains(u"microsoft excel"_q);
+	const auto excelProgId = folded.contains(u"progid"_q)
+		&& folded.contains(u"excel.sheet"_q);
+	const auto excelNamespace = folded.contains(
+		u"urn:schemas-microsoft-com:office:excel"_q);
+	return excelGenerator || excelProgId || excelNamespace;
+}
+
+[[nodiscard]] bool HasExcelHtml(const QMimeData *mimeData) {
+	if (mimeData->hasHtml() && IsExcelHtml(mimeData->html())) {
+		return true;
+	}
+	const auto name = u"HTML Format"_q;
+	const auto wrapped = QtWindowsMimeName(name);
+	return (mimeData->hasFormat(name)
+			&& IsExcelHtml(QString::fromUtf8(mimeData->data(name))))
+		|| (mimeData->hasFormat(wrapped)
+			&& IsExcelHtml(QString::fromUtf8(mimeData->data(wrapped))));
+}
+
+[[nodiscard]] std::vector<QString> SplitRows(const QString &text) {
+	auto result = std::vector<QString>();
+	auto start = 0;
+	for (auto i = 0; i != text.size(); ++i) {
+		if (text[i] != u'\r' && text[i] != u'\n') {
+			continue;
+		}
+		result.push_back(text.mid(start, i - start));
+		if (text[i] == u'\r'
+			&& i + 1 != text.size()
+			&& text[i + 1] == u'\n') {
+			++i;
+		}
+		start = i + 1;
+	}
+	result.push_back(text.mid(start));
+	if (text.endsWith(u'\r') || text.endsWith(u'\n')) {
+		result.pop_back();
+	}
+	return result;
+}
+
 } // namespace
 
 QString ClipboardMimeType() {
@@ -85,6 +162,50 @@ std::optional<ClipboardData> ClipboardDataFromMimeData(
 		return std::nullopt;
 	}
 	return storage.data;
+}
+
+std::optional<RichPage::Block> ExcelTableBlockFromMimeData(
+		const QMimeData *mimeData) {
+	if (!mimeData
+		|| !mimeData->hasText()
+		|| (!HasExcelNativeFormat(mimeData) && !HasExcelHtml(mimeData))) {
+		return std::nullopt;
+	}
+	const auto text = mimeData->text();
+	if (text.isEmpty()) {
+		return std::nullopt;
+	}
+	const auto rows = SplitRows(text);
+	if (rows.empty()) {
+		return std::nullopt;
+	}
+	auto cells = std::vector<QStringList>();
+	cells.reserve(rows.size());
+	for (const auto &row : rows) {
+		cells.push_back(row.split(u'\t', Qt::KeepEmptyParts));
+	}
+	const auto columns = cells.front().size();
+	for (const auto &row : cells) {
+		if (row.size() != columns) {
+			return std::nullopt;
+		}
+	}
+
+	auto result = RichPage::Block();
+	result.kind = RichPage::BlockKind::Table;
+	result.bordered = true;
+	result.tableRows.reserve(cells.size());
+	for (const auto &fields : cells) {
+		auto row = RichPage::TableRow();
+		row.cells.reserve(fields.size());
+		for (const auto &field : fields) {
+			auto cell = RichPage::TableCell();
+			cell.text.text.text = field;
+			row.cells.push_back(std::move(cell));
+		}
+		result.tableRows.push_back(std::move(row));
+	}
+	return result;
 }
 
 } // namespace Iv::Editor

--- a/Telegram/SourceFiles/iv/editor/iv_editor_clipboard.h
+++ b/Telegram/SourceFiles/iv/editor/iv_editor_clipboard.h
@@ -43,5 +43,7 @@ using ClipboardData = std::variant<ClipboardBlockData, ClipboardListItemsData>;
 	ClipboardData data);
 [[nodiscard]] std::optional<ClipboardData> ClipboardDataFromMimeData(
 	const QMimeData *mimeData);
+[[nodiscard]] std::optional<RichPage::Block> ExcelTableBlockFromMimeData(
+	const QMimeData *mimeData);
 
 } // namespace Iv::Editor

--- a/Telegram/SourceFiles/iv/editor/iv_editor_widget.cpp
+++ b/Telegram/SourceFiles/iv/editor/iv_editor_widget.cpp
@@ -4060,6 +4060,13 @@ bool Widget::handleClipboardKey(QKeyEvent *e) {
 			e->accept();
 			return true;
 		}
+		if (auto block = ExcelTableBlockFromMimeData(mimeData)) {
+			auto data = ClipboardBlockData();
+			data.blocks.push_back(std::move(*block));
+			pasteStructuredClipboardData(ClipboardData(std::move(data)));
+			e->accept();
+			return true;
+		}
 		if (mimeData && _applyPreparedMedia) {
 			if (auto list = PreparedMediaFromClipboard(
 					not_null<const QMimeData*>(mimeData),
@@ -8664,6 +8671,18 @@ bool Widget::handleIvClipboardMime(
 		}
 		crl::on_main(this, [=, clipboardData = *clipboardData] {
 			pasteStructuredClipboardData(clipboardData);
+		});
+		return true;
+	}
+	if (auto block = ExcelTableBlockFromMimeData(data.get())) {
+		if (action == Ui::InputField::MimeAction::Check) {
+			return true;
+		}
+		auto excelData = ClipboardBlockData();
+		excelData.blocks.push_back(std::move(*block));
+		auto structured = ClipboardData(std::move(excelData));
+		crl::on_main(this, [=, structured = std::move(structured)] {
+			pasteStructuredClipboardData(structured);
 		});
 		return true;
 	}


### PR DESCRIPTION
I aislopped Excel selection pasting as article tables, which I find rather useful. It works on my machine, but it'd definitely benefit from adding text entities parsing.

<img width="600" height="421" alt="image" src="https://github.com/user-attachments/assets/83a45dfa-58b0-42d0-a0f4-bb62107b658f" />

