### PR TITLE
Fix QScroller overshoot at the bottom of chat history.

### DIFF
--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -386,7 +386,12 @@ HistoryWidget::HistoryWidget(
 	_scroll->setOverscrollBg(QColor(0, 0, 0, 0));
 	_scroll->setOverscrollEdges(
 		[=] { return historyLoadedAtTop(); },
-		[=] { return historyLoadedAtBottom(); });
+		[=] {
+			return Core::App().settings().pullToNextChannel()
+				&& _history
+				&& _history->peer->isBroadcast()
+				&& historyLoadedAtBottom();
+		});
 	_scroll->geometryChanged(
 	) | rpl::on_next(crl::guard(_list, [=] {
 		_list->onParentGeometryChanged();

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -212,6 +212,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include <QtGui/QWindow>
 #include <QtCore/QMimeData>
+#include <QtWidgets/QScroller>
 
 namespace {
 
@@ -11124,6 +11125,9 @@ void HistoryWidget::synteticScrollToY(int y) {
 	if (_scroll->scrollTop() == y) {
 		visibleAreaUpdated();
 	} else {
+		if (QScroller::hasScroller(_scroll.data())) {
+			QScroller::scroller(_scroll.data())->stop();
+		}
 		_scroll->scrollToY(y);
 	}
 	_synteticScrollEvent = false;


### PR DESCRIPTION
Scrolling at the bottom of a
fully loaded chat doesn't stop at the last message.

Most visibly with the experimental `QScroller` option enabled.

Verified on a Debug build against latest dev.