### PR TITLE
Expose discrete slider sections as accessible tabs

### DIFF
--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
@@ -91,6 +91,10 @@ rpl::producer<int> DiscreteSlider::accessibilitySectionBrowsed() const {
 	return _accessibilitySectionBrowsed.events();
 }
 
+void DiscreteSlider::setAccessibilityActivateOnBrowse(bool activate) {
+	_accessibilityActivateOnBrowse = activate;
+}
+
 int DiscreteSlider::sectionsCount() const {
 	return int(_sections.size());
 }
@@ -304,12 +308,27 @@ void DiscreteSlider::keyPressEvent(QKeyEvent *e) {
 		browseAndActivate(0);
 	} else if (key == Qt::Key_End && count > 0) {
 		browseAndActivate(count - 1);
+	} else if (!e->isAutoRepeat()
+		&& !_accessibilityActivateOnBrowse
+		&& (key == Qt::Key_Space
+			|| key == Qt::Key_Return
+			|| key == Qt::Key_Enter)
+		&& _accessibilitySelected >= 0
+		&& _accessibilitySelected < count) {
+		// Only an opted-out strip needs the explicit commit step.
+		activateSectionByAccessibility(_accessibilitySelected);
 	} else {
 		RpWidget::keyPressEvent(e);
 	}
 }
 
 void DiscreteSlider::browseAndActivate(int index) {
+	// An opted-out strip (see setAccessibilityActivateOnBrowse) only moves
+	// the browse position, keeping activation on Enter / Space.
+	if (!_accessibilityActivateOnBrowse) {
+		setAccessibilitySelected(index, Announce::Always);
+		return;
+	}
 	// A native Windows tab control switches to the tab the arrows land on
 	// right away, with no separate Enter / Space step, and what the screen
 	// reader announces is the focus moving onto that tab - which by then

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/discrete_sliders.h"
 
 #include "ui/effects/ripple_animation.h"
+#include "ui/screen_reader_mode.h"
 #include "styles/style_widgets.h"
 
 namespace Ui {
@@ -86,6 +87,10 @@ void DiscreteSlider::setAdditionalContentWidthToSection(int index, int w) {
 	}
 }
 
+rpl::producer<int> DiscreteSlider::accessibilitySectionBrowsed() const {
+	return _accessibilitySectionBrowsed.events();
+}
+
 int DiscreteSlider::sectionsCount() const {
 	return int(_sections.size());
 }
@@ -154,6 +159,9 @@ void DiscreteSlider::refresh() {
 	}
 	if (_selected >= _sections.size()) {
 		_selected = 0;
+	}
+	if (_accessibilitySelected >= int(_sections.size())) {
+		_accessibilitySelected = -1;
 	}
 	resizeToWidth(width());
 	update();
@@ -257,6 +265,242 @@ int DiscreteSlider::getIndexFromPosition(QPoint pos) {
 		}
 	}
 	return count - 1;
