### PR TITLE
Fix reply keyboards in bot forum topics

### DIFF
--- a/Telegram/SourceFiles/data/data_forum.cpp
+++ b/Telegram/SourceFiles/data/data_forum.cpp
@@ -549,6 +549,7 @@ ForumTopic *Forum::reserveNewBotTopic() {
 void Forum::discardCreatingId(MsgId rootId) {
 	Expects(creating(rootId));
 
+	_history->removeTopicReplyKeyboard(rootId);
 	const auto i = _topics.find(rootId);
 	if (i != end(_topics)) {
 		Assert(!i->second->inChatList());
@@ -571,6 +572,7 @@ void Forum::created(MsgId rootId, MsgId realId) {
 	auto topic = std::move(i->second);
 	_topics.erase(i);
 	const auto id = FullMsgId(_history->peer->id, realId);
+	_history->migrateTopicReplyKeyboard(rootId, realId);
 	if (!_topics.contains(realId)) {
 		_topics.emplace(
 			realId,

--- a/Telegram/SourceFiles/data/data_session.cpp
+++ b/Telegram/SourceFiles/data/data_session.cpp
@@ -2858,6 +2858,7 @@ bool Session::updateExistingMessage(const MTPDmessage &data) {
 		return false;
 	}
 	existing->applySentMessage(data);
+	existing->history()->applyItemReplyKeyboard(existing);
 	const auto result = (existing->mainView() != nullptr);
 	if (result) {
 		stickers().checkSavedGif(existing);

--- a/Telegram/SourceFiles/history/history.cpp
+++ b/Telegram/SourceFiles/history/history.cpp
@@ -178,16 +178,247 @@ History::History(not_null<Data::Session*> owner, PeerId peerId)
 
 History::~History() = default;
 
+void History::notifyReplyKeyboardUpdated() {
+	session().changes().historyUpdated(this, UpdateFlag::BotKeyboard);
+}
+
+MsgId History::replyKeyboardTopicKey(MsgId topicRootId) const {
+	return isForum() ? topicRootId : MsgId(0);
+}
+
+History::ReplyKeyboardState &History::replyKeyboardState(MsgId topicRootId) {
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	Expects(key != 0);
+	return _topicReplyKeyboards[key];
+}
+
+const History::ReplyKeyboardState &History::replyKeyboardState(
+		MsgId topicRootId) const {
+	static const ReplyKeyboardState kEmpty;
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	if (!key) {
+		return kEmpty;
+	}
+	const auto i = _topicReplyKeyboards.find(key);
+	if (i != end(_topicReplyKeyboards)) {
+		return i->second;
+	}
+	return kEmpty;
+}
+
 void History::clearLastKeyboard() {
+	auto changed = false;
 	if (lastKeyboardId) {
 		if (lastKeyboardId == lastKeyboardHiddenId) {
 			lastKeyboardHiddenId = 0;
 		}
 		lastKeyboardId = 0;
-		session().changes().historyUpdated(this, UpdateFlag::BotKeyboard);
+		changed = true;
 	}
 	lastKeyboardInited = true;
 	lastKeyboardFrom = 0;
+	if (!_topicReplyKeyboards.empty()) {
+		for (auto &[id, state] : _topicReplyKeyboards) {
+			if (state.id) {
+				changed = true;
+			}
+			state = ReplyKeyboardState{ .inited = true };
+		}
+	}
+	if (changed) {
+		notifyReplyKeyboardUpdated();
+	}
+}
+
+void History::clearLastKeyboard(MsgId topicRootId) {
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	if (!key) {
+		if (lastKeyboardId) {
+			if (lastKeyboardId == lastKeyboardHiddenId) {
+				lastKeyboardHiddenId = 0;
+			}
+			lastKeyboardId = 0;
+			notifyReplyKeyboardUpdated();
+		}
+		lastKeyboardInited = true;
+		lastKeyboardFrom = 0;
+		return;
+	}
+	auto &state = _topicReplyKeyboards[key];
+	const auto had = (state.id != 0);
+	if (state.id == state.hiddenId) {
+		state.hiddenId = 0;
+	}
+	state.id = 0;
+	state.from = 0;
+	state.inited = true;
+	state.used = false;
+	if (had) {
+		notifyReplyKeyboardUpdated();
+	}
+}
+
+void History::applyItemReplyKeyboard(not_null<HistoryItem*> item) {
+	if (!item->definesReplyKeyboard() || item->out()) {
+		return;
+	}
+	const auto markupFlags = item->replyKeyboardFlags();
+	if ((markupFlags & ReplyMarkupFlag::Selective) && !item->mentionsMe()) {
+		return;
+	}
+
+	const auto from = item->from();
+	const auto markupSenders = [&]() -> base::flat_set<not_null<PeerData*>>* {
+		if (const auto chat = peer->asChat()) {
+			return &chat->markupSenders;
+		} else if (const auto channel = peer->asMegagroup()) {
+			return &channel->mgInfo->markupSenders;
+		}
+		return nullptr;
+	}();
+	if (markupSenders) {
+		markupSenders->insert(from);
+	}
+
+	const auto topicKey = replyKeyboardTopicKey(item->topicRootId());
+	const auto isOlderThan = [&](MsgId lastUpdateId) {
+		return lastUpdateId
+			&& item->isRegular()
+			&& lastUpdateId > item->id;
+	};
+	if (topicKey) {
+		const auto i = _topicReplyKeyboards.find(topicKey);
+		if (i != end(_topicReplyKeyboards)
+			&& isOlderThan(i->second.lastUpdateId)) {
+			return;
+		}
+	} else if (isOlderThan(lastKeyboardUpdateId)) {
+		return;
+	}
+	const auto applyHide = [&] {
+		if (topicKey) {
+			const auto i = _topicReplyKeyboards.find(topicKey);
+			if (i != end(_topicReplyKeyboards)
+				&& i->second.inited
+				&& i->second.id
+				&& i->second.from != from->id) {
+				return;
+			}
+			if (i != end(_topicReplyKeyboards) && i->second.inited) {
+				clearLastKeyboard(topicKey);
+			} else {
+				_topicReplyKeyboards[topicKey] = {
+					.inited = true,
+				};
+			}
+			_topicReplyKeyboards[topicKey].lastUpdateId = item->id;
+		} else if (lastKeyboardFrom == from->id
+			|| (lastKeyboardInited && !lastKeyboardId)
+			|| (!lastKeyboardInited
+				&& !peer->isChat()
+				&& !peer->isMegagroup())) {
+			clearLastKeyboard(MsgId(0));
+			lastKeyboardUpdateId = item->id;
+		}
+	};
+	const auto applyShow = [&] {
+		auto botNotInChat = false;
+		if (peer->isChat()) {
+			botNotInChat = from->isUser()
+				&& (!peer->asChat()->participants.empty()
+					|| !Data::CanSendAnything(peer))
+				&& !peer->asChat()->participants.contains(from->asUser());
+		} else if (peer->isMegagroup()) {
+			botNotInChat = from->isUser()
+				&& (peer->asChannel()->mgInfo->botStatus
+						!= Data::BotStatus::Unknown
+					|| !Data::CanSendAnything(peer))
+				&& !peer->asChannel()->mgInfo->bots.contains(from->asUser());
+		}
+		if (botNotInChat) {
+			clearLastKeyboard(topicKey);
+			if (topicKey) {
+				_topicReplyKeyboards[topicKey].lastUpdateId = item->id;
+			} else {
+				lastKeyboardUpdateId = item->id;
+			}
+			return;
+		}
+		if (topicKey) {
+			auto &state = _topicReplyKeyboards[topicKey];
+			const auto changed = (state.id != item->id)
+				|| (state.from != from->id)
+				|| !state.inited;
+			state.inited = true;
+			state.lastUpdateId = item->id;
+			if (changed) {
+				state.id = item->id;
+				state.from = from->id;
+				state.used = false;
+				state.hiddenId = 0;
+				notifyReplyKeyboardUpdated();
+			}
+		} else {
+			const auto changed = (lastKeyboardId != item->id)
+				|| (lastKeyboardFrom != from->id)
+				|| !lastKeyboardInited;
+			lastKeyboardInited = true;
+			lastKeyboardUpdateId = item->id;
+			if (changed) {
+				lastKeyboardId = item->id;
+				lastKeyboardFrom = from->id;
+				lastKeyboardUsed = false;
+				lastKeyboardHiddenId = 0;
+				notifyReplyKeyboardUpdated();
+			}
+		}
+	};
+
+	if (markupFlags & ReplyMarkupFlag::None) {
+		applyHide();
+	} else {
+		applyShow();
+	}
+}
+
+void History::migrateTopicReplyKeyboard(MsgId fromRootId, MsgId toRootId) {
+	if (!fromRootId
+		|| !toRootId
+		|| fromRootId == toRootId
+		|| !isForum()) {
+		return;
+	}
+	const auto fromIt = _topicReplyKeyboards.find(fromRootId);
+	if (fromIt == end(_topicReplyKeyboards)) {
+		return;
+	}
+	const auto toIt = _topicReplyKeyboards.find(toRootId);
+	if (toIt != end(_topicReplyKeyboards) && toIt->second.inited) {
+		_topicReplyKeyboards.erase(fromIt);
+		return;
+	}
+	auto state = std::move(fromIt->second);
+	_topicReplyKeyboards.erase(fromIt);
+	_topicReplyKeyboards[toRootId] = std::move(state);
+	if (_topicReplyKeyboards[toRootId].id) {
+		notifyReplyKeyboardUpdated();
+	}
+}
+
+void History::removeTopicReplyKeyboard(MsgId topicRootId) {
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	if (!key) {
+		return;
+	}
+	const auto i = _topicReplyKeyboards.find(key);
+	if (i == end(_topicReplyKeyboards)) {
+		return;
+	}
+	const auto changed = (i->second.id != 0);
+	_topicReplyKeyboards.erase(i);
+	if (changed) {
+		notifyReplyKeyboardUpdated();
+	}
 }
 
 int History::height() const {
@@ -257,8 +488,13 @@ void History::itemVanished(not_null<HistoryItem*> item) {
 	if (const auto thread = item->maybeNotificationThread()) {
 		thread->removeNotification(item);
 	}
-	if (lastKeyboardId == item->id) {
-		clearLastKeyboard();
+	if (const auto key = replyKeyboardTopicKey(item->topicRootId())) {
+		const auto i = _topicReplyKeyboards.find(key);
+		if (i != end(_topicReplyKeyboards) && i->second.id == item->id) {
+			clearLastKeyboard(key);
+		}
+	} else if (lastKeyboardId == item->id) {
+		clearLastKeyboard(MsgId(0));
 	}
 	if ((!item->out() || item->isPost())
 		&& item->unread(this)
@@ -840,6 +1076,7 @@ not_null<HistoryItem*> History::addNewItem(
 	}
 
 	if (!loadedAtBottom() || peer->migrateTo()) {
+		applyItemReplyKeyboard(item);
 		setLastMessage(item);
 		if (unread) {
 			const auto type = item->out()
@@ -1163,56 +1400,7 @@ not_null<HistoryItem*> History::addNewToBack(
 			}
 		}
 	}
-	if (item->definesReplyKeyboard()) {
-		const auto markupFlags = item->replyKeyboardFlags();
-		if (!(markupFlags & ReplyMarkupFlag::Selective)
-			|| item->mentionsMe()) {
-			const auto markupSenders = [&]() -> base::flat_set<not_null<PeerData*>>* {
-				if (const auto chat = peer->asChat()) {
-					return &chat->markupSenders;
-				} else if (const auto channel = peer->asMegagroup()) {
-					return &channel->mgInfo->markupSenders;
-				}
-				return nullptr;
-			}();
-			if (markupSenders) {
-				markupSenders->insert(from);
-			}
-			if (markupFlags & ReplyMarkupFlag::None) {
-				// None markup means replyKeyboardHide.
-				if (lastKeyboardFrom == from->id
-					|| (!lastKeyboardInited
-						&& !peer->isChat()
-						&& !peer->isMegagroup()
-						&& !item->out())) {
-					clearLastKeyboard();
-				}
-			} else {
-				bool botNotInChat = false;
-				if (peer->isChat()) {
-					botNotInChat = from->isUser()
-						&& (!peer->asChat()->participants.empty()
-							|| !Data::CanSendAnything(peer))
-						&& !peer->asChat()->participants.contains(
-							from->asUser());
-				} else if (peer->isMegagroup()) {
-					botNotInChat = from->isUser()
-						&& (peer->asChannel()->mgInfo->botStatus != Data::BotStatus::Unknown
-							|| !Data::CanSendAnything(peer))
-						&& !peer->asChannel()->mgInfo->bots.contains(
-							from->asUser());
-				}
-				if (botNotInChat) {
-					clearLastKeyboard();
-				} else {
-					lastKeyboardInited = true;
-					lastKeyboardId = item->id;
-					lastKeyboardFrom = from->id;
-					lastKeyboardUsed = false;
-				}
-			}
-		}
-	}
+	applyItemReplyKeyboard(item);
 
 	setLastMessage(item);
 	if (unread) {
@@ -1288,8 +1476,19 @@ void History::applyServiceChanges(
 		}
 	}, [&](const MTPDmessageActionChatDeleteUser &data) {
 		const auto uid = data.vuser_id().v;
-		if (lastKeyboardFrom == peerFromUser(uid)) {
-			clearLastKeyboard();
+		const auto fromId = peerFromUser(uid);
+		if (lastKeyboardFrom == fromId) {
+			clearLastKeyboard(MsgId(0));
+		}
+		for (auto i = begin(_topicReplyKeyboards)
+			; i != end(_topicReplyKeyboards);) {
+			if (i->second.from == fromId) {
+				const auto key = i->first;
+				++i;
+				clearLastKeyboard(key);
+			} else {
+				++i;
+			}
 		}
 		if (const auto megagroup = peer->asMegagroup()) {
 			if (const auto user = owner().userLoaded(uid)) {
@@ -1944,50 +2143,96 @@ void History::addItemsToLists(
 			}
 		}
 		if (item->author()->id) {
+			const auto topicKey = replyKeyboardTopicKey(item->topicRootId());
+			const auto keyboardInited = [&] {
+				if (topicKey) {
+					const auto i = _topicReplyKeyboards.find(topicKey);
+					return (i != end(_topicReplyKeyboards)) && i->second.inited;
+				}
+				return lastKeyboardInited;
+			};
 			if (markupSenders) { // chats with bots
-				if (!lastKeyboardInited && item->definesReplyKeyboard() && !item->out()) {
+				if (!keyboardInited()
+					&& item->definesReplyKeyboard()
+					&& !item->out()) {
 					const auto markupFlags = item->replyKeyboardFlags();
-					if (!(markupFlags & ReplyMarkupFlag::Selective) || item->mentionsMe()) {
-						bool wasKeyboardHide = markupSenders->contains(item->author());
+					if (!(markupFlags & ReplyMarkupFlag::Selective)
+						|| item->mentionsMe()) {
+						const auto wasKeyboardHide = markupSenders->contains(
+							item->author());
 						if (!wasKeyboardHide) {
 							markupSenders->insert(item->author());
 						}
 						if (!(markupFlags & ReplyMarkupFlag::None)) {
-							if (!lastKeyboardInited) {
+							if (!keyboardInited()) {
 								bool botNotInChat = false;
 								if (peer->isChat()) {
 									botNotInChat = (!Data::CanSendAnything(peer)
 										|| !peer->asChat()->participants.empty())
 										&& item->author()->isUser()
-										&& !peer->asChat()->participants.contains(item->author()->asUser());
+										&& !peer->asChat()->participants.contains(
+											item->author()->asUser());
 								} else if (peer->isMegagroup()) {
 									botNotInChat = (!Data::CanSendAnything(peer)
-										|| peer->asChannel()->mgInfo->botStatus != Data::BotStatus::Unknown)
+										|| peer->asChannel()->mgInfo->botStatus
+											!= Data::BotStatus::Unknown)
 										&& item->author()->isUser()
-										&& !peer->asChannel()->mgInfo->bots.contains(item->author()->asUser());
+										&& !peer->asChannel()->mgInfo->bots.contains(
+											item->author()->asUser());
 								}
 								if (wasKeyboardHide || botNotInChat) {
-									clearLastKeyboard();
+									clearLastKeyboard(topicKey);
+									if (topicKey) {
+										_topicReplyKeyboards[topicKey]
+											.lastUpdateId = item->id;
+									} else {
+										lastKeyboardUpdateId = item->id;
+									}
+								} else if (topicKey) {
+									auto &state = _topicReplyKeyboards[topicKey];
+									state.inited = true;
+									state.id = item->id;
+									state.from = item->author()->id;
+									state.used = false;
+									state.lastUpdateId = item->id;
 								} else {
 									lastKeyboardInited = true;
 									lastKeyboardId = item->id;
 									lastKeyboardFrom = item->author()->id;
 									lastKeyboardUsed = false;
+									lastKeyboardUpdateId = item->id;
 								}
 							}
 						}
 					}
 				}
-			} else if (!lastKeyboardInited && item->definesReplyKeyboard() && !item->out()) { // conversations with bots
+			} else if (!keyboardInited()
+				&& item->definesReplyKeyboard()
+				&& !item->out()) { // conversations with bots
 				const auto markupFlags = item->replyKeyboardFlags();
-				if (!(markupFlags & ReplyMarkupFlag::Selective) || item->mentionsMe()) {
+				if (!(markupFlags & ReplyMarkupFlag::Selective)
+					|| item->mentionsMe()) {
 					if (markupFlags & ReplyMarkupFlag::None) {
-						clearLastKeyboard();
+						clearLastKeyboard(topicKey);
+						if (topicKey) {
+							_topicReplyKeyboards[topicKey].lastUpdateId
+								= item->id;
+						} else {
+							lastKeyboardUpdateId = item->id;
+						}
+					} else if (topicKey) {
+						auto &state = _topicReplyKeyboards[topicKey];
+						state.inited = true;
+						state.id = item->id;
+						state.from = item->author()->id;
+						state.used = false;
+						state.lastUpdateId = item->id;
 					} else {
 						lastKeyboardInited = true;
 						lastKeyboardId = item->id;
 						lastKeyboardFrom = item->author()->id;
 						lastKeyboardUsed = false;
+						lastKeyboardUpdateId = item->id;
 					}
 				}
 			}
@@ -4363,6 +4608,8 @@ void History::clear(ClearType type, bool markEmpty) {
 	blocks.clear();
 	owner().notifyHistoryUnloaded(this);
 	lastKeyboardInited = false;
+	lastKeyboardUpdateId = 0;
+	_topicReplyKeyboards.clear();
 	if (type == ClearType::Unload) {
 		_loadedAtTop = _loadedAtBottom = markEmpty;
 	} else {

--- a/Telegram/SourceFiles/history/history.h
+++ b/Telegram/SourceFiles/history/history.h
@@ -300,7 +300,23 @@ public:
 		return &_sendActionPainter;
 	}
 
+	struct ReplyKeyboardState {
+		bool inited = false;
+		bool used = false;
+		MsgId id = 0;
+		MsgId hiddenId = 0;
+		MsgId lastUpdateId = 0;
+		PeerId from = 0;
+	};
+
 	void clearLastKeyboard();
+	void clearLastKeyboard(MsgId topicRootId);
+	void applyItemReplyKeyboard(not_null<HistoryItem*> item);
+	void migrateTopicReplyKeyboard(MsgId fromRootId, MsgId toRootId);
+	void removeTopicReplyKeyboard(MsgId topicRootId);
+	[[nodiscard]] ReplyKeyboardState &replyKeyboardState(MsgId topicRootId);
+	[[nodiscard]] const ReplyKeyboardState &replyKeyboardState(
+		MsgId topicRootId) const;
 	void clearUnreadMentionsFor(MsgId topicRootId);
 	void clearUnreadReactionsFor(
 		MsgId topicRootId,
@@ -499,12 +515,16 @@ public:
 	bool lastKeyboardUsed = false;
 	MsgId lastKeyboardId = 0;
 	MsgId lastKeyboardHiddenId = 0;
+	MsgId lastKeyboardUpdateId = 0;
 	PeerId lastKeyboardFrom = 0;
 
 	mtpRequestId sendRequestId = 0;
 
 private:
 	friend class HistoryBlock;
+
+	[[nodiscard]] MsgId replyKeyboardTopicKey(MsgId topicRootId) const;
+	void notifyReplyKeyboardUpdated();
 
 	enum class Flag : ushort {
 		HasPendingResizedItems = (1 << 0),
@@ -700,6 +720,7 @@ private:
 	base::flat_map<Data::DraftKey, Data::ForwardDraft> _forwardDrafts;
 
 	base::flat_map<MsgId, TimeId> _unknownDeletedMessages;
+	base::flat_map<MsgId, ReplyKeyboardState> _topicReplyKeyboards;
 
 	QString _topPromotedMessage;
 	QString _topPromotedType;

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -8438,6 +8438,8 @@ void HistoryWidget::updateBotKeyboard(History *h, bool force) {
 		changed = _keyboard->updateMarkup(nullptr, force);
 	} else if (_replyTo && _replyEditMsg) {
 		changed = _keyboard->updateMarkup(_replyEditMsg, force);
+	} else if (_history->peer->isForum()) {
+		changed = _keyboard->updateMarkup(nullptr, force);
 	} else {
 		const auto keyboardItem = _history->lastKeyboardId
 			? session().data().message(

--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
+++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
@@ -24,6 +24,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "calls/group/ui/calls_group_stars_coloring.h"
 #include "calls/group/calls_group_stars_box.h"
 #include "chat_helpers/compose/compose_show.h"
+#include "chat_helpers/bot_command.h"
+#include "chat_helpers/bot_keyboard.h"
 #include "chat_helpers/emoji_suggestions_widget.h"
 #include "chat_helpers/message_field.h"
 #include "chat_helpers/tabbed_panel.h"
@@ -103,6 +105,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/fields/input_field.h"
 #include "ui/widgets/dropdown_menu.h"
 #include "ui/widgets/popup_menu.h"
+#include "ui/widgets/scroll_area.h"
 #include "ui/text/format_values.h"
 #include "ui/controls/compose_ai_button_factory.h"
 #include "ui/controls/emoji_button.h"
@@ -1195,6 +1198,7 @@ void ComposeControls::updateTopicRootId(MsgId topicRootId) {
 	trackThreadFieldVisibility();
 	registerDraftSource();
 	updateFieldVisibility();
+	updateBotKeyboard(true);
 }
 
 void ComposeControls::updateShortcutId(BusinessShortcutId shortcutId) {
@@ -1220,6 +1224,17 @@ void ComposeControls::setHistory(SetHistoryArgs &&args) {
 		: rpl::single(0);
 	const auto history = *args.history;
 	if (_history == history) {
+		if (_topicRootId != args.topicRootId) {
+			updateTopicRootId(args.topicRootId);
+		}
+		if (_monoforumPeerId != args.monoforumPeerId) {
+			unregisterDraftSources();
+			_monoforumPeerId = args.monoforumPeerId;
+			_header->setHistory(args);
+			registerDraftSource();
+			updateFieldVisibility();
+			updateBotKeyboard(true);
+		}
 		return;
 	}
 	untrackThreadFieldVisibility();
@@ -1247,6 +1262,7 @@ void ComposeControls::setHistory(SetHistoryArgs &&args) {
 	_sendAs = nullptr;
 	_silent = nullptr;
 	if (!_history) {
+		updateBotKeyboard(true);
 		return;
 	}
 	const auto peer = _history->peer;
@@ -1268,6 +1284,55 @@ void ComposeControls::setHistory(SetHistoryArgs &&args) {
 	_field->setMode(args.videoStream
 		? Ui::InputField::Mode::NoNewlines
 		: Ui::InputField::Mode::MultiLine);
+
+	session().changes().historyUpdates(
+		_history,
+		Data::HistoryUpdate::Flag::BotKeyboard
+	) | rpl::on_next([=] {
+		updateBotKeyboard(true);
+	}, _historyLifetime);
+	session().data().historyChanged(
+	) | rpl::filter([=](not_null<const History*> history) {
+		return history == _history;
+	}) | rpl::on_next([=] {
+		updateBotKeyboard();
+	}, _historyLifetime);
+	session().changes().messageUpdates(
+		Data::MessageUpdate::Flag::ReplyMarkup
+		| Data::MessageUpdate::Flag::NewAdded
+		| Data::MessageUpdate::Flag::NewMaybeAdded
+	) | rpl::filter([=](const Data::MessageUpdate &update) {
+		if (update.item->history() != _history) {
+			return false;
+		}
+		if (update.flags & Data::MessageUpdate::Flag::ReplyMarkup) {
+			return _keyboard
+				&& (_keyboard->forMsgId() == update.item->fullId());
+		}
+		if (_topicRootId
+			&& update.item->topicRootId() != _topicRootId) {
+			return false;
+		}
+		if (!update.item->definesReplyKeyboard() || update.item->out()) {
+			return false;
+		}
+		if (update.flags & Data::MessageUpdate::Flag::NewMaybeAdded) {
+			const auto key = keyboardTopicKey();
+			const auto keyboardId = key
+				? _history->replyKeyboardState(key).id
+				: _history->lastKeyboardId;
+			const auto shownId = _keyboard
+				? _keyboard->forMsgId().msg
+				: MsgId();
+			return keyboardId != shownId;
+		}
+		return true;
+	}) | rpl::on_next([=](const Data::MessageUpdate &) {
+		crl::on_main(_wrap.get(), [=] {
+			updateBotKeyboard(true);
+		});
+	}, _historyLifetime);
+	updateBotKeyboard(true);
 }
 
 void ComposeControls::initLikeButton() {
@@ -1885,6 +1950,255 @@ rpl::producer<VoiceToSend> ComposeControls::sendVoiceRequests() const {
 
 rpl::producer<QString> ComposeControls::sendCommandRequests() const {
 	return _sendCommandRequests.events();
+}
+
+rpl::producer<Bot::SendCommandRequest>
+ComposeControls::botKeyboardCommandRequests() const {
+	return _botKeyboardCommandRequests.events();
+}
+
+void ComposeControls::botKeyboardCommandSent(
+		const Bot::SendCommandRequest &request) {
+	if (!_history || !_keyboard || !request.replyTo) {
+		return;
+	}
+	const auto key = keyboardTopicKey();
+	const auto keyboardId = key
+		? _history->replyKeyboardState(key).id
+		: _history->lastKeyboardId;
+	const auto forMsgId = _keyboard->forMsgId();
+	if (!_keyboard->singleUse()
+		|| !_keyboard->hasMarkup()
+		|| forMsgId != request.replyTo.messageId
+		|| forMsgId != FullMsgId(_history->peer->id, keyboardId)) {
+		return;
+	}
+	if (_kbShown) {
+		toggleKeyboard(false);
+	}
+	if (key) {
+		_history->replyKeyboardState(key).used = true;
+	} else {
+		_history->lastKeyboardUsed = true;
+	}
+}
+
+MsgId ComposeControls::keyboardTopicKey() const {
+	if (!_history || !_history->isForum() || !_topicRootId) {
+		return MsgId(0);
+	}
+	return _topicRootId;
+}
+
+int ComposeControls::keyboardHeight() const {
+	return (_kbShown && _kbScroll) ? _kbScroll->height() : 0;
+}
+
+bool ComposeControls::kbWasHidden() const {
+	if (!_history || !_keyboard) {
+		return false;
+	}
+	const auto forId = _keyboard->forMsgId();
+	if (!forId) {
+		return false;
+	}
+	if (const auto key = keyboardTopicKey()) {
+		return forId.msg == _history->replyKeyboardState(key).hiddenId;
+	}
+	return forId.msg == _history->lastKeyboardHiddenId;
+}
+
+void ComposeControls::showKeyboardHideButton() {
+	if (!_botKeyboardHide || !_keyboard || !_history) {
+		return;
+	}
+	_botKeyboardHide->setVisible(!_history->peer->isUser()
+		|| !_keyboard->persistent());
+}
+
+void ComposeControls::initBotKeyboard() {
+	if (!_regularWindow || _kbScroll) {
+		return;
+	}
+	_kbScroll = std::make_unique<Ui::ScrollArea>(_wrap.get(), st::botKbScroll);
+	_keyboard = _kbScroll->setOwnedWidget(object_ptr<BotKeyboard>(
+		_regularWindow,
+		_wrap.get())).data();
+	_botKeyboardShow = Ui::CreateChild<Ui::IconButton>(
+		_wrap.get(),
+		st::historyBotKeyboardShow);
+	_botKeyboardHide = Ui::CreateChild<Ui::IconButton>(
+		_wrap.get(),
+		st::historyBotKeyboardHide);
+	_kbScroll->hide();
+	_botKeyboardShow->hide();
+	_botKeyboardHide->hide();
+	_botKeyboardShow->setAccessibleName(tr::lng_bot_keyboard_show(tr::now));
+	_botKeyboardHide->setAccessibleName(tr::lng_bot_keyboard_hide(tr::now));
+	_botKeyboardShow->addClickHandler([=] { toggleKeyboard(); });
+	_botKeyboardHide->addClickHandler([=] { toggleKeyboard(); });
+	_keyboard->sendCommandRequests(
+	) | rpl::on_next([=](Bot::SendCommandRequest request) {
+		_botKeyboardCommandRequests.fire(std::move(request));
+	}, _kbScroll->lifetime());
+}
+
+void ComposeControls::toggleKeyboard(bool manual) {
+	if (!_keyboard || !_history) {
+		return;
+	}
+	const auto key = keyboardTopicKey();
+	if (_kbShown) {
+		if (_botKeyboardHide) {
+			_botKeyboardHide->hide();
+		}
+		if (_botKeyboardShow) {
+			_botKeyboardShow->show();
+		}
+		if (manual) {
+			if (key) {
+				_history->replyKeyboardState(key).hiddenId
+					= _keyboard->forMsgId().msg;
+			} else {
+				_history->lastKeyboardHiddenId = _keyboard->forMsgId().msg;
+			}
+		}
+		if (_kbScroll) {
+			_kbScroll->hide();
+		}
+		_kbShown = false;
+		_tabbedSelectorToggle->show();
+		updateHeight();
+		updateControlsVisibility();
+		updateControlsGeometry(_wrap->size());
+	} else if (_keyboard->hasMarkup()) {
+		showKeyboardHideButton();
+		if (_botKeyboardShow) {
+			_botKeyboardShow->hide();
+		}
+		if (_kbScroll) {
+			_kbScroll->show();
+		}
+		_kbShown = true;
+		_tabbedSelectorToggle->hide();
+		if (manual) {
+			if (key) {
+				_history->replyKeyboardState(key).hiddenId = 0;
+			} else {
+				_history->lastKeyboardHiddenId = 0;
+			}
+		}
+		updateHeight();
+		updateControlsVisibility();
+		updateControlsGeometry(_wrap->size());
+	}
+}
+
+void ComposeControls::updateBotKeyboard(bool force) {
+	if (!_regularWindow) {
+		return;
+	}
+	initBotKeyboard();
+	if (!_keyboard) {
+		return;
+	}
+
+	const auto wasVisible = _kbShown;
+	const auto wasMsgId = _keyboard->forMsgId();
+	auto changed = false;
+	if (!_history || isEditingMessage()) {
+		changed = _keyboard->updateMarkup(nullptr, force);
+	} else {
+		const auto key = keyboardTopicKey();
+		const auto keyboardId = key
+			? _history->replyKeyboardState(key).id
+			: _history->lastKeyboardId;
+		const auto keyboardUsed = key
+			? _history->replyKeyboardState(key).used
+			: _history->lastKeyboardUsed;
+		const auto forceMarkup = force
+			|| (keyboardId
+				&& wasMsgId.msg
+				&& wasMsgId.msg != keyboardId);
+		const auto keyboardItem = keyboardId
+			? session().data().message(_history->peer, keyboardId)
+			: nullptr;
+		changed = _keyboard->updateMarkup(keyboardItem, forceMarkup);
+		if (_keyboard->singleUse()
+			&& _keyboard->hasMarkup()
+			&& keyboardId
+			&& keyboardUsed
+			&& (_keyboard->forMsgId()
+				== FullMsgId(_history->peer->id, keyboardId))) {
+			if (key) {
+				_history->replyKeyboardState(key).hiddenId = keyboardId;
+			} else {
+				_history->lastKeyboardHiddenId = keyboardId;
+			}
+		}
+	}
+	if (changed && _keyboard->forMsgId() != wasMsgId && _kbScroll) {
+		_kbScroll->scrollTo({ 0, 0 });
+	}
+	if (changed) {
+		_keyboard->update();
+	}
+
+	const auto hasMarkup = _keyboard->hasMarkup();
+	const auto forceReply = _keyboard->forceReply();
+	const auto markupReplaced = changed
+		&& hasMarkup
+		&& wasMsgId.msg
+		&& (_keyboard->forMsgId().msg != wasMsgId.msg);
+	const auto canShow = hasMarkup
+		&& !isEditingMessage()
+		&& !kbWasHidden()
+		&& (wasVisible
+			|| markupReplaced
+			|| !hasSendableContent()
+			|| force);
+	if (canShow) {
+		if (_kbScroll) {
+			_kbScroll->show();
+		}
+		_tabbedSelectorToggle->hide();
+		showKeyboardHideButton();
+		if (_botKeyboardShow) {
+			_botKeyboardShow->hide();
+		}
+		if (_botCommandStart) {
+			_botCommandStart->hide();
+		}
+		_kbShown = true;
+	} else if (hasMarkup || forceReply) {
+		if (_kbScroll) {
+			_kbScroll->hide();
+		}
+		_tabbedSelectorToggle->show();
+		if (_botKeyboardHide) {
+			_botKeyboardHide->hide();
+		}
+		if (_botKeyboardShow) {
+			_botKeyboardShow->setVisible(hasMarkup);
+		}
+		_kbShown = false;
+	} else {
+		if (_kbScroll) {
+			_kbScroll->hide();
+		}
+		_tabbedSelectorToggle->show();
+		if (_botKeyboardHide) {
+			_botKeyboardHide->hide();
+		}
+		if (_botKeyboardShow) {
+			_botKeyboardShow->hide();
+		}
+		_kbShown = false;
+	}
+	updateFieldPlaceholder();
+	updateHeight();
+	updateControlsVisibility();
+	updateControlsGeometry(_wrap->size());
 }
 
 rpl::producer<MessageToEdit> ComposeControls::editRequests() const {
@@ -2712,12 +3026,18 @@ void ComposeControls::updateFieldPlaceholder() {
 
 	const auto ephemeralReply = session().ephemeralMessages()
 		.isEphemeralBotReply(replyingToMessage().messageId);
+	const auto keyboardPlaceholder = (_keyboard
+		&& (_kbShown || _keyboard->forceReply()))
+		? _keyboard->placeholder()
+		: QString();
 	_field->setPlaceholder([&] {
 		const auto peer = _history ? _history->peer.get() : nullptr;
 		if (_fieldCustomPlaceholder) {
 			return rpl::duplicate(_fieldCustomPlaceholder);
 		} else if (isEditingMessage()) {
 			return tr::lng_edit_message_text();
+		} else if (!keyboardPlaceholder.isEmpty()) {
+			return rpl::single(keyboardPlaceholder) | rpl::type_erased;
 		} else if (!peer) {
 			return tr::lng_message_ph();
 		} else if (const auto stars = ephemeralReply
@@ -2773,6 +3093,15 @@ void ComposeControls::fieldChanged() {
 		&& !suppressSendAction());
 	updateSendButtonType();
 	_hasSendText = _field->isVisible() && HasSendText(_field);
+	if (_kbShown && _hasSendText.current()) {
+		toggleKeyboard();
+	} else if (!_kbShown
+		&& _keyboard
+		&& _keyboard->hasMarkup()
+		&& !_hasSendText.current()
+		&& !kbWasHidden()) {
+		updateBotKeyboard();
+	}
 	if (updateBotCommandShown() || updateLikeShown()) {
 		updateControlsVisibility();
 		updateControlsGeometry(_wrap->size());
@@ -4027,11 +4356,14 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	// (_commentsShown) (_attachToggle|_replaceMedia) (_sendAs) -- _inlineResults ------ _tabbedPanel -- _fieldBarCancel (_starsReaction)
 	// (_attachDocument|_attachPhoto) _field (_ttlInfo) (_scheduled) (_silent|_botCommandStart) _tabbedSelectorToggle _send
 
+	const auto kbheight = keyboardHeight();
 	const auto oldComposeHeight = shouldShowRichDraftPreview()
 		? _richDraftPreview->height()
 		: _field->height();
 	const auto commentsShown = _commentsShown
 		&& !_commentsShown->isHidden();
+	const auto kbShowShown = _botKeyboardShow
+		&& !_botKeyboardShow->isHidden();
 	const auto fieldWidth = size.width()
 		- (commentsShown
 			? (_commentsShown->width() + _st.commentsSkip)
@@ -4042,9 +4374,12 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 		- _st.padding.right()
 		- _send->width()
 		- (_editStars ? _editStars->width() : 0)
-		- _tabbedSelectorToggle->width()
+		- (_kbShown
+			? (_botKeyboardHide ? _botKeyboardHide->width() : 0)
+			: _tabbedSelectorToggle->width())
+		- (kbShowShown ? _botKeyboardShow->width() : 0)
 		- (_likeShown ? _like->width() : 0)
-		- (_botCommandShown ? _botCommandStart->width() : 0)
+		- (_botCommandShown && !_kbShown ? _botCommandStart->width() : 0)
 		- ((_silent && !_silent->isHidden()) ? _silent->width() : 0)
 		- ((_scheduled && !_scheduled->isHidden())
 			? _scheduled->width()
@@ -4071,7 +4406,15 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 		}
 	}
 
-	const auto buttonsTop = size.height() - _st.attach.height;
+	if (_kbShown && _kbScroll) {
+		_kbScroll->setGeometryToLeft(
+			0,
+			size.height() - kbheight,
+			size.width(),
+			kbheight);
+	}
+
+	const auto buttonsTop = size.height() - kbheight - _st.attach.height;
 
 	auto left = 0;
 	if (commentsShown) {
@@ -4093,7 +4436,10 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	const auto fieldHeight = shouldShowRichDraftPreview()
 		? _richDraftPreview->height()
 		: _field->height();
-	const auto fieldTop = size.height() - _st.padding.bottom() - fieldHeight;
+	const auto fieldTop = size.height()
+		- kbheight
+		- _st.padding.bottom()
+		- fieldHeight;
 	_field->moveToLeft(left, fieldTop);
 	if (_richDraftPreview) {
 		_richDraftPreview->moveToLeft(left, fieldTop);
@@ -4116,8 +4462,17 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 		_editStars->moveToRight(right, buttonsTop);
 		right += _editStars->width();
 	}
-	_tabbedSelectorToggle->moveToRight(right, buttonsTop);
-	right += _tabbedSelectorToggle->width();
+	if (_kbShown && _botKeyboardHide) {
+		_botKeyboardHide->moveToRight(right, buttonsTop);
+		right += _botKeyboardHide->width();
+	} else {
+		_tabbedSelectorToggle->moveToRight(right, buttonsTop);
+		right += _tabbedSelectorToggle->width();
+	}
+	if (_botKeyboardShow && !_botKeyboardShow->isHidden()) {
+		_botKeyboardShow->moveToRight(right, buttonsTop);
+		right += _botKeyboardShow->width();
+	}
 	if (_like) {
 		using Type = Controls::WriteRestrictionType;
 		if (_writeRestriction.current().type == Type::PremiumRequired) {
@@ -4131,7 +4486,7 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	}
 	if (_botCommandStart) {
 		_botCommandStart->moveToRight(right, buttonsTop);
-		if (_botCommandShown) {
+		if (_botCommandShown && !_kbShown) {
 			right += _botCommandStart->width();
 		}
 	}
@@ -4157,7 +4512,7 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	_voiceRecordBar->resizeToWidth(size.width());
 	_voiceRecordBar->moveToLeft(
 		0,
-		size.height() - _voiceRecordBar->height());
+		size.height() - kbheight - _voiceRecordBar->height());
 }
 
 void ComposeControls::updateControlsVisibility() {
@@ -4643,14 +4998,26 @@ void ComposeControls::toggleTabbedSelectorMode() {
 }
 
 void ComposeControls::updateHeight() {
+	auto kbheight = 0;
+	if (_kbShown && _keyboard && _kbScroll) {
+		const auto maxKeyboardHeight = std::max(
+			st::historyComposeFieldMaxHeight / 2,
+			_field->height());
+		_keyboard->resizeToWidth(_wrap->width(), maxKeyboardHeight);
+		kbheight = std::min(_keyboard->height(), maxKeyboardHeight);
+		_kbScroll->resize(_wrap->width(), kbheight);
+	}
 	const auto height = (_header->isDisplayed() ? _header->height() : 0)
 		+ _st.padding.top()
 		+ (shouldShowRichDraftPreview()
 			? _richDraftPreview->height()
 			: _field->height())
-		+ _st.padding.bottom();
+		+ _st.padding.bottom()
+		+ kbheight;
 	if (height != _wrap->height()) {
 		_wrap->resize(_wrap->width(), height);
+	} else if (kbheight) {
+		updateControlsGeometry(_wrap->size());
 	}
 }
 

--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.h
+++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.h
@@ -20,8 +20,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/fields/input_field.h"
 
 class History;
+class HistoryItem;
 class DocumentData;
 class Image;
+class BotKeyboard;
 
 namespace style {
 struct ComposeControls;
@@ -60,6 +62,10 @@ class Result;
 struct ResultSelected;
 } // namespace InlineBots
 
+namespace Bot {
+struct SendCommandRequest;
+} // namespace Bot
+
 namespace Ui {
 class AbstractButton;
 class SendButton;
@@ -68,6 +74,7 @@ class EmojiButton;
 class SendAsButton;
 class SilentToggle;
 class DropdownMenu;
+class ScrollArea;
 struct PreparedBundle;
 struct PreparedList;
 struct SendStarButtonState;
@@ -201,6 +208,9 @@ public:
 	[[nodiscard]] rpl::producer<Api::SendOptions> sendRequests() const;
 	[[nodiscard]] rpl::producer<VoiceToSend> sendVoiceRequests() const;
 	[[nodiscard]] rpl::producer<QString> sendCommandRequests() const;
+	[[nodiscard]] rpl::producer<Bot::SendCommandRequest>
+	botKeyboardCommandRequests() const;
+	void botKeyboardCommandSent(const Bot::SendCommandRequest &request);
 	[[nodiscard]] rpl::producer<MessageToEdit> editRequests() const;
 	[[nodiscard]] rpl::producer<std::optional<bool>> attachRequests() const;
 	void setSendAsFileConfirmed(
@@ -375,6 +385,14 @@ private:
 	void updateSilentBroadcast();
 	void editMessage(not_null<HistoryItem*> item);
 
+	void initBotKeyboard();
+	void updateBotKeyboard(bool force = false);
+	void toggleKeyboard(bool manual = true);
+	[[nodiscard]] bool kbWasHidden() const;
+	void showKeyboardHideButton();
+	[[nodiscard]] int keyboardHeight() const;
+	[[nodiscard]] MsgId keyboardTopicKey() const;
+
 	void escape();
 	void fieldChanged();
 	[[nodiscard]] bool suppressSendAction() const;
@@ -511,6 +529,10 @@ private:
 	const not_null<Ui::InputField*> _field;
 	std::unique_ptr<Controls::RichDraftPreview> _richDraftPreview;
 	Ui::IconButton * const _botCommandStart = nullptr;
+	std::unique_ptr<Ui::ScrollArea> _kbScroll;
+	BotKeyboard *_keyboard = nullptr;
+	Ui::IconButton *_botKeyboardShow = nullptr;
+	Ui::IconButton *_botKeyboardHide = nullptr;
 	std::unique_ptr<Ui::SendAsButton> _sendAs;
 	rpl::variable<bool> _videoStreamAdmin;
 	std::unique_ptr<Ui::SilentToggle> _silent;
@@ -541,6 +563,7 @@ private:
 	rpl::event_stream<InlineChosen> _inlineResultChosen;
 	rpl::event_stream<SendActionUpdate> _sendActionUpdates;
 	rpl::event_stream<QString> _sendCommandRequests;
+	rpl::event_stream<Bot::SendCommandRequest> _botKeyboardCommandRequests;
 	rpl::event_stream<not_null<QKeyEvent*>> _scrollKeyEvents;
 	rpl::event_stream<not_null<QKeyEvent*>> _editLastMessageRequests;
 	rpl::event_stream<std::optional<bool>> _attachRequests;
@@ -571,6 +594,7 @@ private:
 	mtpRequestId _inlineBotResolveRequestId = 0;
 	bool _isInlineBot = false;
 	bool _botCommandShown = false;
+	bool _kbShown = false;
 	bool _likeShown = false;
 	Webrtc::RecordAvailability _recordAvailability = {};
 

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
@@ -51,6 +51,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "api/api_sending.h"
 #include "apiwrap.h"
 #include "ui/boxes/confirm_box.h"
+#include "chat_helpers/bot_command.h"
 #include "chat_helpers/message_field.h"
 #include "chat_helpers/tabbed_selector.h"
 #include "boxes/delete_messages_box.h"
@@ -886,6 +887,15 @@ void ChatWidget::setupComposeControls() {
 	_composeControls->sendCommandRequests(
 	) | rpl::on_next([=](const QString &command) {
 		listSendBotCommand(command, FullMsgId());
+		session().api().finishForwarding(prepareSendAction({}));
+	}, lifetime());
+
+	_composeControls->botKeyboardCommandRequests(
+	) | rpl::on_next([=](const Bot::SendCommandRequest &request) {
+		if (request.peer != _peer) {
+			return;
+		}
+		sendBotKeyboardCommandWithOptions(request, {});
 		session().api().finishForwarding(prepareSendAction({}));
 	}, lifetime());
 
@@ -3567,6 +3577,46 @@ void ChatWidget::sendBotCommandWithOptions(
 	}
 
 	session().api().sendMessage(std::move(message));
+	finishSending();
+}
+
+void ChatWidget::sendBotKeyboardCommandWithOptions(
+		Bot::SendCommandRequest request,
+		Api::SendOptions options) {
+	if (request.peer != _peer) {
+		return;
+	} else if (!request.replyTo) {
+		sendBotCommandWithOptions(request.command, request.context, options);
+		return;
+	}
+
+	auto message = Api::MessageToSend(prepareSendAction(options));
+	message.textWithTags = { request.command, TextWithTags::Tags() };
+	if (!_peer->isUser()) {
+		message.action.replyTo = request.replyTo;
+	}
+
+	const auto ephemeral = session().ephemeralMessages().wouldSend(message);
+	if (!ephemeral && showSlowmodeError()) {
+		return;
+	}
+	if (!ephemeral) {
+		const auto withPaymentApproved = [=](int approved) {
+			auto copy = options;
+			copy.starsApproved = approved;
+			sendBotKeyboardCommandWithOptions(request, copy);
+		};
+		const auto checked = checkSendPayment(
+			1,
+			options,
+			withPaymentApproved);
+		if (!checked) {
+			return;
+		}
+	}
+
+	session().api().sendMessage(std::move(message));
+	_composeControls->botKeyboardCommandSent(request);
 	finishSending();
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.h
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.h
@@ -376,6 +376,9 @@ private:
 		const QString &command,
 		const FullMsgId &context,
 		Api::SendOptions options);
+	void sendBotKeyboardCommandWithOptions(
+		Bot::SendCommandRequest request,
+		Api::SendOptions options);
 
 	bool sendExistingDocument(
 		not_null<DocumentData*> document,


### PR DESCRIPTION
## Summary

- keep reply keyboard state per bot forum topic
- hide topic keyboards in the All feed while showing the correct keyboard in each thread
- refresh live keyboard replacements and migrate state from temporary to server topic IDs
- send keyboard button text through the normal slow-mode and paid-message checks

## Why

Telegram Desktop kept one reply keyboard per history. Bot forum topics share a history, so the All feed showed a topic keyboard while individual threads showed none at all. Mobile clients correctly showed the matching reply keyboard in each topic.

## Steps to reproduce

1. Open a private chat with a bot that has threaded mode enabled.
2. Open a topic where the bot sends `ReplyKeyboardMarkup`.
3. Switch between **All** and that topic.
4. Have the bot replace the keyboard, or create a new topic whose first reply contains a keyboard.

Before this change, **All** displayed a topic keyboard of the latest topic, topic views displayed none

## Before
<img width="1804" height="1391" alt="1" src="https://github.com/user-attachments/assets/4ba05a88-959b-4a73-8535-9998c619c311" />
<img width="1802" height="1461" alt="2" src="https://github.com/user-attachments/assets/fd8cbe0d-eec7-484f-bf99-c8eb02f79ecb" />


## Testing

- Windows x64 Debug build with MSVC 14.44
- manually verified that All hides keyboards, existing and newly created threads show their own keyboards, and live replacements appear without restarting

## Related

- [Custom Keyboard not visible in Topic / Forum chats in Telegram Desktop](https://bugs.telegram.org/c/47099)
