### PR TITLE
Make the chat folder tabs and the chat list column accessible

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -730,6 +730,11 @@ Widget::Widget(
 
 	_search->customUpDown(true);
 
+	// The bars above the list and the folder tabs are created only once they
+	// are needed, long after the list and the buttons below it, so the Tab
+	// chain has to follow the column instead of the creation order.
+	setVisualTabOrder(true);
+
 	updateJumpToDateVisibility(true);
 	updateSearchFromVisibility(true);
 	setupSupportMode();

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
@@ -7,6 +7,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "ui/widgets/chat_filters_tabs_slider.h"
 
+#include "lang/lang_keys.h"
 #include "ui/effects/ripple_animation.h"
 #include "ui/widgets/side_bar_button.h"
 #include "styles/style_dialogs.h"
@@ -169,15 +170,18 @@ void ChatsFiltersTabs::setUnreadCount(int index, int unreadCount, bool mute) {
 				.muted = mute,
 			});
 			update();
+			accessibilityChildNameChanged(index);
 		}
 	} else if (!unreadCount) {
 		_unreadCounts.erase(it);
 		update();
+		accessibilityChildNameChanged(index);
 	} else if (it->second.count != unreadCount || it->second.muted != mute) {
 		it->second.count = unreadCount;
 		it->second.muted = mute;
 		it->second.cache = cacheUnreadCount(unreadCount, mute);
 		update();
+		accessibilityChildNameChanged(index);
 	}
 	updateSectionsContentWidths();
 }
@@ -436,6 +440,41 @@ void ChatsFiltersTabs::contextMenuEvent(QContextMenuEvent *e) {
 		return true;
 	});
 	_contextMenuRequested.fire_copy(index);
