### PR TITLE
Bump libheif to 1.23.1

### DIFF
--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -375,7 +375,7 @@ FROM builder AS heif
 COPY --link --from=de265 /usr/src/de265-cache /
 
 RUN --mount=type=cache,target=/var/cache/ccache <<EOF
-git clone -b v1.21.2 --depth=1 https://github.com/strukturag/libheif.git
+git clone -b v1.23.1 --depth=1 https://github.com/strukturag/libheif.git
 cd libheif
 cmake -B build . \
 	-DBUILD_SHARED_LIBS=OFF \

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -966,7 +966,7 @@ mac:
 """)
 
 stage('libheif', """
-    git clone -b v1.21.2 https://github.com/strukturag/libheif.git
+    git clone -b v1.23.1 https://github.com/strukturag/libheif.git
     cd libheif
 win:
     %THIRDPARTY_DIR%\\msys64\\usr\\bin\\sed.exe -i 's/LIBHEIF_EXPORTS/LIBDE265_STATIC_BUILD/g' libheif/CMakeLists.txt


### PR DESCRIPTION
## Summary
- Bump libheif pin from **1.21.2** to **1.23.1** in:
  - `Telegram/build/prepare/prepare.py`
  - `Telegram/build/docker/centos_env/Dockerfile`
- Includes fixes for **CVE-2026-32740** and **CVE-2026-32741** (fixed upstream in libheif 1.22.0+).

## Test plan
- [x] macOS (Apple Silicon): `Telegram/build/prepare/mac.sh skip-release` completed successfully with libheif **v1.23.1** (`Libraries/local/lib/libheif.a`)
- [x] macOS Debug: `./configure.sh` + `cmake --build out --config Debug --target Telegram` → **BUILD SUCCEEDED** (`out/Debug/Telegram.app`)
- [ ] CI / other platforms as available