+}
+
+void DiscreteSlider::focusInEvent(QFocusEvent *e) {
+	// On real Tab traversal always land on the active section: the
+	// accessibility SetFocus / Invoke actions leave a browse position behind,
+	// and keeping it here would move Tab focus to whatever section was last
+	// acted on instead. Those actions themselves come through with
+	// OtherFocusReason (plain setFocus()) and must keep the position they
+	// have just set.
+	const auto count = int(_sections.size());
+	const auto tab = (e->reason() == Qt::TabFocusReason)
+		|| (e->reason() == Qt::BacktabFocusReason);
+	if (count > 0 && (tab || _accessibilitySelected < 0)) {
+		setAccessibilitySelected(
+			std::clamp(_activeIndex, 0, count - 1),
+			Announce::No);
+	}
+	// Taking focus raises a focus event of its own, which the platform hands
+	// to focusChild() - the browsed section - so announcing it here as well
+	// would read it twice.
+	RpWidget::focusInEvent(e);
+}
+
+void DiscreteSlider::keyPressEvent(QKeyEvent *e) {
+	const auto count = int(_sections.size());
+	const auto key = e->key();
+	// Sections are painted mirrored in RTL, so arrows move by visual order.
+	const auto forward = style::RightToLeft() ? Qt::Key_Left : Qt::Key_Right;
+	const auto backward = style::RightToLeft() ? Qt::Key_Right : Qt::Key_Left;
+	if ((key == forward || key == backward) && count > 0) {
+		const auto current = (_accessibilitySelected >= 0)
+			? _accessibilitySelected
+			: _activeIndex;
+		const auto delta = (key == forward) ? 1 : -1;
+		browseAndActivate(std::clamp(current + delta, 0, count - 1));
+	} else if (key == Qt::Key_Home && count > 0) {
+		browseAndActivate(0);
+	} else if (key == Qt::Key_End && count > 0) {
+		browseAndActivate(count - 1);
+	} else {
+		RpWidget::keyPressEvent(e);
+	}
+}
+
+void DiscreteSlider::browseAndActivate(int index) {
+	// A native Windows tab control switches to the tab the arrows land on
+	// right away, with no separate Enter / Space step, and what the screen
+	// reader announces is the focus moving onto that tab - which by then
+	// already reports itself selected. So activate silently first, then
+	// announce through the focus move.
+	if (index != _activeIndex) {
+		setActiveSection(index);
+		accessibilityChildStateChanged(index, { .selected = true });
+		setAccessibilitySelected(index, Announce::Always);
+	} else {
+		// Nothing to switch (e.g. the edge tab again) - just keep the browse
+		// position in place, announcing only if it actually moved.
+		setAccessibilitySelected(index, Announce::OnChange);
+	}
+}
+
+void DiscreteSlider::activateSectionByAccessibility(int index) {
+	const auto previous = _activeIndex;
+	setActiveSection(index);
+	accessibilityChildStateChanged(index, { .selected = true });
+	// The state change alone stays silent on Windows, where the bridge reads
+	// only the checked flag out of it - the selection events below are the
+	// ones a screen reader hears, the way SideBarButton announces the active
+	// folder of the vertical strip.
+	if (previous != index
+		&& previous >= 0
+		&& previous < int(_sections.size())) {
+		accessibilityChildSelectionChanged(previous);
+	}
+	accessibilityChildSelectionChanged(index);
+}
+
+int DiscreteSlider::accessibilityBrowsedSection() const {
+	return (_accessibilitySelected >= 0
+		&& _accessibilitySelected < int(_sections.size()))
+		? _accessibilitySelected
+		: -1;
+}
+
+void DiscreteSlider::setAccessibilitySelected(int index, Announce announce) {
+	if (index >= int(_sections.size())) {
+		return;
+	}
+	const auto changed = (_accessibilitySelected != index);
+	_accessibilitySelected = index;
+	if (changed && index >= 0) {
+		_accessibilitySectionBrowsed.fire_copy(index);
+	}
+	const auto shouldAnnounce = (announce == Announce::Always)
+		|| (announce == Announce::OnChange && changed);
+	if (shouldAnnounce && index >= 0) {
+		accessibilityChildFocused(index);
+	}
+}
+
+QAccessible::Role DiscreteSlider::accessibilityRole() {
+	return QAccessible::PageTabList;
+}
+
+bool DiscreteSlider::accessibilitySelectionList() const {
+	// Grants the sections the platform selection item pattern, which is what
+	// a screen reader reads "selected" / "not selected" from while browsing.
+	return true;
+}
+
+Qt::FocusPolicy DiscreteSlider::accessibilityFocusPolicy() {
+	return Qt::TabFocus;
+}
+
+std::optional<Qt::Orientation> DiscreteSlider::accessibilityOrientation() const {
+	return Qt::Horizontal;
+}
+
+QAccessible::Role DiscreteSlider::accessibilityChildRole() const {
+	return QAccessible::PageTab;
+}
+
+QAccessible::State DiscreteSlider::accessibilityChildState(int index) const {
+	QAccessible::State state;
+	state.selectable = true;
+	if (ScreenReaderModeActive()) {
+		state.focusable = true;
+	}
+	if (index == _activeIndex) {
+		state.selected = true;
+	}
+	if (index == _accessibilitySelected) {
+		state.active = true;
+		if (hasFocus()) {
+			state.focused = true;
+		}
+	}
+	return state;
+}
+
+int DiscreteSlider::accessibilityChildCount() const {
+	return int(_sections.size());
+}
+
+QString DiscreteSlider::accessibilityChildName(int index) const {
+	if (index < 0 || index >= int(_sections.size())) {
+		return {};
+	}
+	return _sections[index].label.toString();
+}
+
+QRect DiscreteSlider::accessibilityChildRect(int index) const {
+	if (index < 0 || index >= int(_sections.size())) {
+		return {};
+	}
+	const auto &section = _sections[index];
+	return myrtlrect(section.left, 0, section.width, height());
+}
+
+bool DiscreteSlider::accessibilityChildSupportsActions(int index) const {
+	// Every section can be focused and activated, and each has a stable
+	// identity below. Tying the opt-in to a valid identity keeps the action
+	// interface off invalid indices.
+	return accessibilityChildIdentity(index) != 0;
+}
+
+quintptr DiscreteSlider::accessibilityChildIdentity(int index) const {
+	// The sections are rebuilt wholesale by setSections(), so an index is
+	// not stable by the time a queued action runs. The label text names a
+	// section within one slider; hash collisions (or duplicate labels) are
+	// possible but acceptable, same as in the language and country boxes.
+	// Shift instead of masking so that small hash values keep their
+	// distinguishing low bits; the tag bit keeps the token non-zero.
+	if (index < 0 || index >= int(_sections.size())) {
+		return 0;
+	}
+	const auto value = quintptr(qHash(_sections[index].label.toString()));
+	return value ? ((value << 3) | quintptr(1)) : quintptr(0);
+}
+
+int DiscreteSlider::accessibilityChildIndexByIdentity(
+		quintptr identity) const {
+	if (!identity) {
+		return -1;
+	}
+	const auto count = accessibilityChildCount();
+	for (auto i = 0; i != count; ++i) {
+		if (accessibilityChildIdentity(i) == identity) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+void DiscreteSlider::accessibilityChildSetFocus(quintptr identity) {
+	// UIA invokes provider actions (SetFocus) on a background thread, so hop
+	// to the main thread before touching any widget state. Resolve the stable
+	// identity to its current index here (not on the background thread) so a
+	// sections rebuild does not move focus to another section.
+	crl::on_main(this, [=] {
+		const auto index = accessibilityChildIndexByIdentity(identity);
+		if (index < 0) {
+			return;
+		}
+		// The sections are virtual (no real QWidget), so the screen reader's
+		// SetFocus can't move real keyboard focus to a section. Translate it
+		// into our browse position, then either announce it directly or grab
+		// keyboard focus (taking it announces the section by itself).
+		setAccessibilitySelected(
+			index,
+			hasFocus() ? Announce::Always : Announce::No);
+		if (!hasFocus()) {
+			setFocus();
+		}
+	});
+}
+
+void DiscreteSlider::accessibilityChildActivate(quintptr identity) {
+	// UIA invokes the press action on a background thread too; resolve the
+	// identity, move the browse position and activate the section on the
+	// main thread. Take focus onto the section first (as the SetFocus action
+	// does), so the "selected" announcement is heard from Invoke as well as
+	// from Space.
+	crl::on_main(this, [=] {
+		const auto index = accessibilityChildIndexByIdentity(identity);
+		if (index < 0) {
+			return;
+		}
+		setAccessibilitySelected(
+			index,
+			hasFocus() ? Announce::OnChange : Announce::No);
+		if (!hasFocus()) {
+			setFocus();
+		}
+		activateSectionByAccessibility(index);
+	});
 }
 
 DiscreteSlider::Section::Section(

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
@@ -57,6 +57,13 @@ public:
 	// owners of a scrollable slider can bring that section into view.
 	[[nodiscard]] rpl::producer<int> accessibilitySectionBrowsed() const;
 
+	// Whether the arrows switch to the tab they land on right away (the
+	// default - native Windows tab controls do) or only browse, committing
+	// on Enter / Space. Turn it off where a switch is expensive or has side
+	// effects, like the folder tabs: they reload the whole chat list, and a
+	// locked premium folder opens an upsell on activation.
+	void setAccessibilityActivateOnBrowse(bool activate);
+
 	[[nodiscard]] int sectionsCount() const;
 	[[nodiscard]] int lookupSectionLeft(int index) const;
 
@@ -165,6 +172,7 @@ private:
 	int _pressed = -1;
 	int _selected = 0;
 	int _accessibilitySelected = -1;
+	bool _accessibilityActivateOnBrowse = true;
 	Ui::Animations::Simple _a_left;
 	Ui::Animations::Simple _a_width;
 

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
@@ -53,14 +53,44 @@ public:
 		return _sectionActivated.events();
 	}
 
+	// Fired when the screen reader browse position moves to a section, so
+	// owners of a scrollable slider can bring that section into view.
+	[[nodiscard]] rpl::producer<int> accessibilitySectionBrowsed() const;
+
 	[[nodiscard]] int sectionsCount() const;
 	[[nodiscard]] int lookupSectionLeft(int index) const;
+
+	// Accessibility: a horizontal strip of painted tabs.
+	QAccessible::Role accessibilityRole() override;
+	bool accessibilitySelectionList() const override;
+	Qt::FocusPolicy accessibilityFocusPolicy() override;
+	std::optional<Qt::Orientation> accessibilityOrientation() const override;
+	QAccessible::Role accessibilityChildRole() const override;
+	QAccessible::State accessibilityChildState(int index) const override;
+	int accessibilityChildCount() const override;
+	QString accessibilityChildName(int index) const override;
+	QRect accessibilityChildRect(int index) const override;
+	bool accessibilityChildSupportsActions(int index) const override;
+	quintptr accessibilityChildIdentity(int index) const override;
+	int accessibilityChildIndexByIdentity(quintptr identity) const override;
+	void accessibilityChildSetFocus(quintptr identity) override;
+	void accessibilityChildActivate(quintptr identity) override;
 
 protected:
 	void timerEvent(QTimerEvent *e) override;
 	void mousePressEvent(QMouseEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;
 	void mouseReleaseEvent(QMouseEvent *e) override;
+	void keyPressEvent(QKeyEvent *e) override;
+	void focusInEvent(QFocusEvent *e) override;
+
+	// Activation coming from accessibility (keyboard or a screen reader
+	// action); subclasses can intercept it (e.g. locked premium folders).
+	virtual void activateSectionByAccessibility(int index);
+
+	// The section the browse position is on, or -1 when it isn't on any -
+	// a context menu opened from the keyboard has no position to look at.
+	[[nodiscard]] int accessibilityBrowsedSection() const;
 
 	int resizeGetHeight(int newWidth) override = 0;
 
@@ -108,12 +138,20 @@ protected:
 	[[nodiscard]] bool paused() const;
 
 private:
+	enum class Announce {
+		No,
+		OnChange,
+		Always,
+	};
+
 	void activateCallback();
 	virtual const style::TextStyle &getLabelStyle() const = 0;
 	virtual int getAnimationDuration() const = 0;
 
 	int getIndexFromPosition(QPoint pos);
 	void setSelectedSection(int index);
+	void setAccessibilitySelected(int index, Announce announce);
+	void browseAndActivate(int index);
 
 	std::vector<Section> _sections;
 	Fn<bool()> _paused;
@@ -122,9 +160,11 @@ private:
 	bool _snapToLabel = false;
 
 	rpl::event_stream<int> _sectionActivated;
+	rpl::event_stream<int> _accessibilitySectionBrowsed;
 
 	int _pressed = -1;
 	int _selected = 0;
+	int _accessibilitySelected = -1;
 	Ui::Animations::Simple _a_left;
 	Ui::Animations::Simple _a_width;
 


### PR DESCRIPTION
The tab-like switchers built on Ui::DiscreteSlider / SettingsSlider (search result tabs, stickers box tabs, emoji panel tabs, message options box tabs and so on) were invisible to screen readers: the sections are painted, so there was nothing to focus or read.

The slider now reports itself as a tab control with one virtual tab per section - the UI calls these controls tabs, so the screen reader calls them that too. In screen reader mode the widget becomes a Tab stop: Tab lands on the active tab, and the arrows (mirrored in RTL) and Home/End switch right away to the tab they land on, the way native Windows tab controls behave - the switch is announced through the focus move, so the screen reader reads the tab it landed on. UIA SetFocus / Invoke are dispatched by a stable per-section identity on the main thread.

Not every strip wants that: where switching loads content or can be refused, setAccessibilityActivateOnBrowse(false) keeps a browse-then-commit model - the arrows only move the reading position and announce the tab with its selected state, Enter or Space activates. The search scope tabs (#31184) and the chat folder tabs (#31098) use it. For such subclasses the browse position is exposed as an rpl producer (accessibilitySectionBrowsed), so a scrollable strip can bring the browsed tab into view, activation goes through a protected virtual (activateSectionByAccessibility), so locked premium folders can be intercepted, and a protected accessor (accessibilityBrowsedSection) lets a keyboard-invoked context menu anchor on the browsed tab - a menu asked for from the keyboard arrives with the center of an empty input method rect, so a position based lookup can't find the right one.

Three things outside this repo are needed on Windows, all about what the Qt 5 UIA bridge does and doesn't forward:

- desktop-app/patches#263. Qt 5.15 forwards a focus event to focusChild() only for an accessible with a table interface, so taking focus announced the container and not the tab it points at. Upstream generalized the condition to any element with children in 6.2, and that patch backports it.
- desktop-app/lib_ui#348. The selection interface is what carries the "selected" / "not selected" state a screen reader reads; that PR lets it accept tab items and makes a browsed painted section win over the selected one when the container forwards focus.
- desktop-app/lib_ui#345. The bridge reads only the checked flag out of a state change, so reporting a new selection that way stayed silent. The selection events raised on activation are the ones a screen reader actually hears.

Tested with NVDA on Windows 10 with all three applied: Tab lands on the active tab and it is announced once, and the arrows switch and announce the tab they land on, exactly like the native Windows tab controls. Without a screen reader nothing changes - the widget is not focusable outside screen reader mode.
