### PR TITLE
Fix Linux Mini App shadow offset

### DIFF
--- a/Telegram/SourceFiles/payments/ui/payments.style
+++ b/Telegram/SourceFiles/payments/ui/payments.style
@@ -156,7 +156,7 @@ botWebViewMenu: PopupMenu(popupMenuWithIcons) {
 }
 botWebViewShellRadius: 7px;
 botWebViewShellPadding: margins(12px, 12px, 12px, 12px);
-botWebViewShellShadowPadding: margins(14px, 12px, 14px, 16px);
+botWebViewShellShadowPadding: margins(0px, 0px, 0px, 0px);
 botWebViewShellHeaderHeight: 60px;
 botWebViewShellTitlePadding: margins(0px, 0px, 0px, 0px);
 botWebViewShellBadgeSkip: 4px;


### PR DESCRIPTION
## Summary

- remove the internal shadow margins from the Linux external Mini App shell
- keep the WebView content aligned with the visible window bounds on Wayland

## Problem

Linux Mini Apps opened in an external shell reserve `botWebViewShellShadowPadding` as part of the client window. Under Wayland, those margins remain visible inside the surface, shifting the content 14 px to the right and 12 px down while clipping the opposite edges.

The padding is only consumed by the Linux external shell. Setting it to zero lets the shell match the actual client bounds; compositor-provided window shadows remain unaffected.

## Validation

- built and tested with Telegram Desktop 7.0.6 on Arch Linux
- tested under Hyprland 0.56.1 using the native Wayland backend
- verified multiple external Mini Apps, including Wallet and BotFather
- confirmed the patch applies cleanly to the current `dev` branch

