### PR TITLE
Fix reply keyboards in bot forum topics

### DIFF
--- a/Telegram/SourceFiles/api/api_chat_participants.cpp
+++ b/Telegram/SourceFiles/api/api_chat_participants.cpp
@@ -192,7 +192,7 @@ void ApplyBotsList(
 
 	auto needBotsInfos = false;
 	auto botStatus = channel->mgInfo->botStatus;
-	auto keyboardBotFound = !history || !history->lastKeyboardFrom;
+	auto present = base::flat_set<PeerId>();
 	for (const auto &p : list) {
 		const auto participant = channel->owner().peer(p.id());
 		const auto user = participant->asUser();
@@ -203,16 +203,13 @@ void ApplyBotsList(
 				needBotsInfos = true;
 			}
 		}
-		if (!keyboardBotFound
-			&& participant->id == history->lastKeyboardFrom) {
-			keyboardBotFound = true;
-		}
+		present.emplace(participant->id);
 	}
 	if (needBotsInfos) {
 		channel->session().api().requestFullPeer(channel);
 	}
-	if (!keyboardBotFound) {
-		history->clearLastKeyboard();
+	if (history) {
+		history->validateReplyKeyboardSenders(present);
 	}
 
 	channel->mgInfo->botStatus = botStatus;

--- a/Telegram/SourceFiles/data/data_forum.cpp
+++ b/Telegram/SourceFiles/data/data_forum.cpp
@@ -549,6 +549,7 @@ ForumTopic *Forum::reserveNewBotTopic() {
 void Forum::discardCreatingId(MsgId rootId) {
 	Expects(creating(rootId));
 
+	_history->removeTopicReplyKeyboard(rootId);
 	const auto i = _topics.find(rootId);
 	if (i != end(_topics)) {
 		Assert(!i->second->inChatList());
@@ -571,6 +572,7 @@ void Forum::created(MsgId rootId, MsgId realId) {
 	auto topic = std::move(i->second);
 	_topics.erase(i);
 	const auto id = FullMsgId(_history->peer->id, realId);
+	_history->migrateTopicReplyKeyboard(rootId, realId);
 	if (!_topics.contains(realId)) {
 		_topics.emplace(
 			realId,

--- a/Telegram/SourceFiles/data/data_session.cpp
+++ b/Telegram/SourceFiles/data/data_session.cpp
@@ -2858,6 +2858,7 @@ bool Session::updateExistingMessage(const MTPDmessage &data) {
 		return false;
 	}
 	existing->applySentMessage(data);
+	existing->history()->applyItemReplyKeyboard(existing);
 	const auto result = (existing->mainView() != nullptr);
 	if (result) {
 		stickers().checkSavedGif(existing);

--- a/Telegram/SourceFiles/history/history.cpp
+++ b/Telegram/SourceFiles/history/history.cpp
@@ -178,16 +178,270 @@ History::History(not_null<Data::Session*> owner, PeerId peerId)
 
 History::~History() = default;
 
+void History::notifyReplyKeyboardUpdated() {
+	session().changes().historyUpdated(this, UpdateFlag::BotKeyboard);
+}
+
+MsgId History::replyKeyboardTopicKey(MsgId topicRootId) const {
+	return isForum() ? topicRootId : MsgId(0);
+}
+
+History::ReplyKeyboardState &History::replyKeyboardState(MsgId topicRootId) {
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	Expects(key != 0);
+	return _topicReplyKeyboards[key];
+}
+
+const History::ReplyKeyboardState &History::replyKeyboardState(
+		MsgId topicRootId) const {
+	static const ReplyKeyboardState kEmpty;
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	if (!key) {
+		return kEmpty;
+	}
+	const auto i = _topicReplyKeyboards.find(key);
+	if (i != end(_topicReplyKeyboards)) {
+		return i->second;
+	}
+	return kEmpty;
+}
+
 void History::clearLastKeyboard() {
+	auto changed = false;
 	if (lastKeyboardId) {
 		if (lastKeyboardId == lastKeyboardHiddenId) {
 			lastKeyboardHiddenId = 0;
 		}
 		lastKeyboardId = 0;
-		session().changes().historyUpdated(this, UpdateFlag::BotKeyboard);
+		changed = true;
 	}
 	lastKeyboardInited = true;
 	lastKeyboardFrom = 0;
+	if (!_topicReplyKeyboards.empty()) {
+		for (auto &[id, state] : _topicReplyKeyboards) {
+			if (state.id) {
+				changed = true;
+			}
+			state = ReplyKeyboardState{ .inited = true };
+		}
+	}
+	if (changed) {
+		notifyReplyKeyboardUpdated();
+	}
+}
+
+void History::clearLastKeyboard(MsgId topicRootId) {
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	if (!key) {
+		if (lastKeyboardId) {
+			if (lastKeyboardId == lastKeyboardHiddenId) {
+				lastKeyboardHiddenId = 0;
+			}
+			lastKeyboardId = 0;
+			notifyReplyKeyboardUpdated();
+		}
+		lastKeyboardInited = true;
+		lastKeyboardFrom = 0;
+		return;
+	}
+	auto &state = _topicReplyKeyboards[key];
+	const auto had = (state.id != 0);
+	if (state.id == state.hiddenId) {
+		state.hiddenId = 0;
+	}
+	state.id = 0;
+	state.from = 0;
+	state.inited = true;
+	state.used = false;
+	if (had) {
+		notifyReplyKeyboardUpdated();
+	}
+}
+
+void History::validateReplyKeyboardSenders(
+		const base::flat_set<PeerId> &presentPeerIds) {
+	if (lastKeyboardFrom && !presentPeerIds.contains(lastKeyboardFrom)) {
+		clearLastKeyboard(MsgId(0));
+	}
+	for (auto i = begin(_topicReplyKeyboards)
+		; i != end(_topicReplyKeyboards);) {
+		const auto from = i->second.from;
+		if (from && !presentPeerIds.contains(from)) {
+			const auto key = i->first;
+			++i;
+			clearLastKeyboard(key);
+		} else {
+			++i;
+		}
+	}
+}
+
+void History::applyItemReplyKeyboard(not_null<HistoryItem*> item) {
+	if (!item->definesReplyKeyboard() || item->out()) {
+		return;
+	}
+	const auto markupFlags = item->replyKeyboardFlags();
+	if ((markupFlags & ReplyMarkupFlag::Selective) && !item->mentionsMe()) {
+		return;
+	}
+
+	const auto from = item->from();
+	const auto topicKey = replyKeyboardTopicKey(item->topicRootId());
+	if (topicKey) {
+		_topicMarkupSenders[topicKey].emplace(from);
+	} else if (const auto chat = peer->asChat()) {
+		chat->markupSenders.emplace(from);
+	} else if (const auto channel = peer->asMegagroup()) {
+		channel->mgInfo->markupSenders.emplace(from);
+	}
+
+	const auto isOlderThan = [&](MsgId lastUpdateId) {
+		return lastUpdateId
+			&& item->isRegular()
+			&& lastUpdateId > item->id;
+	};
+	if (topicKey) {
+		const auto i = _topicReplyKeyboards.find(topicKey);
+		if (i != end(_topicReplyKeyboards)
+			&& isOlderThan(i->second.lastUpdateId)) {
+			return;
+		}
+	} else if (isOlderThan(lastKeyboardUpdateId)) {
+		return;
+	}
+	const auto applyHide = [&] {
+		if (topicKey) {
+			const auto i = _topicReplyKeyboards.find(topicKey);
+			if (i != end(_topicReplyKeyboards)
+				&& i->second.inited
+				&& i->second.id
+				&& i->second.from != from->id) {
+				return;
+			}
+			if (i != end(_topicReplyKeyboards) && i->second.inited) {
+				clearLastKeyboard(topicKey);
+			} else {
+				_topicReplyKeyboards[topicKey] = {
+					.inited = true,
+				};
+			}
+			_topicReplyKeyboards[topicKey].lastUpdateId = item->id;
+		} else if (lastKeyboardFrom == from->id
+			|| (lastKeyboardInited && !lastKeyboardId)
+			|| (!lastKeyboardInited
+				&& !peer->isChat()
+				&& !peer->isMegagroup())) {
+			clearLastKeyboard(MsgId(0));
+			lastKeyboardUpdateId = item->id;
+		}
+	};
+	const auto applyShow = [&] {
+		auto botNotInChat = false;
+		if (peer->isChat()) {
+			botNotInChat = from->isUser()
+				&& (!peer->asChat()->participants.empty()
+					|| !Data::CanSendAnything(peer))
+				&& !peer->asChat()->participants.contains(from->asUser());
+		} else if (peer->isMegagroup()) {
+			botNotInChat = from->isUser()
+				&& (peer->asChannel()->mgInfo->botStatus
+						!= Data::BotStatus::Unknown
+					|| !Data::CanSendAnything(peer))
+				&& !peer->asChannel()->mgInfo->bots.contains(from->asUser());
+		}
+		if (botNotInChat) {
+			clearLastKeyboard(topicKey);
+			if (topicKey) {
+				_topicReplyKeyboards[topicKey].lastUpdateId = item->id;
+			} else {
+				lastKeyboardUpdateId = item->id;
+			}
+			return;
+		}
+		if (topicKey) {
+			auto &state = _topicReplyKeyboards[topicKey];
+			const auto changed = (state.id != item->id)
+				|| (state.from != from->id)
+				|| !state.inited;
+			state.inited = true;
+			state.lastUpdateId = item->id;
+			if (changed) {
+				state.id = item->id;
+				state.from = from->id;
+				state.used = false;
+				state.hiddenId = 0;
+				notifyReplyKeyboardUpdated();
+			}
+		} else {
+			const auto changed = (lastKeyboardId != item->id)
+				|| (lastKeyboardFrom != from->id)
+				|| !lastKeyboardInited;
+			lastKeyboardInited = true;
+			lastKeyboardUpdateId = item->id;
+			if (changed) {
+				lastKeyboardId = item->id;
+				lastKeyboardFrom = from->id;
+				lastKeyboardUsed = false;
+				lastKeyboardHiddenId = 0;
+				notifyReplyKeyboardUpdated();
+			}
+		}
+	};
+
+	if (markupFlags & ReplyMarkupFlag::None) {
+		applyHide();
+	} else {
+		applyShow();
+	}
+}
+
+void History::migrateTopicReplyKeyboard(MsgId fromRootId, MsgId toRootId) {
+	if (!fromRootId
+		|| !toRootId
+		|| fromRootId == toRootId
+		|| !isForum()) {
+		return;
+	}
+	if (const auto fromSenders = _topicMarkupSenders.find(fromRootId)
+		; fromSenders != end(_topicMarkupSenders)) {
+		auto &toSenders = _topicMarkupSenders[toRootId];
+		for (const auto &sender : fromSenders->second) {
+			toSenders.emplace(sender);
+		}
+		_topicMarkupSenders.erase(fromSenders);
+	}
+	const auto fromIt = _topicReplyKeyboards.find(fromRootId);
+	if (fromIt == end(_topicReplyKeyboards)) {
+		return;
+	}
+	const auto toIt = _topicReplyKeyboards.find(toRootId);
+	if (toIt != end(_topicReplyKeyboards) && toIt->second.inited) {
+		_topicReplyKeyboards.erase(fromIt);
+		return;
+	}
+	auto state = std::move(fromIt->second);
+	_topicReplyKeyboards.erase(fromIt);
+	_topicReplyKeyboards[toRootId] = std::move(state);
+	if (_topicReplyKeyboards[toRootId].id) {
+		notifyReplyKeyboardUpdated();
+	}
+}
+
+void History::removeTopicReplyKeyboard(MsgId topicRootId) {
+	const auto key = replyKeyboardTopicKey(topicRootId);
+	if (!key) {
+		return;
+	}
+	_topicMarkupSenders.remove(key);
+	const auto i = _topicReplyKeyboards.find(key);
+	if (i == end(_topicReplyKeyboards)) {
+		return;
+	}
+	const auto changed = (i->second.id != 0);
+	_topicReplyKeyboards.erase(i);
+	if (changed) {
+		notifyReplyKeyboardUpdated();
+	}
 }
 
 int History::height() const {
@@ -257,8 +511,13 @@ void History::itemVanished(not_null<HistoryItem*> item) {
 	if (const auto thread = item->maybeNotificationThread()) {
 		thread->removeNotification(item);
 	}
-	if (lastKeyboardId == item->id) {
-		clearLastKeyboard();
+	if (const auto key = replyKeyboardTopicKey(item->topicRootId())) {
+		const auto i = _topicReplyKeyboards.find(key);
+		if (i != end(_topicReplyKeyboards) && i->second.id == item->id) {
+			clearLastKeyboard(key);
+		}
+	} else if (lastKeyboardId == item->id) {
+		clearLastKeyboard(MsgId(0));
 	}
 	if ((!item->out() || item->isPost())
 		&& item->unread(this)
@@ -840,6 +1099,7 @@ not_null<HistoryItem*> History::addNewItem(
 	}
 
 	if (!loadedAtBottom() || peer->migrateTo()) {
+		applyItemReplyKeyboard(item);
 		setLastMessage(item);
 		if (unread) {
 			const auto type = item->out()
@@ -1163,56 +1423,7 @@ not_null<HistoryItem*> History::addNewToBack(
 			}
 		}
 	}
-	if (item->definesReplyKeyboard()) {
-		const auto markupFlags = item->replyKeyboardFlags();
-		if (!(markupFlags & ReplyMarkupFlag::Selective)
-			|| item->mentionsMe()) {
-			const auto markupSenders = [&]() -> base::flat_set<not_null<PeerData*>>* {
-				if (const auto chat = peer->asChat()) {
-					return &chat->markupSenders;
-				} else if (const auto channel = peer->asMegagroup()) {
-					return &channel->mgInfo->markupSenders;
-				}
-				return nullptr;
-			}();
-			if (markupSenders) {
-				markupSenders->insert(from);
-			}
-			if (markupFlags & ReplyMarkupFlag::None) {
-				// None markup means replyKeyboardHide.
-				if (lastKeyboardFrom == from->id
-					|| (!lastKeyboardInited
-						&& !peer->isChat()
-						&& !peer->isMegagroup()
-						&& !item->out())) {
-					clearLastKeyboard();
-				}
-			} else {
-				bool botNotInChat = false;
-				if (peer->isChat()) {
-					botNotInChat = from->isUser()
-						&& (!peer->asChat()->participants.empty()
-							|| !Data::CanSendAnything(peer))
-						&& !peer->asChat()->participants.contains(
-							from->asUser());
-				} else if (peer->isMegagroup()) {
-					botNotInChat = from->isUser()
-						&& (peer->asChannel()->mgInfo->botStatus != Data::BotStatus::Unknown
-							|| !Data::CanSendAnything(peer))
-						&& !peer->asChannel()->mgInfo->bots.contains(
-							from->asUser());
-				}
-				if (botNotInChat) {
-					clearLastKeyboard();
-				} else {
-					lastKeyboardInited = true;
-					lastKeyboardId = item->id;
-					lastKeyboardFrom = from->id;
-					lastKeyboardUsed = false;
-				}
-			}
-		}
-	}
+	applyItemReplyKeyboard(item);
 
 	setLastMessage(item);
 	if (unread) {
@@ -1288,8 +1499,19 @@ void History::applyServiceChanges(
 		}
 	}, [&](const MTPDmessageActionChatDeleteUser &data) {
 		const auto uid = data.vuser_id().v;
-		if (lastKeyboardFrom == peerFromUser(uid)) {
-			clearLastKeyboard();
+		const auto fromId = peerFromUser(uid);
+		if (lastKeyboardFrom == fromId) {
+			clearLastKeyboard(MsgId(0));
+		}
+		for (auto i = begin(_topicReplyKeyboards)
+			; i != end(_topicReplyKeyboards);) {
+			if (i->second.from == fromId) {
+				const auto key = i->first;
+				++i;
+				clearLastKeyboard(key);
+			} else {
+				++i;
+			}
 		}
 		if (const auto megagroup = peer->asMegagroup()) {
 			if (const auto user = owner().userLoaded(uid)) {
@@ -1944,50 +2166,107 @@ void History::addItemsToLists(
 			}
 		}
 		if (item->author()->id) {
+			const auto topicKey = replyKeyboardTopicKey(item->topicRootId());
+			const auto keyboardInited = [&] {
+				if (topicKey) {
+					const auto i = _topicReplyKeyboards.find(topicKey);
+					return (i != end(_topicReplyKeyboards)) && i->second.inited;
+				}
+				return lastKeyboardInited;
+			};
 			if (markupSenders) { // chats with bots
-				if (!lastKeyboardInited && item->definesReplyKeyboard() && !item->out()) {
+				if (!keyboardInited()
+					&& item->definesReplyKeyboard()
+					&& !item->out()) {
 					const auto markupFlags = item->replyKeyboardFlags();
-					if (!(markupFlags & ReplyMarkupFlag::Selective) || item->mentionsMe()) {
-						bool wasKeyboardHide = markupSenders->contains(item->author());
-						if (!wasKeyboardHide) {
-							markupSenders->insert(item->author());
-						}
+					if (!(markupFlags & ReplyMarkupFlag::Selective)
+						|| item->mentionsMe()) {
+						const auto author = item->author();
+						const auto wasKeyboardHide = [&] {
+							if (topicKey) {
+								auto &senders = _topicMarkupSenders[topicKey];
+								const auto was = senders.contains(author);
+								if (!was) {
+									senders.emplace(author);
+								}
+								return was;
+							}
+							const auto was = markupSenders->contains(author);
+							if (!was) {
+								markupSenders->emplace(author);
+							}
+							return was;
+						}();
 						if (!(markupFlags & ReplyMarkupFlag::None)) {
-							if (!lastKeyboardInited) {
+							if (!keyboardInited()) {
 								bool botNotInChat = false;
 								if (peer->isChat()) {
 									botNotInChat = (!Data::CanSendAnything(peer)
 										|| !peer->asChat()->participants.empty())
-										&& item->author()->isUser()
-										&& !peer->asChat()->participants.contains(item->author()->asUser());
+										&& author->isUser()
+										&& !peer->asChat()->participants.contains(
+											author->asUser());
 								} else if (peer->isMegagroup()) {
 									botNotInChat = (!Data::CanSendAnything(peer)
-										|| peer->asChannel()->mgInfo->botStatus != Data::BotStatus::Unknown)
-										&& item->author()->isUser()
-										&& !peer->asChannel()->mgInfo->bots.contains(item->author()->asUser());
+										|| peer->asChannel()->mgInfo->botStatus
+											!= Data::BotStatus::Unknown)
+										&& author->isUser()
+										&& !peer->asChannel()->mgInfo->bots.contains(
+											author->asUser());
 								}
 								if (wasKeyboardHide || botNotInChat) {
-									clearLastKeyboard();
+									clearLastKeyboard(topicKey);
+									if (topicKey) {
+										_topicReplyKeyboards[topicKey]
+											.lastUpdateId = item->id;
+									} else {
+										lastKeyboardUpdateId = item->id;
+									}
+								} else if (topicKey) {
+									auto &state = _topicReplyKeyboards[topicKey];
+									state.inited = true;
+									state.id = item->id;
+									state.from = author->id;
+									state.used = false;
+									state.lastUpdateId = item->id;
 								} else {
 									lastKeyboardInited = true;
 									lastKeyboardId = item->id;
-									lastKeyboardFrom = item->author()->id;
+									lastKeyboardFrom = author->id;
 									lastKeyboardUsed = false;
+									lastKeyboardUpdateId = item->id;
 								}
 							}
 						}
 					}
 				}
-			} else if (!lastKeyboardInited && item->definesReplyKeyboard() && !item->out()) { // conversations with bots
+			} else if (!keyboardInited()
+				&& item->definesReplyKeyboard()
+				&& !item->out()) { // conversations with bots
 				const auto markupFlags = item->replyKeyboardFlags();
-				if (!(markupFlags & ReplyMarkupFlag::Selective) || item->mentionsMe()) {
+				if (!(markupFlags & ReplyMarkupFlag::Selective)
+					|| item->mentionsMe()) {
 					if (markupFlags & ReplyMarkupFlag::None) {
-						clearLastKeyboard();
+						clearLastKeyboard(topicKey);
+						if (topicKey) {
+							_topicReplyKeyboards[topicKey].lastUpdateId
+								= item->id;
+						} else {
+							lastKeyboardUpdateId = item->id;
+						}
+					} else if (topicKey) {
+						auto &state = _topicReplyKeyboards[topicKey];
+						state.inited = true;
+						state.id = item->id;
+						state.from = item->author()->id;
+						state.used = false;
+						state.lastUpdateId = item->id;
 					} else {
 						lastKeyboardInited = true;
 						lastKeyboardId = item->id;
 						lastKeyboardFrom = item->author()->id;
 						lastKeyboardUsed = false;
+						lastKeyboardUpdateId = item->id;
 					}
 				}
 			}
@@ -4363,6 +4642,9 @@ void History::clear(ClearType type, bool markEmpty) {
 	blocks.clear();
 	owner().notifyHistoryUnloaded(this);
 	lastKeyboardInited = false;
+	lastKeyboardUpdateId = 0;
+	_topicReplyKeyboards.clear();
+	_topicMarkupSenders.clear();
 	if (type == ClearType::Unload) {
 		_loadedAtTop = _loadedAtBottom = markEmpty;
 	} else {

--- a/Telegram/SourceFiles/history/history.h
+++ b/Telegram/SourceFiles/history/history.h
@@ -300,7 +300,25 @@ public:
 		return &_sendActionPainter;
 	}
 
+	struct ReplyKeyboardState {
+		bool inited = false;
+		bool used = false;
+		MsgId id = 0;
+		MsgId hiddenId = 0;
+		MsgId lastUpdateId = 0;
+		PeerId from = 0;
+	};
+
 	void clearLastKeyboard();
+	void clearLastKeyboard(MsgId topicRootId);
+	void validateReplyKeyboardSenders(
+		const base::flat_set<PeerId> &presentPeerIds);
+	void applyItemReplyKeyboard(not_null<HistoryItem*> item);
+	void migrateTopicReplyKeyboard(MsgId fromRootId, MsgId toRootId);
+	void removeTopicReplyKeyboard(MsgId topicRootId);
+	[[nodiscard]] ReplyKeyboardState &replyKeyboardState(MsgId topicRootId);
+	[[nodiscard]] const ReplyKeyboardState &replyKeyboardState(
+		MsgId topicRootId) const;
 	void clearUnreadMentionsFor(MsgId topicRootId);
 	void clearUnreadReactionsFor(
 		MsgId topicRootId,
@@ -499,12 +517,16 @@ public:
 	bool lastKeyboardUsed = false;
 	MsgId lastKeyboardId = 0;
 	MsgId lastKeyboardHiddenId = 0;
+	MsgId lastKeyboardUpdateId = 0;
 	PeerId lastKeyboardFrom = 0;
 
 	mtpRequestId sendRequestId = 0;
 
 private:
 	friend class HistoryBlock;
+
+	[[nodiscard]] MsgId replyKeyboardTopicKey(MsgId topicRootId) const;
+	void notifyReplyKeyboardUpdated();
 
 	enum class Flag : ushort {
 		HasPendingResizedItems = (1 << 0),
@@ -700,6 +722,8 @@ private:
 	base::flat_map<Data::DraftKey, Data::ForwardDraft> _forwardDrafts;
 
 	base::flat_map<MsgId, TimeId> _unknownDeletedMessages;
+	base::flat_map<MsgId, ReplyKeyboardState> _topicReplyKeyboards;
+	base::flat_map<MsgId, base::flat_set<not_null<PeerData*>>> _topicMarkupSenders;
 
 	QString _topPromotedMessage;
 	QString _topPromotedType;

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -8438,6 +8438,8 @@ void HistoryWidget::updateBotKeyboard(History *h, bool force) {
 		changed = _keyboard->updateMarkup(nullptr, force);
 	} else if (_replyTo && _replyEditMsg) {
 		changed = _keyboard->updateMarkup(_replyEditMsg, force);
+	} else if (_history->peer->isForum()) {
+		changed = _keyboard->updateMarkup(nullptr, force);
 	} else {
 		const auto keyboardItem = _history->lastKeyboardId
 			? session().data().message(

--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
+++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
@@ -24,6 +24,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "calls/group/ui/calls_group_stars_coloring.h"
 #include "calls/group/calls_group_stars_box.h"
 #include "chat_helpers/compose/compose_show.h"
+#include "chat_helpers/bot_command.h"
+#include "chat_helpers/bot_keyboard.h"
 #include "chat_helpers/emoji_suggestions_widget.h"
 #include "chat_helpers/message_field.h"
 #include "chat_helpers/tabbed_panel.h"
@@ -103,6 +105,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/fields/input_field.h"
 #include "ui/widgets/dropdown_menu.h"
 #include "ui/widgets/popup_menu.h"
+#include "ui/widgets/scroll_area.h"
 #include "ui/text/format_values.h"
 #include "ui/controls/compose_ai_button_factory.h"
 #include "ui/controls/emoji_button.h"
@@ -191,6 +194,7 @@ public:
 		SuggestOptions suggest,
 		bool photoEditAllowed = false);
 	void replyToMessage(FullReplyTo id);
+	void keyboardReplyToMessage(FullMsgId id);
 	void updateForwarding(
 		Data::Thread *thread,
 		Data::ResolvedForwardDraft items);
@@ -222,6 +226,9 @@ public:
 	[[nodiscard]] rpl::producer<> replyCancelled() const {
 		return _replyCancelled.events();
 	}
+	[[nodiscard]] rpl::producer<> keyboardReplyCancelled() const {
+		return _keyboardReplyCancelled.events();
+	}
 	[[nodiscard]] rpl::producer<> forwardCancelled() const {
 		return _forwardCancelled.events();
 	}
@@ -237,6 +244,7 @@ public:
 private:
 	void updateControlsGeometry(QSize size);
 	void updateVisible();
+	[[nodiscard]] FullReplyTo displayedReplyTo() const;
 	void setShownMessage(HistoryItem *message);
 	void resolveMessageData();
 	void updateShownMessageText();
@@ -267,6 +275,7 @@ private:
 	Preview _preview;
 	rpl::event_stream<> _editCancelled;
 	rpl::event_stream<> _replyCancelled;
+	rpl::event_stream<> _keyboardReplyCancelled;
 	rpl::event_stream<> _forwardCancelled;
 	rpl::event_stream<> _previewCancelled;
 	rpl::event_stream<> _saveDraftRequests;
@@ -274,6 +283,7 @@ private:
 
 	rpl::variable<FullMsgId> _editMsgId;
 	rpl::variable<FullReplyTo> _replyTo;
+	FullMsgId _keyboardReplyTo;
 	std::unique_ptr<ForwardPanel> _forwardPanel;
 	std::unique_ptr<SuggestOptionsBar> _suggestOptions;
 	rpl::producer<> _toForwardUpdated;
@@ -354,7 +364,7 @@ void FieldHeader::init() {
 			st::historyLinkIcon.paint(p, position, width());
 		} else if (isEditingMessage()) {
 			st::historyEditIcon.paint(p, position, width());
-		} else if (const auto reply = replyingToMessage(); reply.replying()) {
+		} else if (const auto reply = displayedReplyTo(); reply.replying()) {
 			if (!reply.quote.empty()) {
 				st::historyQuoteIcon.paint(p, position, width());
 			} else {
@@ -368,7 +378,7 @@ void FieldHeader::init() {
 			paintWebPage(
 				p,
 				_history ? _history->peer : _data->session().user());
-		} else if (isEditingMessage() || replyingToMessage()) {
+		} else if (isEditingMessage() || displayedReplyTo()) {
 			paintEditOrReplyToMessage(p);
 		} else if (readyToForward()) {
 			paintForwardInfo(p);
@@ -377,14 +387,14 @@ void FieldHeader::init() {
 
 	_editMsgId.value(
 	) | rpl::on_next([=](FullMsgId value) {
-		const auto shown = value ? value : _replyTo.current().messageId;
+		const auto shown = value ? value : displayedReplyTo().messageId;
 		setShownMessage(_data->message(shown));
 	}, lifetime());
 
 	_replyTo.value(
-	) | rpl::on_next([=](const FullReplyTo &value) {
+	) | rpl::on_next([=](const FullReplyTo &) {
 		if (!_editMsgId.current()) {
-			setShownMessage(_data->message(value.messageId));
+			setShownMessage(_data->message(displayedReplyTo().messageId));
 		}
 	}, lifetime());
 
@@ -400,6 +410,8 @@ void FieldHeader::init() {
 			}
 			if (_replyTo.current().messageId == update.item->fullId()) {
 				_replyCancelled.fire({});
+			} else if (_keyboardReplyTo == update.item->fullId()) {
+				_keyboardReplyCancelled.fire({});
 			}
 		} else {
 			updateShownMessageText();
@@ -414,6 +426,8 @@ void FieldHeader::init() {
 			_editCancelled.fire({});
 		} else if (_replyTo.current()) {
 			_replyCancelled.fire({});
+		} else if (_keyboardReplyTo) {
+			_keyboardReplyCancelled.fire({});
 		} else if (readyToForward()) {
 			_forwardCancelled.fire({});
 		}
@@ -429,7 +443,7 @@ void FieldHeader::init() {
 		return (ranges::contains(kMouseEvents, type) || leaving)
 			&& (isEditingMessage()
 				|| readyToForward()
-				|| replyingToMessage()
+				|| displayedReplyTo()
 				|| _preview.parsed);
 	}) | rpl::on_next([=](not_null<QEvent*> event) {
 		const auto updateOver = [&](bool inClickable, bool inPhotoEdit) {
@@ -469,7 +483,7 @@ void FieldHeader::init() {
 			if (isLeftButton && inPhotoEdit) {
 				_editPhotoRequests.fire({});
 			} else if (isLeftButton && inPreviewRect) {
-				const auto reply = replyingToMessage();
+				const auto reply = displayedReplyTo();
 				if (_preview.parsed) {
 					_editOptionsRequests.fire({});
 				} else if (isEditingMessage()) {
@@ -482,6 +496,8 @@ void FieldHeader::init() {
 					}
 				} else if (reply && (e->modifiers() & Qt::ControlModifier)) {
 					_jumpToItemRequests.fire_copy(reply);
+				} else if (reply && !_replyTo.current().messageId) {
+					_jumpToItemRequests.fire_copy(reply);
 				} else if (reply || readyToForward()) {
 					_editOptionsRequests.fire({});
 				}
@@ -491,7 +507,7 @@ void FieldHeader::init() {
 						this,
 						[=] { update(); },
 						_hasSendText());
-				} else if (const auto reply = replyingToMessage()) {
+				} else if (const auto reply = displayedReplyTo()) {
 					_jumpToItemRequests.fire_copy(reply);
 				} else if (readyToForward()) {
 					_forwardPanel->editToNextOption();
@@ -508,7 +524,7 @@ void FieldHeader::updateShownMessageText() {
 		.session = &_data->session(),
 		.repaint = [=] { customEmojiRepaint(); },
 	});
-	const auto reply = replyingToMessage();
+	const auto reply = displayedReplyTo();
 	_shownMessageText.setMarkedText(
 		st::messageTextStyle,
 		((isEditingMessage() || reply.quote.empty())
@@ -524,6 +540,16 @@ void FieldHeader::customEmojiRepaint() {
 	}
 	_repaintScheduled = true;
 	update();
+}
+
+FullReplyTo FieldHeader::displayedReplyTo() const {
+	auto result = _replyTo.current();
+	if (!result.messageId && _keyboardReplyTo) {
+		result.messageId = _keyboardReplyTo;
+		result.topicRootId = _topicRootId;
+		result.monoforumPeerId = _monoforumPeerId;
+	}
+	return result;
 }
 
 void FieldHeader::setShownMessage(HistoryItem *item) {
@@ -544,7 +570,7 @@ void FieldHeader::setShownMessage(HistoryItem *item) {
 			.session = &_history->session(),
 			.customEmojiLoopLimit = 1,
 		});
-		const auto replyTo = _replyTo.current();
+		const auto replyTo = displayedReplyTo();
 		_shownMessageName.setMarkedText(
 			st::fwdTextStyle,
 			HistoryView::Reply::ComposePreviewName(_history, item, replyTo),
@@ -560,7 +586,7 @@ void FieldHeader::setShownMessage(HistoryItem *item) {
 void FieldHeader::resolveMessageData() {
 	const auto id = isEditingMessage()
 		? _editMsgId.current()
-		: _replyTo.current().messageId;
+		: displayedReplyTo().messageId;
 	if (!id) {
 		return;
 	}
@@ -569,14 +595,16 @@ void FieldHeader::resolveMessageData() {
 	const auto callback = crl::guard(this, [=] {
 		const auto now = isEditingMessage()
 			? _editMsgId.current()
-			: _replyTo.current().messageId;
+			: displayedReplyTo().messageId;
 		if (now == id && !_shownMessage) {
 			if (const auto message = _data->message(peer, itemId)) {
 				setShownMessage(message);
 			} else if (isEditingMessage()) {
 				_editCancelled.fire({});
-			} else {
+			} else if (_replyTo.current().messageId == id) {
 				_replyCancelled.fire({});
+			} else if (_keyboardReplyTo == id) {
+				_keyboardReplyCancelled.fire({});
 			}
 		}
 	});
@@ -669,7 +697,7 @@ void FieldHeader::paintEditOrReplyToMessage(Painter &p) {
 
 	const auto media = _shownMessage->media();
 	const auto poll = media ? media->poll() : nullptr;
-	const auto reply = replyingToMessage();
+	const auto reply = displayedReplyTo();
 	const auto pollAnswer = poll
 		? poll->answerByOption(reply.pollOption)
 		: nullptr;
@@ -788,7 +816,7 @@ rpl::producer<bool> FieldHeader::visibleChanged() {
 bool FieldHeader::isDisplayed() const {
 	return isEditingMessage()
 		|| readyToForward()
-		|| replyingToMessage()
+		|| displayedReplyTo()
 		|| hasPreview();
 }
 
@@ -899,6 +927,16 @@ void FieldHeader::cancelSuggestPost() {
 void FieldHeader::replyToMessage(FullReplyTo id) {
 	id.monoforumPeerId = 0;
 	_replyTo = id;
+}
+
+void FieldHeader::keyboardReplyToMessage(FullMsgId id) {
+	if (_keyboardReplyTo == id) {
+		return;
+	}
+	_keyboardReplyTo = id;
+	if (!isEditingMessage() && !_replyTo.current().messageId) {
+		setShownMessage(_data->message(id));
+	}
 }
 
 void FieldHeader::updateForwarding(
@@ -1195,6 +1233,7 @@ void ComposeControls::updateTopicRootId(MsgId topicRootId) {
 	trackThreadFieldVisibility();
 	registerDraftSource();
 	updateFieldVisibility();
+	updateBotKeyboard(true);
 }
 
 void ComposeControls::updateShortcutId(BusinessShortcutId shortcutId) {
@@ -1220,6 +1259,17 @@ void ComposeControls::setHistory(SetHistoryArgs &&args) {
 		: rpl::single(0);
 	const auto history = *args.history;
 	if (_history == history) {
+		if (_topicRootId != args.topicRootId) {
+			updateTopicRootId(args.topicRootId);
+		}
+		if (_monoforumPeerId != args.monoforumPeerId) {
+			unregisterDraftSources();
+			_monoforumPeerId = args.monoforumPeerId;
+			_header->setHistory(args);
+			registerDraftSource();
+			updateFieldVisibility();
+			updateBotKeyboard(true);
+		}
 		return;
 	}
 	untrackThreadFieldVisibility();
@@ -1247,6 +1297,7 @@ void ComposeControls::setHistory(SetHistoryArgs &&args) {
 	_sendAs = nullptr;
 	_silent = nullptr;
 	if (!_history) {
+		updateBotKeyboard(true);
 		return;
 	}
 	const auto peer = _history->peer;
@@ -1268,6 +1319,55 @@ void ComposeControls::setHistory(SetHistoryArgs &&args) {
 	_field->setMode(args.videoStream
 		? Ui::InputField::Mode::NoNewlines
 		: Ui::InputField::Mode::MultiLine);
+
+	session().changes().historyUpdates(
+		_history,
+		Data::HistoryUpdate::Flag::BotKeyboard
+	) | rpl::on_next([=] {
+		updateBotKeyboard(true);
+	}, _historyLifetime);
+	session().data().historyChanged(
+	) | rpl::filter([=](not_null<const History*> history) {
+		return history == _history;
+	}) | rpl::on_next([=] {
+		updateBotKeyboard();
+	}, _historyLifetime);
+	session().changes().messageUpdates(
+		Data::MessageUpdate::Flag::ReplyMarkup
+		| Data::MessageUpdate::Flag::NewAdded
+		| Data::MessageUpdate::Flag::NewMaybeAdded
+	) | rpl::filter([=](const Data::MessageUpdate &update) {
+		if (update.item->history() != _history) {
+			return false;
+		}
+		if (update.flags & Data::MessageUpdate::Flag::ReplyMarkup) {
+			return _keyboard
+				&& (_keyboard->forMsgId() == update.item->fullId());
+		}
+		if (_topicRootId
+			&& update.item->topicRootId() != _topicRootId) {
+			return false;
+		}
+		if (!update.item->definesReplyKeyboard() || update.item->out()) {
+			return false;
+		}
+		if (update.flags & Data::MessageUpdate::Flag::NewMaybeAdded) {
+			const auto key = keyboardTopicKey();
+			const auto keyboardId = key
+				? _history->replyKeyboardState(key).id
+				: _history->lastKeyboardId;
+			const auto shownId = _keyboard
+				? _keyboard->forMsgId().msg
+				: MsgId();
+			return keyboardId != shownId;
+		}
+		return true;
+	}) | rpl::on_next([=](const Data::MessageUpdate &) {
+		crl::on_main(_wrap.get(), [=] {
+			updateBotKeyboard(true);
+		});
+	}, _historyLifetime);
+	updateBotKeyboard(true);
 }
 
 void ComposeControls::initLikeButton() {
@@ -1887,6 +1987,260 @@ rpl::producer<QString> ComposeControls::sendCommandRequests() const {
 	return _sendCommandRequests.events();
 }
 
+rpl::producer<Bot::SendCommandRequest>
+ComposeControls::botKeyboardCommandRequests() const {
+	return _botKeyboardCommandRequests.events();
+}
+
+void ComposeControls::botKeyboardCommandSent(
+		const Bot::SendCommandRequest &request) {
+	if (!_history || !_keyboard || !request.replyTo) {
+		return;
+	}
+	const auto key = keyboardTopicKey();
+	const auto keyboardId = key
+		? _history->replyKeyboardState(key).id
+		: _history->lastKeyboardId;
+	const auto forMsgId = _keyboard->forMsgId();
+	if (!_keyboard->singleUse()
+		|| !_keyboard->hasMarkup()
+		|| forMsgId != request.replyTo.messageId
+		|| forMsgId != FullMsgId(_history->peer->id, keyboardId)) {
+		return;
+	}
+	if (_kbShown) {
+		toggleKeyboard(false);
+	}
+	if (key) {
+		_history->replyKeyboardState(key).used = true;
+	} else {
+		_history->lastKeyboardUsed = true;
+	}
+}
+
+MsgId ComposeControls::keyboardTopicKey() const {
+	if (!_history || !_history->isForum() || !_topicRootId) {
+		return MsgId(0);
+	}
+	return _topicRootId;
+}
+
+int ComposeControls::keyboardHeight() const {
+	return (_kbShown && _kbScroll) ? _kbScroll->height() : 0;
+}
+
+bool ComposeControls::kbWasHidden() const {
+	if (!_history || !_keyboard) {
+		return false;
+	}
+	const auto forId = _keyboard->forMsgId();
+	if (!forId) {
+		return false;
+	}
+	if (const auto key = keyboardTopicKey()) {
+		return forId.msg == _history->replyKeyboardState(key).hiddenId;
+	}
+	return forId.msg == _history->lastKeyboardHiddenId;
+}
+
+void ComposeControls::showKeyboardHideButton() {
+	if (!_botKeyboardHide || !_keyboard || !_history) {
+		return;
+	}
+	_botKeyboardHide->setVisible(!_history->peer->isUser()
+		|| !_keyboard->persistent());
+}
+
+void ComposeControls::initBotKeyboard() {
+	if (!_regularWindow || _kbScroll) {
+		return;
+	}
+	_kbScroll = std::make_unique<Ui::ScrollArea>(_wrap.get(), st::botKbScroll);
+	_keyboard = _kbScroll->setOwnedWidget(object_ptr<BotKeyboard>(
+		_regularWindow,
+		_wrap.get())).data();
+	_botKeyboardShow = Ui::CreateChild<Ui::IconButton>(
+		_wrap.get(),
+		st::historyBotKeyboardShow);
+	_botKeyboardHide = Ui::CreateChild<Ui::IconButton>(
+		_wrap.get(),
+		st::historyBotKeyboardHide);
+	_kbScroll->hide();
+	_botKeyboardShow->hide();
+	_botKeyboardHide->hide();
+	_botKeyboardShow->setAccessibleName(tr::lng_bot_keyboard_show(tr::now));
+	_botKeyboardHide->setAccessibleName(tr::lng_bot_keyboard_hide(tr::now));
+	_botKeyboardShow->addClickHandler([=] { toggleKeyboard(); });
+	_botKeyboardHide->addClickHandler([=] { toggleKeyboard(); });
+	_keyboard->sendCommandRequests(
+	) | rpl::on_next([=](Bot::SendCommandRequest request) {
+		_botKeyboardCommandRequests.fire(std::move(request));
+	}, _kbScroll->lifetime());
+}
+
+void ComposeControls::toggleKeyboard(bool manual) {
+	if (!_keyboard || !_history) {
+		return;
+	}
+	const auto key = keyboardTopicKey();
+	if (_kbShown) {
+		if (_botKeyboardHide) {
+			_botKeyboardHide->hide();
+		}
+		if (_botKeyboardShow) {
+			_botKeyboardShow->show();
+		}
+		if (manual) {
+			if (key) {
+				_history->replyKeyboardState(key).hiddenId
+					= _keyboard->forMsgId().msg;
+			} else {
+				_history->lastKeyboardHiddenId = _keyboard->forMsgId().msg;
+			}
+		}
+		if (_kbScroll) {
+			_kbScroll->hide();
+		}
+		_kbShown = false;
+		_tabbedSelectorToggle->show();
+		updateHeight();
+		updateControlsVisibility();
+		updateControlsGeometry(_wrap->size());
+	} else if (_keyboard->hasMarkup()) {
+		showKeyboardHideButton();
+		if (_botKeyboardShow) {
+			_botKeyboardShow->hide();
+		}
+		if (_kbScroll) {
+			_kbScroll->show();
+		}
+		_kbShown = true;
+		_tabbedSelectorToggle->hide();
+		if (manual) {
+			if (key) {
+				_history->replyKeyboardState(key).hiddenId = 0;
+			} else {
+				_history->lastKeyboardHiddenId = 0;
+			}
+		}
+		updateHeight();
+		updateControlsVisibility();
+		updateControlsGeometry(_wrap->size());
+	} else if (_keyboard->forceReply()) {
+		dismissForceReplyKeyboard();
+		return;
+	}
+	_header->keyboardReplyToMessage(keyboardReplyTo());
+}
+
+void ComposeControls::updateBotKeyboard(bool force) {
+	if (!_regularWindow) {
+		return;
+	}
+	initBotKeyboard();
+	if (!_keyboard) {
+		return;
+	}
+
+	const auto wasVisible = _kbShown;
+	const auto wasMsgId = _keyboard->forMsgId();
+	auto changed = false;
+	if (!_history || isEditingMessage()) {
+		changed = _keyboard->updateMarkup(nullptr, force);
+	} else {
+		const auto key = keyboardTopicKey();
+		const auto keyboardId = key
+			? _history->replyKeyboardState(key).id
+			: _history->lastKeyboardId;
+		const auto keyboardUsed = key
+			? _history->replyKeyboardState(key).used
+			: _history->lastKeyboardUsed;
+		const auto forceMarkup = force
+			|| (keyboardId
+				&& wasMsgId.msg
+				&& wasMsgId.msg != keyboardId);
+		const auto keyboardItem = keyboardId
+			? session().data().message(_history->peer, keyboardId)
+			: nullptr;
+		changed = _keyboard->updateMarkup(keyboardItem, forceMarkup);
+		if (_keyboard->singleUse()
+			&& _keyboard->hasMarkup()
+			&& keyboardId
+			&& keyboardUsed
+			&& (_keyboard->forMsgId()
+				== FullMsgId(_history->peer->id, keyboardId))) {
+			if (key) {
+				_history->replyKeyboardState(key).hiddenId = keyboardId;
+			} else {
+				_history->lastKeyboardHiddenId = keyboardId;
+			}
+		}
+	}
+	if (changed && _keyboard->forMsgId() != wasMsgId && _kbScroll) {
+		_kbScroll->scrollTo({ 0, 0 });
+	}
+	if (changed) {
+		_keyboard->update();
+	}
+
+	const auto hasMarkup = _keyboard->hasMarkup();
+	const auto forceReply = _keyboard->forceReply();
+	const auto markupReplaced = changed
+		&& hasMarkup
+		&& wasMsgId.msg
+		&& (_keyboard->forMsgId().msg != wasMsgId.msg);
+	const auto canShow = hasMarkup
+		&& !isEditingMessage()
+		&& !kbWasHidden()
+		&& (wasVisible
+			|| markupReplaced
+			|| !hasSendableContent()
+			|| force);
+	if (canShow) {
+		if (_kbScroll) {
+			_kbScroll->show();
+		}
+		_tabbedSelectorToggle->hide();
+		showKeyboardHideButton();
+		if (_botKeyboardShow) {
+			_botKeyboardShow->hide();
+		}
+		if (_botCommandStart) {
+			_botCommandStart->hide();
+		}
+		_kbShown = true;
+	} else if (hasMarkup || forceReply) {
+		if (_kbScroll) {
+			_kbScroll->hide();
+		}
+		_tabbedSelectorToggle->show();
+		if (_botKeyboardHide) {
+			_botKeyboardHide->hide();
+		}
+		if (_botKeyboardShow) {
+			_botKeyboardShow->setVisible(hasMarkup);
+		}
+		_kbShown = false;
+	} else {
+		if (_kbScroll) {
+			_kbScroll->hide();
+		}
+		_tabbedSelectorToggle->show();
+		if (_botKeyboardHide) {
+			_botKeyboardHide->hide();
+		}
+		if (_botKeyboardShow) {
+			_botKeyboardShow->hide();
+		}
+		_kbShown = false;
+	}
+	_header->keyboardReplyToMessage(keyboardReplyTo());
+	updateFieldPlaceholder();
+	updateHeight();
+	updateControlsVisibility();
+	updateControlsGeometry(_wrap->size());
+}
+
 rpl::producer<MessageToEdit> ComposeControls::editRequests() const {
 	auto toValue = rpl::map([=] { return _header->queryToEdit(); });
 	auto filter = rpl::filter([=] {
@@ -2307,6 +2661,7 @@ void ComposeControls::init() {
 			orderControls();
 		}
 		registerDraftSource();
+		updateBotKeyboard();
 	}, _wrap->lifetime());
 
 	_header->replyingToMessageValue(
@@ -2398,6 +2753,11 @@ void ComposeControls::init() {
 	_header->replyCancelled(
 	) | rpl::on_next([=] {
 		cancelReplyMessage();
+	}, _wrap->lifetime());
+
+	_header->keyboardReplyCancelled(
+	) | rpl::on_next([=] {
+		toggleKeyboard();
 	}, _wrap->lifetime());
 
 	_header->forwardCancelled(
@@ -2712,12 +3072,18 @@ void ComposeControls::updateFieldPlaceholder() {
 
 	const auto ephemeralReply = session().ephemeralMessages()
 		.isEphemeralBotReply(replyingToMessage().messageId);
+	const auto keyboardPlaceholder = (_keyboard
+		&& (_kbShown || _keyboard->forceReply()))
+		? _keyboard->placeholder()
+		: QString();
 	_field->setPlaceholder([&] {
 		const auto peer = _history ? _history->peer.get() : nullptr;
 		if (_fieldCustomPlaceholder) {
 			return rpl::duplicate(_fieldCustomPlaceholder);
 		} else if (isEditingMessage()) {
 			return tr::lng_edit_message_text();
+		} else if (!keyboardPlaceholder.isEmpty()) {
+			return rpl::single(keyboardPlaceholder) | rpl::type_erased;
 		} else if (!peer) {
 			return tr::lng_message_ph();
 		} else if (const auto stars = ephemeralReply
@@ -2773,6 +3139,17 @@ void ComposeControls::fieldChanged() {
 		&& !suppressSendAction());
 	updateSendButtonType();
 	_hasSendText = _field->isVisible() && HasSendText(_field);
+	if (!isEditingMessage()) {
+		if (_kbShown && _hasSendText.current()) {
+			toggleKeyboard();
+		} else if (!_kbShown
+			&& _keyboard
+			&& _keyboard->hasMarkup()
+			&& !_hasSendText.current()
+			&& !kbWasHidden()) {
+			updateBotKeyboard();
+		}
+	}
 	if (updateBotCommandShown() || updateLikeShown()) {
 		updateControlsVisibility();
 		updateControlsGeometry(_wrap->size());
@@ -3084,6 +3461,11 @@ void ComposeControls::applyDraft(FieldHistoryAction fieldHistoryAction) {
 		return;
 	}
 
+	if (draft == editDraft) {
+		_header->editMessage(editingId, editingSuggest, false);
+		_header->replyToMessage({});
+	}
+
 	_textUpdateEvents = 0;
 	setFieldText(draft->textWithTags, 0, fieldHistoryAction);
 	if (hadFocus) {
@@ -3153,7 +3535,6 @@ void ComposeControls::applyDraft(FieldHistoryAction fieldHistoryAction) {
 				editingId.msg,
 				callback);
 		}
-		_header->replyToMessage({});
 	} else {
 		_canReplaceMedia = _canAddMedia = false;
 		_photoEditMedia = nullptr;
@@ -4027,11 +4408,14 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	// (_commentsShown) (_attachToggle|_replaceMedia) (_sendAs) -- _inlineResults ------ _tabbedPanel -- _fieldBarCancel (_starsReaction)
 	// (_attachDocument|_attachPhoto) _field (_ttlInfo) (_scheduled) (_silent|_botCommandStart) _tabbedSelectorToggle _send
 
+	const auto kbheight = keyboardHeight();
 	const auto oldComposeHeight = shouldShowRichDraftPreview()
 		? _richDraftPreview->height()
 		: _field->height();
 	const auto commentsShown = _commentsShown
 		&& !_commentsShown->isHidden();
+	const auto kbShowShown = _botKeyboardShow
+		&& !_botKeyboardShow->isHidden();
 	const auto fieldWidth = size.width()
 		- (commentsShown
 			? (_commentsShown->width() + _st.commentsSkip)
@@ -4042,9 +4426,12 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 		- _st.padding.right()
 		- _send->width()
 		- (_editStars ? _editStars->width() : 0)
-		- _tabbedSelectorToggle->width()
+		- (_kbShown
+			? (_botKeyboardHide ? _botKeyboardHide->width() : 0)
+			: _tabbedSelectorToggle->width())
+		- (kbShowShown ? _botKeyboardShow->width() : 0)
 		- (_likeShown ? _like->width() : 0)
-		- (_botCommandShown ? _botCommandStart->width() : 0)
+		- (botCommandVisible() ? _botCommandStart->width() : 0)
 		- ((_silent && !_silent->isHidden()) ? _silent->width() : 0)
 		- ((_scheduled && !_scheduled->isHidden())
 			? _scheduled->width()
@@ -4071,7 +4458,15 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 		}
 	}
 
-	const auto buttonsTop = size.height() - _st.attach.height;
+	if (_kbShown && _kbScroll) {
+		_kbScroll->setGeometryToLeft(
+			0,
+			size.height() - kbheight,
+			size.width(),
+			kbheight);
+	}
+
+	const auto buttonsTop = size.height() - kbheight - _st.attach.height;
 
 	auto left = 0;
 	if (commentsShown) {
@@ -4093,7 +4488,10 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	const auto fieldHeight = shouldShowRichDraftPreview()
 		? _richDraftPreview->height()
 		: _field->height();
-	const auto fieldTop = size.height() - _st.padding.bottom() - fieldHeight;
+	const auto fieldTop = size.height()
+		- kbheight
+		- _st.padding.bottom()
+		- fieldHeight;
 	_field->moveToLeft(left, fieldTop);
 	if (_richDraftPreview) {
 		_richDraftPreview->moveToLeft(left, fieldTop);
@@ -4116,8 +4514,17 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 		_editStars->moveToRight(right, buttonsTop);
 		right += _editStars->width();
 	}
-	_tabbedSelectorToggle->moveToRight(right, buttonsTop);
-	right += _tabbedSelectorToggle->width();
+	if (_kbShown && _botKeyboardHide) {
+		_botKeyboardHide->moveToRight(right, buttonsTop);
+		right += _botKeyboardHide->width();
+	} else {
+		_tabbedSelectorToggle->moveToRight(right, buttonsTop);
+		right += _tabbedSelectorToggle->width();
+	}
+	if (_botKeyboardShow && !_botKeyboardShow->isHidden()) {
+		_botKeyboardShow->moveToRight(right, buttonsTop);
+		right += _botKeyboardShow->width();
+	}
 	if (_like) {
 		using Type = Controls::WriteRestrictionType;
 		if (_writeRestriction.current().type == Type::PremiumRequired) {
@@ -4131,7 +4538,7 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	}
 	if (_botCommandStart) {
 		_botCommandStart->moveToRight(right, buttonsTop);
-		if (_botCommandShown) {
+		if (botCommandVisible()) {
 			right += _botCommandStart->width();
 		}
 	}
@@ -4157,13 +4564,13 @@ void ComposeControls::updateControlsGeometry(QSize size) {
 	_voiceRecordBar->resizeToWidth(size.width());
 	_voiceRecordBar->moveToLeft(
 		0,
-		size.height() - _voiceRecordBar->height());
+		size.height() - kbheight - _voiceRecordBar->height());
 }
 
 void ComposeControls::updateControlsVisibility() {
 	const auto hide = hideExtraButtons();
 	if (_botCommandStart) {
-		_botCommandStart->setVisible(_botCommandShown);
+		_botCommandStart->setVisible(botCommandVisible());
 	}
 	if (_like) {
 		_like->setVisible(_likeShown);
@@ -4415,6 +4822,13 @@ bool ComposeControls::updateBotCommandShown() {
 	return false;
 }
 
+bool ComposeControls::botCommandVisible() const {
+	return _botCommandShown
+		&& !isEditingMessage()
+		&& (!_keyboard
+			|| (!_keyboard->hasMarkup() && !_keyboard->forceReply()));
+}
+
 bool ComposeControls::hasVisibleSendText() const {
 	return !_field->isHidden() && HasSendText(_field);
 }
@@ -4643,14 +5057,26 @@ void ComposeControls::toggleTabbedSelectorMode() {
 }
 
 void ComposeControls::updateHeight() {
+	auto kbheight = 0;
+	if (_kbShown && _keyboard && _kbScroll) {
+		const auto maxKeyboardHeight = std::max(
+			st::historyComposeFieldMaxHeight / 2,
+			_field->height());
+		_keyboard->resizeToWidth(_wrap->width(), maxKeyboardHeight);
+		kbheight = std::min(_keyboard->height(), maxKeyboardHeight);
+		_kbScroll->resize(_wrap->width(), kbheight);
+	}
 	const auto height = (_header->isDisplayed() ? _header->height() : 0)
 		+ _st.padding.top()
 		+ (shouldShowRichDraftPreview()
 			? _richDraftPreview->height()
 			: _field->height())
-		+ _st.padding.bottom();
+		+ _st.padding.bottom()
+		+ kbheight;
 	if (height != _wrap->height()) {
 		_wrap->resize(_wrap->width(), height);
+	} else if (kbheight) {
+		updateControlsGeometry(_wrap->size());
 	}
 }
 
@@ -4824,6 +5250,12 @@ void ComposeControls::replyToMessage(FullReplyTo id) {
 
 void ComposeControls::cancelReplyMessage() {
 	const auto wasReply = replyingToMessage();
+	const auto forceReplyUsed = _keyboard
+		&& _history
+		&& _keyboard->forceReply()
+		&& _keyboard->singleUse()
+		&& keyboardReplyTo()
+		&& (wasReply.messageId == keyboardReplyTo());
 	_header->replyToMessage({});
 	if (_history) {
 		const auto key = draftKey(DraftType::Normal);
@@ -4840,6 +5272,17 @@ void ComposeControls::cancelReplyMessage() {
 			saveDraftWithTextNow();
 		}
 	}
+	if (forceReplyUsed) {
+		dismissForceReplyKeyboard();
+	}
+}
+
+void ComposeControls::dismissForceReplyKeyboard() {
+	if (!_history || !_keyboard) {
+		return;
+	}
+	_history->clearLastKeyboard(keyboardTopicKey());
+	updateBotKeyboard(true);
 }
 
 void ComposeControls::updateForwarding() {
@@ -4862,8 +5305,11 @@ bool ComposeControls::handleCancelRequest() {
 	} else if (isEditingMessage()) {
 		maybeCancelEditMessage();
 		return true;
-	} else if (replyingToMessage().replying()) {
+	} else if (_header->replyingToMessage().replying()) {
 		cancelReplyMessage();
+		return true;
+	} else if (keyboardReplyTo()) {
+		toggleKeyboard();
 		return true;
 	} else if (readyToForward()) {
 		cancelForward();
@@ -4983,8 +5429,28 @@ bool ComposeControls::isEditingMessage() const {
 	return _header->isEditingMessage();
 }
 
+FullMsgId ComposeControls::keyboardReplyTo() const {
+	if (!_history || !_keyboard) {
+		return {};
+	}
+	const auto forceReply = _keyboard->forceReply();
+	if (!_kbShown && !forceReply) {
+		return {};
+	}
+	const auto peer = _history->peer;
+	if (!peer->isChat() && !peer->isChannel() && !forceReply) {
+		return {};
+	}
+	return _keyboard->forMsgId();
+}
+
 FullReplyTo ComposeControls::replyingToMessage() const {
 	auto result = _header->replyingToMessage();
+	if (!result.messageId) {
+		if (const auto keyboardReply = keyboardReplyTo()) {
+			result.messageId = keyboardReply;
+		}
+	}
 	result.topicRootId = _topicRootId;
 	result.monoforumPeerId = _monoforumPeerId;
 	return result;

--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.h
+++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.h
@@ -20,8 +20,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/fields/input_field.h"
 
 class History;
+class HistoryItem;
 class DocumentData;
 class Image;
+class BotKeyboard;
 
 namespace style {
 struct ComposeControls;
@@ -60,6 +62,10 @@ class Result;
 struct ResultSelected;
 } // namespace InlineBots
 
+namespace Bot {
+struct SendCommandRequest;
+} // namespace Bot
+
 namespace Ui {
 class AbstractButton;
 class SendButton;
@@ -68,6 +74,7 @@ class EmojiButton;
 class SendAsButton;
 class SilentToggle;
 class DropdownMenu;
+class ScrollArea;
 struct PreparedBundle;
 struct PreparedList;
 struct SendStarButtonState;
@@ -201,6 +208,9 @@ public:
 	[[nodiscard]] rpl::producer<Api::SendOptions> sendRequests() const;
 	[[nodiscard]] rpl::producer<VoiceToSend> sendVoiceRequests() const;
 	[[nodiscard]] rpl::producer<QString> sendCommandRequests() const;
+	[[nodiscard]] rpl::producer<Bot::SendCommandRequest>
+	botKeyboardCommandRequests() const;
+	void botKeyboardCommandSent(const Bot::SendCommandRequest &request);
 	[[nodiscard]] rpl::producer<MessageToEdit> editRequests() const;
 	[[nodiscard]] rpl::producer<std::optional<bool>> attachRequests() const;
 	void setSendAsFileConfirmed(
@@ -375,6 +385,16 @@ private:
 	void updateSilentBroadcast();
 	void editMessage(not_null<HistoryItem*> item);
 
+	void initBotKeyboard();
+	void updateBotKeyboard(bool force = false);
+	void toggleKeyboard(bool manual = true);
+	[[nodiscard]] bool kbWasHidden() const;
+	void showKeyboardHideButton();
+	[[nodiscard]] int keyboardHeight() const;
+	[[nodiscard]] MsgId keyboardTopicKey() const;
+	[[nodiscard]] FullMsgId keyboardReplyTo() const;
+	void dismissForceReplyKeyboard();
+
 	void escape();
 	void fieldChanged();
 	[[nodiscard]] bool suppressSendAction() const;
@@ -389,6 +409,7 @@ private:
 	[[nodiscard]] bool showEditStarsButton() const;
 	[[nodiscard]] int shownStarsPerMessage() const;
 	bool updateBotCommandShown();
+	[[nodiscard]] bool botCommandVisible() const;
 	bool updateLikeShown();
 	[[nodiscard]] bool hasVisibleSendText() const;
 	[[nodiscard]] bool hasSendableContent() const;
@@ -511,6 +532,10 @@ private:
 	const not_null<Ui::InputField*> _field;
 	std::unique_ptr<Controls::RichDraftPreview> _richDraftPreview;
 	Ui::IconButton * const _botCommandStart = nullptr;
+	std::unique_ptr<Ui::ScrollArea> _kbScroll;
+	BotKeyboard *_keyboard = nullptr;
+	Ui::IconButton *_botKeyboardShow = nullptr;
+	Ui::IconButton *_botKeyboardHide = nullptr;
 	std::unique_ptr<Ui::SendAsButton> _sendAs;
 	rpl::variable<bool> _videoStreamAdmin;
 	std::unique_ptr<Ui::SilentToggle> _silent;
@@ -541,6 +566,7 @@ private:
 	rpl::event_stream<InlineChosen> _inlineResultChosen;
 	rpl::event_stream<SendActionUpdate> _sendActionUpdates;
 	rpl::event_stream<QString> _sendCommandRequests;
+	rpl::event_stream<Bot::SendCommandRequest> _botKeyboardCommandRequests;
 	rpl::event_stream<not_null<QKeyEvent*>> _scrollKeyEvents;
 	rpl::event_stream<not_null<QKeyEvent*>> _editLastMessageRequests;
 	rpl::event_stream<std::optional<bool>> _attachRequests;
@@ -571,6 +597,7 @@ private:
 	mtpRequestId _inlineBotResolveRequestId = 0;
 	bool _isInlineBot = false;
 	bool _botCommandShown = false;
+	bool _kbShown = false;
 	bool _likeShown = false;
 	Webrtc::RecordAvailability _recordAvailability = {};
 

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
@@ -51,6 +51,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "api/api_sending.h"
 #include "apiwrap.h"
 #include "ui/boxes/confirm_box.h"
+#include "chat_helpers/bot_command.h"
 #include "chat_helpers/message_field.h"
 #include "chat_helpers/tabbed_selector.h"
 #include "boxes/delete_messages_box.h"
@@ -886,6 +887,15 @@ void ChatWidget::setupComposeControls() {
 	_composeControls->sendCommandRequests(
 	) | rpl::on_next([=](const QString &command) {
 		listSendBotCommand(command, FullMsgId());
+		session().api().finishForwarding(prepareSendAction({}));
+	}, lifetime());
+
+	_composeControls->botKeyboardCommandRequests(
+	) | rpl::on_next([=](const Bot::SendCommandRequest &request) {
+		if (request.peer != _peer) {
+			return;
+		}
+		sendBotKeyboardCommandWithOptions(request, {});
 		session().api().finishForwarding(prepareSendAction({}));
 	}, lifetime());
 
@@ -3567,6 +3577,46 @@ void ChatWidget::sendBotCommandWithOptions(
 	}
 
 	session().api().sendMessage(std::move(message));
+	finishSending();
+}
+
+void ChatWidget::sendBotKeyboardCommandWithOptions(
+		Bot::SendCommandRequest request,
+		Api::SendOptions options) {
+	if (request.peer != _peer) {
+		return;
+	} else if (!request.replyTo) {
+		sendBotCommandWithOptions(request.command, request.context, options);
+		return;
+	}
+
+	auto message = Api::MessageToSend(prepareSendAction(options));
+	message.textWithTags = { request.command, TextWithTags::Tags() };
+	if (!_peer->isUser()) {
+		message.action.replyTo = request.replyTo;
+	}
+
+	const auto ephemeral = session().ephemeralMessages().wouldSend(message);
+	if (!ephemeral && showSlowmodeError()) {
+		return;
+	}
+	if (!ephemeral) {
+		const auto withPaymentApproved = [=](int approved) {
+			auto copy = options;
+			copy.starsApproved = approved;
+			sendBotKeyboardCommandWithOptions(request, copy);
+		};
+		const auto checked = checkSendPayment(
+			1,
+			options,
+			withPaymentApproved);
+		if (!checked) {
+			return;
+		}
+	}
+
+	session().api().sendMessage(std::move(message));
+	_composeControls->botKeyboardCommandSent(request);
 	finishSending();
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.h
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.h
@@ -376,6 +376,9 @@ private:
 		const QString &command,
 		const FullMsgId &context,
 		Api::SendOptions options);
+	void sendBotKeyboardCommandWithOptions(
+		Bot::SendCommandRequest request,
+		Api::SendOptions options);
 
 	bool sendExistingDocument(
 		not_null<DocumentData*> document,


### PR DESCRIPTION
## Why

Telegram Desktop kept one reply keyboard per history. Bot forum topics share a history, so the All feed showed a topic keyboard while individual threads showed none at all. Mobile clients correctly showed the matching reply keyboard in each topic.

## Summary

- keep reply keyboard state isolated per bot forum topic, including cold-load reconstruction and live updates
- preserve keyboard state across temporary-to-real topic IDs and edit-mode transitions
- route keyboard and ForceReply sends to the source message
- restore the existing reply-header and cancellation behavior for ForceReply
- hide bot-command controls while reply keyboards or ForceReply are active
- clear topic keyboards when their bot leaves the chat

## Steps to reproduce
Open a private chat with a bot that has threaded mode enabled.
Open a topic where the bot sends ReplyKeyboardMarkup.
Switch between All and that topic.
Have the bot replace the keyboard, or create a new topic whose first reply contains a keyboard.
Before this change, All displayed a topic keyboard of the latest topic, topic views displayed none

## Validation

- Windows x64 Debug build with MSVC 14.44
- fresh-login test in an isolated workdir
- manual coverage: All tab, multiple existing and new topics, live replacement, relaunch reconstruction, keyboard-button send, ForceReply reply/cancel, and edit-mode restore

## Related

- [Custom Keyboard not visible in Topic / Forum chats in Telegram Desktop](https://bugs.telegram.org/c/47099)

## Before
<img width="450" height="347" alt="1" src="https://github.com/user-attachments/assets/f42cfa8f-3773-47ed-a741-638c56d544fc" />
<img width="450" height="365" alt="2" src="https://github.com/user-attachments/assets/e5635305-bc16-4ca8-a640-cbdd25779d25" />

## After
<img width="389" height="342" alt="1 after" src="https://github.com/user-attachments/assets/ae63d9ed-fec1-4e50-9fdf-2a1f61e97db0" />
<img width="388" height="363" alt="2 after" src="https://github.com/user-attachments/assets/271752c5-2109-47bd-b2d9-01c9c0b94c41" />
