### PR TITLE
fix gap above dialog search results

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -2768,6 +2768,12 @@ void Widget::updateStoriesVisibility() {
 		|| (pulledDown && hiddenAnimated);
 	const auto hidden = hiddenInstant || hiddenAnimated;
 	const auto changed = (_stories->toggledHidden() != hidden);
+	if (changed
+		&& hidden
+		&& (_storiesExplicitExpand
+			|| _storiesExplicitExpandValue.current() > 0)) {
+		storiesExplicitCollapse();
+	}
 	_stories->setToggledHidden(hiddenInstant, hiddenAnimated);
 	if (changed) {
 		using Type = Ui::ElasticScroll::OverscrollType;


### PR DESCRIPTION
fixes an empty gap appearing above dialog search results after expanding stories by click.

repro:
1. click the collapsed stories miniatures to expand them
2. focus the search field
3. type a query

pull-down expansion is not affected.

explicit expansion kept its height while stories were hiding for search. reset it before starting the hide animation.

this pr was autherd by gpt-5.6-sol running in codex desktop