### PR TITLE
Fix Mini App cookies on Linux

### DIFF
--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
@@ -2129,6 +2129,7 @@ bool Panel::createWebview(const Webview::ThemeParams &params) {
 		Webview::WindowConfig{
 			.opaqueBg = params.bodyBg,
 			.storageId = _storageId,
+			.allowThirdPartyCookies = _externalShell,
 			.mode = _externalShell
 				? Webview::WindowMode::External
 				: Webview::WindowMode::Embedded,


### PR DESCRIPTION
## Summary

- enable third-party cookies for the external Linux Mini App shell
- preserve the default cookie policy for embedded webviews and other platforms
- update `lib_webview` to the opt-in API from desktop-app/lib_webview#146

Fixes #30889.

## Dependency

- https://github.com/desktop-app/lib_webview/pull/146 must merge first

## Testing

- generated and inspected the updated Linux helper D-Bus interface
- compiled, linked, and ran strict cookie API probes against Ubuntu 24.04 WebKitGTK 6.0 and 4.1
- passed XML and whitespace validation

A full Telegram build was not run because this checkout has no configured `out/` tree or local dependency bundle.