### PR TITLE
Update dav1d, libavif, libheif, libjxl

### DIFF
--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -228,7 +228,7 @@ EOF
 
 FROM builder AS brotli
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b v1.1.0 --depth=1 https://github.com/google/brotli.git
+git clone -b v1.2.0 --depth=1 https://github.com/google/brotli.git
 cd brotli
 cmake -B build . -DBUILD_SHARED_LIBS=OFF -DBROTLI_DISABLE_TESTS=ON
 cmake --build build
@@ -239,7 +239,7 @@ EOF
 
 FROM builder AS highway
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b 1.0.7 --depth=1 https://github.com/google/highway.git
+git clone -b 1.4.0 --depth=1 https://github.com/google/highway.git
 cd highway
 cmake -B build . -DBUILD_TESTING=OFF -DHWY_ENABLE_CONTRIB=OFF -DHWY_ENABLE_EXAMPLES=OFF
 cmake --build build
@@ -277,7 +277,7 @@ EOF
 
 FROM builder AS dav1d
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b 1.5.3 --depth=1 https://github.com/videolan/dav1d.git
+git clone -b 1.5.4 --depth=1 https://github.com/videolan/dav1d.git
 cd dav1d
 meson build \
 	--buildtype=plain \
@@ -303,7 +303,7 @@ EOF
 
 FROM builder AS de265
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b v1.0.16 --depth=1 https://github.com/strukturag/libde265.git
+git clone -b v1.1.1 --depth=1 https://github.com/strukturag/libde265.git
 cd libde265
 cmake -B build . \
 	-DCMAKE_BUILD_TYPE=None \
@@ -362,7 +362,7 @@ FROM builder AS avif
 COPY --link --from=dav1d /usr/src/dav1d-cache /
 
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b v1.3.0 --depth=1 https://github.com/AOMediaCodec/libavif.git
+git clone -b v1.4.2 --depth=1 https://github.com/AOMediaCodec/libavif.git
 cd libavif
 cmake -B build . -DBUILD_SHARED_LIBS=OFF -DAVIF_CODEC_DAV1D=SYSTEM -DAVIF_LIBYUV=OFF
 cmake --build build
@@ -375,11 +375,11 @@ FROM builder AS heif
 COPY --link --from=de265 /usr/src/de265-cache /
 
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b v1.21.2 --depth=1 https://github.com/strukturag/libheif.git
+git clone -b v1.23.1 --depth=1 https://github.com/strukturag/libheif.git
 cd libheif
 cmake -B build . \
 	-DBUILD_SHARED_LIBS=OFF \
-	-DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON \
+	-DBUILD_DOCUMENTATION=OFF \
 	-DBUILD_TESTING=OFF \
 	-DENABLE_PLUGIN_LOADING=OFF \
 	-DWITH_X265=OFF \
@@ -406,7 +406,7 @@ COPY --link --from=brotli /usr/src/brotli-cache /
 COPY --link --from=highway /usr/src/highway-cache /
 
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b v0.11.2 --depth=1 https://github.com/libjxl/libjxl.git
+git clone -b v0.12.0 --depth=1 https://github.com/libjxl/libjxl.git
 cd libjxl
 cmake -B build . \
 	-DBUILD_SHARED_LIBS=OFF \

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -743,7 +743,7 @@ win:
 
 # Somehow in x86 Debug build dav1d crashes on AV1 10bpc videos.
 stage('dav1d', """
-    git clone -b 1.5.3 https://code.videolan.org/videolan/dav1d.git
+    git clone -b 1.5.4 https://code.videolan.org/videolan/dav1d.git
     cd dav1d
 win32:
     SET "TARGET=x86"
@@ -866,7 +866,7 @@ mac:
 """)
 
 stage('libavif', """
-    git clone -b v1.3.0 https://github.com/AOMediaCodec/libavif.git
+    git clone -b v1.4.2 https://github.com/AOMediaCodec/libavif.git
     cd libavif
 win:
     cmake . ^
@@ -895,7 +895,7 @@ mac:
 """)
 
 stage('libde265', """
-    git clone -b v1.0.16 https://github.com/strukturag/libde265.git
+    git clone -b v1.1.1 https://github.com/strukturag/libde265.git
     cd libde265
 win:
     cmake . ^
@@ -966,7 +966,7 @@ mac:
 """)
 
 stage('libheif', """
-    git clone -b v1.21.2 https://github.com/strukturag/libheif.git
+    git clone -b v1.23.1 https://github.com/strukturag/libheif.git
     cd libheif
 win:
     %THIRDPARTY_DIR%\\msys64\\usr\\bin\\sed.exe -i 's/LIBHEIF_EXPORTS/LIBDE265_STATIC_BUILD/g' libheif/CMakeLists.txt
@@ -977,7 +977,7 @@ win:
         -DCMAKE_INSTALL_PREFIX=%LIBS_DIR%/local ^
         -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" ^
         -DBUILD_SHARED_LIBS=OFF ^
-        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON ^
+        -DBUILD_DOCUMENTATION=OFF ^
         -DBUILD_TESTING=OFF ^
         -DENABLE_PLUGIN_LOADING=OFF ^
         -DWITH_LIBDE265=ON ^
@@ -1002,7 +1002,7 @@ mac:
         -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64" \\
         -D CMAKE_INSTALL_PREFIX:STRING=$USED_PREFIX \\
         -D BUILD_SHARED_LIBS=OFF \\
-        -D CMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON \\
+        -D BUILD_DOCUMENTATION=OFF \\
         -D BUILD_TESTING=OFF \\
         -D ENABLE_PLUGIN_LOADING=OFF \\
         -D WITH_AOM_ENCODER=OFF \\
@@ -1026,7 +1026,7 @@ mac:
 """)
 
 stage('libjxl', """
-    git clone -b v0.11.2 --recursive --shallow-submodules https://github.com/libjxl/libjxl.git
+    git clone -b v0.12.0 --recursive --shallow-submodules https://github.com/libjxl/libjxl.git
     cd libjxl
 """ + setVar("cmake_defines", """
     -DBUILD_SHARED_LIBS=OFF
@@ -1038,7 +1038,6 @@ stage('libjxl', """
     -DJPEGXL_ENABLE_MANPAGES=OFF
     -DJPEGXL_ENABLE_EXAMPLES=OFF
     -DJPEGXL_ENABLE_JNI=OFF
-    -DJPEGXL_ENABLE_JPEGLI_LIBJPEG=OFF
     -DJPEGXL_ENABLE_SJPEG=OFF
     -DJPEGXL_ENABLE_OPENEXR=OFF
     -DJPEGXL_ENABLE_SKCMS=ON


### PR DESCRIPTION
Hello,

I am suggesting to update these libs because fixes (including security) were implemented meanwhile.

I tested release build on Windows (I just had to add yasm.exe to build libvpx) and it worked well (tried opening AVIF, HEIC, JXL, QOI images).