+}
+
+QString ChatsFiltersTabs::accessibilityChildName(int index) const {
+	const auto title = Ui::SettingsSlider::accessibilityChildName(index);
+	if (_lockedFrom > 0 && index >= _lockedFrom) {
+		// Surface a locked folder's premium-gated status, which the visual
+		// lock glyph alone can't convey to a screen reader.
+		return tr::lng_sr_folder_locked(tr::now, lt_text, title);
+	}
+	const auto it = _unreadCounts.find(index);
+	return (it != _unreadCounts.end())
+		? tr::lng_filter_unread_chats(
+			tr::now,
+			lt_count,
+			it->second.count,
+			lt_text,
+			title)
+		: title;
+}
+
+QString ChatsFiltersTabs::accessibilityChildDescription(int index) const {
+	return (_lockedFrom > 0 && index >= _lockedFrom)
+		? tr::lng_sr_folder_locked_about(tr::now)
+		: QString();
+}
+
+void ChatsFiltersTabs::activateSectionByAccessibility(int index) {
+	// Keyboard or screen reader activation of a locked (premium) folder
+	// behaves like a click on it: show the premium promo instead of
+	// switching to a folder the user can't use.
+	if (_lockedFrom > 0 && index >= _lockedFrom) {
+		_lockedClicked.fire({});
+	} else {
+		Ui::SettingsSlider::activateSectionByAccessibility(index);
+	}
 }
 
 rpl::producer<int> ChatsFiltersTabs::contextMenuRequested() const {

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
@@ -424,6 +424,18 @@ void ChatsFiltersTabs::mouseReleaseEvent(QMouseEvent *e) {
 }
 
 void ChatsFiltersTabs::contextMenuEvent(QContextMenuEvent *e) {
+	if (e->reason() == QContextMenuEvent::Keyboard) {
+		// A menu asked for from the keyboard comes with the center of an
+		// empty input method rect instead of a position over a tab, so the
+		// lookup below would land outside of them all - take the tab the
+		// browse position is on, or the active one when it is on none.
+		const auto browsed = accessibilityBrowsedSection();
+		const auto index = (browsed >= 0) ? browsed : activeSection();
+		if (!_lockedFrom || index < _lockedFrom) {
+			_contextMenuRequested.fire_copy(index);
+		}
+		return;
+	}
 	const auto pos = e->pos();
 	if (pos.x() >= _lockedFromX) {
 		return;

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "lang/lang_keys.h"
 #include "ui/effects/ripple_animation.h"
+#include "ui/widgets/popup_menu.h"
 #include "ui/widgets/side_bar_button.h"
 #include "styles/style_dialogs.h"
 #include "styles/style_widgets.h"
@@ -432,7 +433,13 @@ void ChatsFiltersTabs::contextMenuEvent(QContextMenuEvent *e) {
 		const auto browsed = accessibilityBrowsedSection();
 		const auto index = (browsed >= 0) ? browsed : activeSection();
 		if (!_lockedFrom || index < _lockedFrom) {
-			_contextMenuRequested.fire_copy(index);
+			_contextMenuRequested.fire({
+				.index = index,
+				.position = ContextMenuPosition(
+					this,
+					e,
+					accessibilityChildRect(index)),
+			});
 		}
 		return;
 	}
@@ -451,7 +458,10 @@ void ChatsFiltersTabs::contextMenuEvent(QContextMenuEvent *e) {
 		index++;
 		return true;
 	});
-	_contextMenuRequested.fire_copy(index);
+	_contextMenuRequested.fire({
+		.index = index,
+		.position = QCursor::pos(),
+	});
 }
 
 QString ChatsFiltersTabs::accessibilityChildName(int index) const {
@@ -489,7 +499,8 @@ void ChatsFiltersTabs::activateSectionByAccessibility(int index) {
 	}
 }
 
-rpl::producer<int> ChatsFiltersTabs::contextMenuRequested() const {
+auto ChatsFiltersTabs::contextMenuRequested() const
+-> rpl::producer<ChatsFiltersTabMenuRequest> {
 	return _contextMenuRequested.events();
 }
 

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.h
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.h
@@ -25,6 +25,11 @@ class SettingsSlider;
 
 class ChatsFiltersTabsReorder;
 
+struct ChatsFiltersTabMenuRequest {
+	int index = 0;
+	QPoint position; // Global coordinates for showing the menu.
+};
+
 class ChatsFiltersTabs final : public Ui::SettingsSlider {
 public:
 	ChatsFiltersTabs(
@@ -45,7 +50,8 @@ public:
 		return _lockedFrom;
 	}
 
-	[[nodiscard]] rpl::producer<int> contextMenuRequested() const;
+	[[nodiscard]] auto contextMenuRequested() const
+		-> rpl::producer<ChatsFiltersTabMenuRequest>;
 	[[nodiscard]] rpl::producer<> lockedClicked() const;
 
 	void setHorizontalShift(int index, int shift);
@@ -114,7 +120,7 @@ private:
 	int _reordering = 0;
 
 	rpl::lifetime _paletteLifetime;
-	rpl::event_stream<int> _contextMenuRequested;
+	rpl::event_stream<ChatsFiltersTabMenuRequest> _contextMenuRequested;
 	rpl::event_stream<> _lockedClicked;
 
 };

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.h
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.h
@@ -58,6 +58,9 @@ public:
 
 	void stopAnimation();
 
+	QString accessibilityChildName(int index) const override;
+	QString accessibilityChildDescription(int index) const override;
+
 protected:
 	struct ShiftedSection {
 		not_null<Ui::DiscreteSlider::Section*> section;
@@ -71,6 +74,7 @@ protected:
 	void mouseMoveEvent(QMouseEvent *e) override;
 	void mouseReleaseEvent(QMouseEvent *e) override;
 	void contextMenuEvent(QContextMenuEvent *e) override;
+	void activateSectionByAccessibility(int index) override;
 
 	std::vector<ShiftedSection> _sections;
 

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
@@ -230,6 +230,7 @@ not_null<Ui::RpWidget*> AddChatFiltersTabsStrip(
 			trackActiveFilterAndUnreadAndReorder
 				? st::dialogsSearchTabs
 				: st::chatsFiltersTabs));
+	slider->setAccessibleName(tr::lng_filters_title(tr::now));
 	const auto state = wrap->lifetime().make_state<State>();
 	const auto reassignUnreadValue = [=] {
 		state->reorderLifetime.destroy();

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
@@ -365,6 +365,14 @@ not_null<Ui::RpWidget*> AddChatFiltersTabsStrip(
 		}
 	};
 
+	slider->accessibilitySectionBrowsed(
+	) | rpl::on_next([=](int index) {
+		// Browsing with a screen reader moves between sections without
+		// activating them, so nothing else scrolls the strip; keep the
+		// browsed section visible.
+		scrollToIndex(index, anim::type::normal);
+	}, slider->lifetime());
+
 	const auto applyFilter = [=](const Data::ChatFilter &filter) {
 		if (slider->reordering()) {
 			return;

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
@@ -62,7 +62,8 @@ void ShowMenu(
 		not_null<Ui::RpWidget*> parent,
 		not_null<Window::SessionController*> controller,
 		not_null<State*> state,
-		int index) {
+		int index,
+		QPoint position) {
 	const auto session = &controller->session();
 
 	auto id = FilterId(0);
@@ -133,7 +134,7 @@ void ShowMenu(
 		state->menu = nullptr;
 		return;
 	}
-	state->menu->popup(QCursor::pos());
+	state->menu->popup(position);
 }
 
 void ShowFiltersListMenu(
@@ -141,6 +142,7 @@ void ShowFiltersListMenu(
 		not_null<Main::Session*> session,
 		not_null<State*> state,
 		int active,
+		QPoint position,
 		Fn<void(int)> changeActive) {
 	const auto &list = session->data().chatsFilters().list();
 
@@ -195,7 +197,7 @@ void ShowFiltersListMenu(
 		state->menu = nullptr;
 		return;
 	}
-	state->menu->popup(QCursor::pos());
+	state->menu->popup(position);
 }
 
 } // namespace
@@ -501,15 +503,22 @@ not_null<Ui::RpWidget*> AddChatFiltersTabsStrip(
 			}
 			applyFilter(filter);
 		}, state->rebuildLifetime);
-		slider->contextMenuRequested() | rpl::on_next([=](int index) {
+		slider->contextMenuRequested() | rpl::on_next([=](
+				Ui::ChatsFiltersTabMenuRequest request) {
 			if (trackActiveFilterAndUnreadAndReorder) {
-				ShowMenu(wrap, controller, state, index);
+				ShowMenu(
+					wrap,
+					controller,
+					state,
+					request.index,
+					request.position);
 			} else {
 				ShowFiltersListMenu(
 					wrap,
 					session,
 					state,
 					slider->activeSection(),
+					request.position,
 					[=](int i) { slider->setActiveSection(i); });
 			}
 		}, state->rebuildLifetime);

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
@@ -233,6 +233,10 @@ not_null<Ui::RpWidget*> AddChatFiltersTabsStrip(
 				? st::dialogsSearchTabs
 				: st::chatsFiltersTabs));
 	slider->setAccessibleName(tr::lng_filters_title(tr::now));
+	// Switching a folder reloads the whole chat list, and a locked premium
+	// folder opens an upsell on activation - so the arrows only browse the
+	// folder tabs, committing on Enter / Space.
+	slider->setAccessibilityActivateOnBrowse(false);
 	const auto state = wrap->lifetime().make_state<State>();
 	const auto reassignUnreadValue = [=] {
 		state->reorderLifetime.destroy();


### PR DESCRIPTION
Depends on #31097 and builds on top of it: that PR exposes the painted sections of Ui::DiscreteSlider as accessible tabs, this one completes the chat folder tabs strip specifically. It contains no code from #31097 - it only compiles once that lands, since it overrides a virtual and subscribes to a producer introduced there. With #31097 the strips switch to the tab the arrows land on; the folder tabs keep the browse-then-commit model through the opt-out added there (the last commit here), since switching folders reloads the chat list and the strip may include locked ones - the arrows only browse and announce, Enter or Space commits.

Keyboard or screen reader activation of a locked (premium) folder now behaves like a click on it: the premium promo opens instead of switching to a folder the user cannot use. Folder tab names include the unread count via the existing lng_filter_unread_chats key and locked folders get the lng_sr_folder_locked name and description, mirroring the folders sidebar. Unread count changes fire a name-changed event so a screen reader focused on a tab picks them up, and the strip container is named with lng_filters_title instead of being announced as a bare tab control. Browsing with arrows also scrolls the strip to keep the browsed tab visible, reusing the same scrollToIndex animation the strip already uses when the active filter changes. No new lang keys.

The folder context menu (edit, mark as read, remove) was reachable with a right click only. contextMenuEvent looked up the tab under e->pos(), but a menu asked for from the keyboard comes with the center of an empty input method rect, so the lookup ran past every section and the request was dropped - the menu key did nothing. A keyboard request now takes the tab the browse position is on, or the active one when it is on none, and skips locked folders like the mouse path does. The menu is also anchored on that tab (through Ui::ContextMenuPosition from desktop-app/lib_ui#348) instead of the mouse cursor, which may sit nowhere near the strip; a mouse-invoked menu keeps opening at the cursor.

The third commit orders the chat list column in the Tab chain by position, with setVisualTabOrder. The bars above the list and the folder tabs strip are created only once they are needed, long after the list and the buttons below it, so Tab used to reach the folder tabs after the list instead of before it. It now follows the column: main menu, search, the bars, the folder tabs, the list, jump to top, the buttons at the bottom.

Tested with NVDA on Windows 10 with both PRs applied: browsing the folder tabs reads titles with unread counts and scrolls overflowing tabs into view, Enter activates the browsed folder or opens the premium box on a locked one, the menu key opens the menu of the browsed folder, and Tab walks the column top to bottom.
