### PR TITLE
Include muted unread dialogs in unread-on-top

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_entry.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_entry.cpp
@@ -55,8 +55,8 @@ uint64 UnreadOnTopDialogPos(uint64 sortKeyByDate) {
 
 base::options::toggle OptionUnreadOnTop({
 	.id = kOptionDialogsUnreadOnTop,
-	.name = "Keep unmuted unread chats on top",
-	.description = "Sort chats with new unmuted messages right below the "
+	.name = "Keep unread chats on top",
+	.description = "Sort chats with unread messages right below the "
 		"pinned ones and keep them there until you read them.",
 });
 
@@ -249,18 +249,19 @@ uint64 Entry::computeSortPosition(FilterId filterId) const {
 	const auto index = lookupPinnedIndex(filterId);
 	if (index) {
 		return PinnedDialogPos(index);
-	} else if (UnreadOnTopEnabled() && hasUnreadUnmutedForSort()) {
+	} else if (UnreadOnTopEnabled() && hasUnreadForSort()) {
 		return UnreadOnTopDialogPos(_sortKeyByDate);
 	}
 	return _sortKeyByDate;
 }
 
-bool Entry::hasUnreadUnmutedForSort() const {
+bool Entry::hasUnreadForSort() const {
 	const auto state = chatListUnreadState();
-	return (state.messages > state.messagesMuted)
-		|| (state.marks > state.marksMuted)
-		|| (state.reactions > state.reactionsMuted)
-		|| (state.mentions > 0);
+	return (state.messages > 0)
+		|| (state.marks > 0)
+		|| (state.reactions > 0)
+		|| (state.mentions > 0)
+		|| (state.polls > 0);
 }
 
 void Entry::updateChatListExistence() {

--- a/Telegram/SourceFiles/dialogs/dialogs_entry.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_entry.h
@@ -202,7 +202,7 @@ private:
 	virtual void changedChatListPinHook();
 	void pinnedIndexChanged(FilterId filterId, int was, int now);
 	[[nodiscard]] uint64 computeSortPosition(FilterId filterId) const;
-	[[nodiscard]] bool hasUnreadUnmutedForSort() const;
+	[[nodiscard]] bool hasUnreadForSort() const;
 
 	void setChatListExistence(bool exists);
 	not_null<Row*> mainChatListLink(FilterId filterId) const;


### PR DESCRIPTION
## Summary

The existing experimental unread-on-top option only promotes unread state that is not muted. Muted unread chats can therefore remain mixed with read dialogs and still be missed while the option is enabled.

This change makes the existing option cover all unread dialog state:

- unread messages and manual unread marks, including muted ones
- unread reactions, mentions, and polls

It keeps the current sort-key infrastructure and ordering unchanged: fixed/system entries first, then per-filter pinned dialogs, then unread dialogs ordered by date, then ordinary dialogs. The option remains opt-in and defaults to off.

## Validation

- Built the `Telegram` target in Debug on macOS for arm64 and x86_64 with compiler warnings treated as errors.
- Manually verified that a muted unread dialog is placed above a newer read dialog.
- Verified pinned dialogs remain above the unread block and unread dialogs retain date order.
- `git diff --check` passes.
