### PR TITLE
Mark messages read by focus instead of visibility with screen readers

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -1478,7 +1478,9 @@ void HistoryInner::paintEvent(QPaintEvent *e) {
 				_controller->emojiInteractions().startAutoplay(view);
 			}
 		}
-		if (readTill && _widget->markingMessagesRead()) {
+		if (readTill
+			&& _widget->markingMessagesRead()
+			&& !Ui::ScreenReaderModeActive()) {
 			session().data().histories().readInboxTill(readTill);
 		}
 		if (markingAsViewed && !readContents.empty()) {
@@ -4413,6 +4415,9 @@ void HistoryInner::checkActivation() {
 		// Side-effect: Also clears all notifications from forum topics.
 		Core::App().notifications().clearFromHistory(_history);
 	}
+	if (Ui::ScreenReaderModeActive()) {
+		return;
+	}
 	if (_curHistory != _history || _history->isEmpty()) {
 		return;
 	}
@@ -6814,15 +6819,29 @@ void HistoryInner::announceAccessibilityFocusedChild() {
 		announceAccessibilityFocus(_accessibilityFocusedIndex);
 		return;
 	}
-	const auto barIndex = accessibilityUnreadBarIndex();
-	const auto index = (barIndex >= 0 && barIndex + 1 < count)
-		? (barIndex + 1)
-		: (count - 1);
 	const auto elements = accessibleElements();
-	const auto item = accessibilityItemAtIndex(
-		index,
-		elements,
-		barIndex);
+	const auto barIndex = accessibilityUnreadBarIndex();
+	auto index = barIndex;
+	if (index < 0) {
+		// The bar is not always there while messages stay unread (it is
+		// not recreated when the few unread messages fit on one screen):
+		// land on the first unread message itself then, so that every
+		// visit starts at the reading edge and the first arrow press
+		// marks one heard message, not everything above the newest row.
+		_history->calculateFirstUnreadMessage();
+		if (const auto first = _history->firstUnreadMessage()) {
+			for (auto i = 0, n = int(elements.size()); i != n; ++i) {
+				if (elements[i] == first) {
+					index = i;
+					break;
+				}
+			}
+		}
+	}
+	if (index < 0) {
+		index = count - 1;
+	}
+	const auto item = accessibilityItemAtIndex(index, elements, barIndex);
 	setAccessibilityFocusedItem(index, item);
 }
 

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -4400,6 +4400,20 @@ void HistoryWidget::destroyUnreadBar() {
 void HistoryWidget::destroyUnreadBarOnClose() {
 	if (!_history || !_historyInited) {
 		return;
+	} else if (Ui::ScreenReaderModeActive() && _history->unreadCount() > 0) {
+		// The checks below infer "the user has seen it all" from the scroll
+		// position, and with a screen reader what was scrolled into view was
+		// not necessarily heard: while something actually stays unread, keep
+		// the bar, so the next visit lands the focus back on it. Only keep
+		// it while it still sits at the reading edge, though - once reading
+		// advanced past it, drop the stale bar here so that the next visit
+		// puts a fresh one above the first message still actually unread.
+		_history->calculateFirstUnreadMessage();
+		if (_history->unreadBar()
+			&& _history->unreadBar() != _history->firstUnreadMessage()) {
+			destroyUnreadBar();
+		}
+		return;
 	} else if (_scroll->scrollTop() >= _scroll->scrollTopMax()) {
 		destroyUnreadBar();
 		return;
@@ -8191,6 +8205,14 @@ bool HistoryWidget::hasSavedScroll() const {
 }
 
 int HistoryWidget::countInitialScrollTop() {
+	if (Ui::ScreenReaderModeActive()) {
+		// Several of the paths below skip creating the unread bar (a saved
+		// scroll state restores as it was, a jump to the end has no use
+		// for it). With a screen reader the bar is where reading starts
+		// from on every visit, so make sure it exists while something
+		// stays unread, whatever position the chat opens at.
+		createUnreadBarIfBelowVisibleArea(0);
+	}
 	if (hasSavedScroll()) {
 		return _list->historyScrollTop();
 	} else if (_showAtMsgId
@@ -8239,7 +8261,12 @@ void HistoryWidget::createUnreadBarIfBelowVisibleArea(int withScrollTop) {
 	}
 	_history->calculateFirstUnreadMessage();
 	if (const auto unread = _history->firstUnreadMessage()) {
-		if (_list->itemTop(unread) > withScrollTop) {
+		// The visible-area check assumes what fits on the screen is read
+		// at a glance, so a bar above it would only flicker. With a screen
+		// reader the bar is the landmark the focus starts reading from, so
+		// it is worth having however little stays unread.
+		if (Ui::ScreenReaderModeActive()
+			|| _list->itemTop(unread) > withScrollTop) {
 			createUnreadBarAndResize();
 		}
 	}
@@ -8266,7 +8293,13 @@ int HistoryWidget::countAutomaticScrollTop() {
 		const auto possibleUnreadBarTop = _scroll->scrollTopMax()
 			+ HistoryView::UnreadBar::height()
 			- HistoryView::UnreadBar::marginTop();
-		if (firstUnreadTop < possibleUnreadBarTop) {
+		// The position check assumes the few unread messages fitting on
+		// the last screen are read at a glance, so a bar is not worth its
+		// space. With a screen reader the bar is the landmark the focus
+		// starts reading from, so it is worth having however little stays
+		// unread.
+		if (Ui::ScreenReaderModeActive()
+			|| firstUnreadTop < possibleUnreadBarTop) {
 			createUnreadBarAndResize();
 			if (_history->unreadBar() != nullptr) {
 				setMsgId(ShowAtUnreadMsgId);

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -2917,7 +2917,8 @@ void ListWidget::showFinished() {
 void ListWidget::checkActivation() {
 	if (_resizePending
 		|| _visibleTop >= _visibleBottom
-		|| !markingMessagesRead()) {
+		|| !markingMessagesRead()
+		|| Ui::ScreenReaderModeActive()) {
 		return;
 	}
 	for (const auto &view : ranges::views::reverse(_items)) {
@@ -2973,7 +2974,9 @@ void ListWidget::paintEvent(QPaintEvent *e) {
 				controller()->emojiInteractions().startAutoplay(view);
 			}
 		}
-		if (markingAsViewed && readTill) {
+		if (markingAsViewed
+			&& readTill
+			&& !Ui::ScreenReaderModeActive()) {
 			_delegate->listMarkReadTill(readTill);
 		}
 		if (!readContents.empty() && markingContentRead) {
@@ -6374,15 +6377,25 @@ void ListWidget::announceAccessibilityFocusedChild() {
 		announceAccessibilityFocus(_accessibilityFocusedIndex);
 		return;
 	}
-	const auto barIndex = accessibilityUnreadBarIndex();
-	const auto index = (barIndex >= 0 && barIndex + 1 < count)
-		? (barIndex + 1)
-		: accessibilityNewestIndex(count);
 	const auto elements = accessibleElements();
-	const auto item = accessibilityItemAtIndex(
-		index,
-		elements,
-		barIndex);
+	const auto barIndex = accessibilityUnreadBarIndex();
+	auto index = barIndex;
+	if (index < 0 && _bar.element) {
+		// The bar element marks the first unread message even while the
+		// bar itself is hidden: land on it, so that every visit starts
+		// at the reading edge and the first arrow press marks one heard
+		// message, not everything above the newest row.
+		for (auto i = 0, n = int(elements.size()); i != n; ++i) {
+			if (elements[i] == _bar.element) {
+				index = i;
+				break;
+			}
+		}
+	}
+	if (index < 0) {
+		index = accessibilityNewestIndex(count);
+	}
+	const auto item = accessibilityItemAtIndex(index, elements, barIndex);
 	setAccessibilityFocusedItem(index, item);
 }
 


### PR DESCRIPTION
For a screen reader user, on-screen visibility says nothing about what was actually read: just scrolling (or the view moving on its own) marked messages read that were never spoken.

With a screen reader active, everything that inferred reading from visibility is now inert, and the read mark follows the accessibility focus instead, building on the focus-marking already added in aeb3e6be75 and 5f3e4d9a5e:

- deliberate navigation (arrows, PageUp/Down, UIA focus) marks everything up to the focused message - the same semantics as a sighted user paging to the bottom; the automatic pick when the list takes focus never marks anything;
- the unread bar becomes the stable landmark reading starts from. The bar's lifecycle was driven by the same visibility logic (destroyed on close once the bottom was seen, not recreated when the few unread messages fit on one screen, skipped by a saved scroll state or a jump to the end), so a visit after a partial read used to land on an arbitrary row and the first arrow press could sweep dozens of messages read. Now, while something actually stays unread, every visit rebuilds the bar above the first message still unread and lands the focus on it; a bar the reading advanced past is dropped on close so the next one sits at the new reading edge.

Without a screen reader nothing changes.

Tested with NVDA on Windows 10: opening a chat with unreads announces "Unread messages" first and leaves the counter untouched however many times the chat is reopened, arrowing reads and marks messages one by one, PageDown/End marks up to the landing point, and after reading part of the way a reopen lands on the bar again, moved down to exactly the first unheard message. The sighted behavior is unchanged.