### PR TITLE
smoother scrolling on macos

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/stickers_lottie.cpp
+++ b/Telegram/SourceFiles/chat_helpers/stickers_lottie.cpp
@@ -332,15 +332,15 @@ not_null<DocumentData*> GenerateLocalSticker(
 		.caption = {},
 		.idOverride = LocalStickerId(path),
 	});
-	task.process({ .generateGoodThumbnail = false });
+	task.process({
+		.generateGoodThumbnail = false,
+		.generateThumbnailBytes = false,
+	});
 	const auto result = task.peekResult();
 	Assert(result != nullptr);
 	const auto document = session->data().processDocument(
 		result->document,
-		Images::FromImageInMemory(
-			result->thumb,
-			"WEBP",
-			result->thumbbytes));
+		ImageWithLocation());
 	document->setLocation(Core::FileLocation(path));
 
 	Ensures(document->sticker());

--- a/Telegram/SourceFiles/data/data_document_media.cpp
+++ b/Telegram/SourceFiles/data/data_document_media.cpp
@@ -279,7 +279,7 @@ void DocumentMedia::setVideoThumbnail(QByteArray content) {
 }
 
 void DocumentMedia::checkStickerLarge() {
-	if (_sticker) {
+	if (_sticker || _stickerLoading) {
 		return;
 	}
 	const auto data = _owner->sticker();
@@ -290,15 +290,50 @@ void DocumentMedia::checkStickerLarge() {
 	if (data->isAnimated() || !loaded()) {
 		return;
 	}
-	if (_bytes.isEmpty()) {
-		const auto &loc = _owner->location(true);
-		if (loc.accessEnable()) {
-			_sticker = std::make_unique<Image>(loc.name());
-			loc.accessDisable();
-		}
-	} else {
-		_sticker = std::make_unique<Image>(_bytes);
+	auto location = _bytes.isEmpty()
+		? std::make_unique<Core::FileLocation>(_owner->location(true))
+		: nullptr;
+	const auto active = _owner->activeMediaView();
+	if (active.get() != this) {
+		return;
 	}
+	_stickerLoading = true;
+	const auto weak = std::weak_ptr<DocumentMedia>(active);
+	const auto guard = base::make_weak(&_owner->session());
+	crl::async([
+		guard,
+		weak,
+		content = _bytes,
+		location = std::move(location)
+	]() mutable {
+		const auto accessed = location && location->accessEnable();
+		const auto path = accessed
+			? location->name()
+			: QString();
+		const auto attempted = !content.isEmpty() || !path.isEmpty();
+		auto image = !content.isEmpty()
+			? Images::Read({ .content = content }).image
+			: !path.isEmpty()
+			? Images::Read({ .path = path }).image
+			: QImage();
+		if (accessed) {
+			location->accessDisable();
+		}
+		crl::on_main(guard, [
+			weak,
+			attempted,
+			image = std::move(image)
+		]() mutable {
+			if (const auto strong = weak.lock()) {
+				strong->_stickerLoading = false;
+				if (attempted) {
+					strong->_sticker = std::make_unique<Image>(
+						std::move(image));
+				}
+				strong->_owner->session().notifyDownloaderTaskFinished();
+			}
+		});
+	});
 }
 
 void DocumentMedia::automaticLoad(
@@ -421,13 +456,8 @@ Image *DocumentMedia::getStickerSmall() {
 	return _sticker.get();
 }
 
-void DocumentMedia::checkStickerLarge(not_null<FileLoader*> loader) {
-	if (_sticker || !_owner->sticker()) {
-		return;
-	}
-	if (auto image = loader->imageData(); !image.isNull()) {
-		_sticker = std::make_unique<Image>(std::move(image));
-	}
+void DocumentMedia::checkStickerLarge(not_null<FileLoader*>) {
+	checkStickerLarge();
 }
 
 void DocumentMedia::GenerateGoodThumbnail(

--- a/Telegram/SourceFiles/data/data_document_media.h
+++ b/Telegram/SourceFiles/data/data_document_media.h
@@ -110,6 +110,7 @@ private:
 	mutable QPainterPath _pathThumbnail;
 	std::unique_ptr<Image> _thumbnail;
 	std::unique_ptr<Image> _sticker;
+	bool _stickerLoading = false;
 	QByteArray _bytes;
 	QByteArray _videoThumbnailBytes;
 	Flags _flags;

--- a/Telegram/SourceFiles/storage/file_download.cpp
+++ b/Telegram/SourceFiles/storage/file_download.cpp
@@ -25,6 +25,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace {
 
+constexpr char kPartialPrefix[] = "partial:";
+constexpr auto kPartialPrefixSize = int(sizeof(kPartialPrefix) - 1);
+
 class FromMemoryLoader final : public FileLoader {
 public:
 	FromMemoryLoader(
@@ -215,9 +218,9 @@ void FileLoader::localLoaded(
 		start();
 		return;
 	}
-	const auto partial = result.data.startsWith("partial:");
-	constexpr auto kPrefix = 8;
-	if (partial	&& result.data.size() < _loadSize + kPrefix) {
+	const auto partial = result.data.startsWith(kPartialPrefix);
+	if (partial
+		&& result.data.size() < _loadSize + kPartialPrefixSize) {
 		_localStatus = LocalStatus::NotFound;
 		if (checkForOpen()) {
 			startLoadingWithPartial(result.data);
@@ -230,8 +233,8 @@ void FileLoader::localLoaded(
 	}
 	finishWithBytes(partial
 		? QByteArray::fromRawData(
-			result.data.data() + kPrefix,
-			result.data.size() - kPrefix)
+			result.data.data() + kPartialPrefixSize,
+			result.data.size() - kPartialPrefixSize)
 		: result.data);
 }
 
@@ -264,6 +267,7 @@ bool FileLoader::checkForOpen() {
 
 void FileLoader::loadLocal(const Storage::Cache::Key &key) {
 	const auto readImage = (_locationType != AudioFileLocation);
+	const auto loadSize = _loadSize;
 	auto done = [=, guard = _localLoading.make_guard()](
 			QByteArray &&value,
 			QImage &&image,
@@ -282,12 +286,21 @@ void FileLoader::loadLocal(const Storage::Cache::Key &key) {
 	};
 	_session->data().cache().get(key, [=, callback = std::move(done)](
 			QByteArray &&value) mutable {
-		if (readImage && !value.startsWith("partial:")) {
+		const auto partial = value.startsWith(kPartialPrefix);
+		const auto enough = !partial
+			|| (value.size() >= loadSize + kPartialPrefixSize);
+		if (readImage && enough) {
 			crl::async([
 				value = std::move(value),
+				partial,
 				done = std::move(callback)
 			]() mutable {
-				auto read = Images::Read({ .content = value });
+				const auto content = partial
+					? QByteArray::fromRawData(
+						value.data() + kPartialPrefixSize,
+						value.size() - kPartialPrefixSize)
+					: value;
+				auto read = Images::Read({ .content = content });
 				if (!read.image.isNull()) {
 					done(
 						std::move(value),
@@ -463,9 +476,28 @@ bool FileLoader::finalizeResult() {
 				Storage::Cache::Database::TaggedValue(
 					base::duplicate((!_fullSize || _data.size() == _fullSize)
 						? _data
-						: ("partial:" + _data)),
+						: (QByteArray(kPartialPrefix) + _data)),
 					_cacheTag));
 		}
+	}
+	if (_locationType == UnknownFileLocation && !_data.isEmpty()) {
+		const auto weak = base::make_weak(this);
+		crl::async([weak, data = base::duplicate(_data)]() mutable {
+			auto read = Images::Read({ .content = data });
+			crl::on_main(weak, [
+				weak,
+				read = std::move(read)
+			]() mutable {
+				if (!read.image.isNull()) {
+					weak->_imageData = std::move(read.image);
+					weak->_imageFormat = std::move(read.format);
+				}
+				const auto session = weak->_session;
+				weak->_updates.fire_done();
+				session->notifyDownloaderTaskFinished();
+			});
+		});
+		return true;
 	}
 	const auto session = _session;
 	_updates.fire_done();

--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++ b/Telegram/SourceFiles/storage/localimageloader.cpp
@@ -114,9 +114,10 @@ struct PreparedFileThumbnail {
 		PreparedFileThumbnail &&prepared,
 		const QString &filemime,
 		int64 filesize,
-		bool isSticker) {
+		bool isSticker,
+		bool generateBytes) {
 	prepared.name = isSticker ? u"thumb.webp"_q : u"thumb.jpg"_q;
-	if (FileThumbnailUploadRequired(filemime, filesize)) {
+	if (generateBytes && FileThumbnailUploadRequired(filemime, filesize)) {
 		const auto format = isSticker ? "WEBP" : "JPG";
 		auto buffer = QBuffer(&prepared.bytes);
 		prepared.image.save(&buffer, format, kThumbnailQuality);
@@ -970,7 +971,8 @@ void FileLoadTask::process(ProcessArgs &&args) {
 		std::move(thumbnail),
 		filemime,
 		filesize,
-		isSticker);
+		isSticker,
+		args.generateThumbnailBytes);
 
 	if (_type == SendMediaType::Photo && photoThumbs.empty()) {
 		_type = SendMediaType::File;

--- a/Telegram/SourceFiles/storage/localimageloader.h
+++ b/Telegram/SourceFiles/storage/localimageloader.h
@@ -256,6 +256,7 @@ public:
 
 	struct ProcessArgs {
 		bool generateGoodThumbnail = true;
+		bool generateThumbnailBytes = true;
 	};
 	void process(ProcessArgs &&args);
 


### PR DESCRIPTION
an attempt to make scrolling the chat history smoother on macos. two parts: render scroll positions with sub-pixel precision (needs desktop-app/lib_ui#324), and stop decoding images on the main thread, which caused visible stutter while scrolling media-heavy chats. it's not perfect but noticeably smoother.

- **skip thumbnail bytes generation for local stickers** — local stickers were re-encoding a WEBP thumbnail that was never used; skip it via a new `generateThumbnailBytes` flag.
- **decode sticker images without blocking the main thread** — `checkStickerLarge` constructed the `Image` (synchronous decode) on the main thread; move the decode to `crl::async` with a loading guard.
- **decode downloaded and partial cached images asynchronously** — `FileLoader` now also decodes `partial:`-prefixed cache entries off-thread when the partial data covers the requested size, and decodes freshly downloaded images on `crl::async` before firing updates instead of leaving it to the consumer on the main thread.
- **apply sub-pixel scroll offset in history view** — `HistoryInner` subscribes to the scroll view's sub-pixel offset, translates painting by the fraction (keeping the floating date badge and forum bar pinned) and compensates in all hit-testing paths.

note: the code in this pr was written partially by claude fable 5 and partially by gpt-5.6-sol.
