### PR TITLE
Make topic tabs accessible to screen readers

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -8581,6 +8581,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_sr_bot_verified_badge" = "Verified Bot";
 "lng_sr_profile_menu" = "Profile menu";
 "lng_sr_close_panel" = "Close panel";
+"lng_sr_tabs_position" = "Change tab bar position";
+"lng_sr_tabs_position_top" = "Tab bar at the top";
+"lng_sr_tabs_position_bottom" = "Tab bar at the bottom";
+"lng_sr_tabs_position_left" = "Tab bar on the left";
 
 "lng_ai_compose_title" = "AI Editor";
 "lng_ai_compose_apply" = "Apply";

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -1182,6 +1182,13 @@ HistoryWidget::HistoryWidget(
 	orderWidgets();
 	setupShortcuts();
 
+	// The topic tabs strip and the bars above the list are created only
+	// once they are needed, long after the top bar, the list and the
+	// composer, so the Tab chain has to follow the layout instead of the
+	// creation order - including the strip's moves between the left
+	// column, the top and the bottom.
+	setVisualTabOrder(true);
+
 	_attachToggle->setAccessibleName(tr::lng_attach(tr::now));
 	_tabbedSelectorToggle->setAccessibleName(tr::lng_emoji_sticker_gif(tr::now));
 	_botKeyboardShow->setAccessibleName(tr::lng_bot_keyboard_show(tr::now));

--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
+++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
@@ -1306,6 +1306,10 @@ ComposeControls::ComposeControls(
 , _unavailableEmojiPasted(std::move(descriptor.unavailableEmojiPasted))
 , _saveDraftTimer([=] { saveDraft(); })
 , _saveCloudDraftTimer([=] { saveCloudDraft(); }) {
+	// The buttons are created in an order unrelated to where they sit in
+	// the row (the send button first of all), so the Tab chain has to
+	// follow the layout instead of the creation order.
+	_wrap->setVisualTabOrder(true);
 	if (_st.radius > 0) {
 		_backgroundRect.emplace(_st.radius, _st.bg);
 	}
@@ -5510,6 +5514,7 @@ bool ComposeControls::updateSendAsButton(
 	}
 	const auto &st = _st.chooseSendAs;
 	_sendAs = std::make_unique<Ui::SendAsButton>(_wrap.get(), st.button);
+	_sendAs->setAccessibleName(tr::lng_send_as_title(tr::now));
 	if (videoStream) {
 		Ui::SetupSendAsButton(_sendAs.get(), st, videoStream, _show);
 		_videoStreamAdmin = videoStream->creator();

--- a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
@@ -1063,6 +1063,12 @@ ChatWidget::ChatWidget(
 
 	orderWidgets();
 
+	// The topic tabs strip is created only once it is needed, long after
+	// the top bar, the list and the composer, so the Tab chain has to
+	// follow the layout instead of the creation order - including the
+	// strip's moves between the left column, the top and the bottom.
+	setVisualTabOrder(true);
+
 	updateControlsVisibility();
 
 	refreshSuggestPostToggle();

--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
@@ -342,9 +342,12 @@ void SubsectionTabs::setupSlider(
 		return _reordering > 0;
 	});
 
-	slider->sectionContextMenu() | rpl::on_next([=](int index) {
-		if (index >= 0 && index < _slice.size()) {
-			showThreadContextMenu(_slice[index].thread);
+	slider->sectionContextMenu() | rpl::on_next([=](
+			Ui::SubsectionTabMenuRequest request) {
+		if (request.index >= 0 && request.index < _slice.size()) {
+			showThreadContextMenu(
+				_slice[request.index].thread,
+				request.position);
 		}
 	}, slider->lifetime());
 
@@ -666,7 +669,9 @@ void SubsectionTabs::startFillingSlider(
 	startScrollChecking(scroll, slider, vertical);
 }
 
-void SubsectionTabs::showThreadContextMenu(not_null<Data::Thread*> thread) {
+void SubsectionTabs::showThreadContextMenu(
+		not_null<Data::Thread*> thread,
+		QPoint position) {
 	_menu = nullptr;
 	_menu = base::make_unique_q<Ui::PopupMenu>(
 		activeWidget(),
@@ -683,7 +688,7 @@ void SubsectionTabs::showThreadContextMenu(not_null<Data::Thread*> thread) {
 	if (_menu->empty()) {
 		_menu = nullptr;
 	} else {
-		_menu->popup(QCursor::pos());
+		_menu->popup(position);
 	}
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
@@ -639,6 +639,9 @@ void SubsectionTabs::startFillingSlider(
 			if (badges.mention) {
 				parts.push_back(tr::lng_sr_chat_mention(tr::now));
 			}
+			if (i >= fixedCount && i < fixedCount + pinnedCount) {
+				parts.push_back(tr::lng_sr_chat_pinned(tr::now));
+			}
 			const auto name = parts.join(u", "_q);
 			const auto tab = slider->buttonAt(i);
 			if (tab->accessibleName() != name) {

--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
@@ -99,6 +99,7 @@ void SubsectionTabs::setup(not_null<Ui::RpWidget*> parent) {
 void SubsectionTabs::setupHorizontal(
 		not_null<QWidget*> parent,
 		bool bottom) {
+	detachToggle();
 	delete base::take(_vertical);
 	delete base::take(bottom ? _horizontal : _bottom);
 	auto &widgetRef = bottom ? _bottom : _horizontal;
@@ -113,19 +114,15 @@ void SubsectionTabs::setupHorizontal(
 		_shadow->raise();
 	}
 
-	const auto toggle = Ui::CreateChild<Ui::IconButton>(
-		widget,
-		st::chatTabsToggle);
-	toggle->show();
+	const auto toggle = ensureToggle(widget);
 	toggle->setIconOverride(
 		bottom ? &st::chatTabsToggleIconBottom : &st::chatTabsToggleIconTop,
 		(bottom
 			? &st::chatTabsToggleIconBottomOver
 			: &st::chatTabsToggleIconTopOver));
-	toggle->setClickedCallback([=] {
-		toggleModes();
-	});
-	toggle->move(0, 0);
+	setToggleAccessibleState(bottom
+		? SubsectionTabsMode::Bottom
+		: SubsectionTabsMode::Top);
 	const auto scroll = Ui::CreateChild<Ui::ScrollArea>(
 		widget,
 		st::chatTabsScroll,
@@ -194,6 +191,7 @@ void SubsectionTabs::setupHorizontal(
 }
 
 void SubsectionTabs::setupVertical(not_null<QWidget*> parent) {
+	detachToggle();
 	delete base::take(_horizontal);
 	delete base::take(_bottom);
 	_vertical = Ui::CreateChild<Ui::RpWidget>(parent);
@@ -204,17 +202,11 @@ void SubsectionTabs::setupVertical(not_null<QWidget*> parent) {
 		_shadow->show();
 	}
 
-	const auto toggle = Ui::CreateChild<Ui::IconButton>(
-		_vertical,
-		st::chatTabsToggle);
-	toggle->show();
+	const auto toggle = ensureToggle(_vertical);
 	toggle->setIconOverride(
 		&st::chatTabsToggleIconLeft,
 		&st::chatTabsToggleIconLeftOver);
-	toggle->setClickedCallback([=] {
-		toggleModes();
-	});
-	toggle->move(0, 0);
+	setToggleAccessibleState(SubsectionTabsMode::Left);
 	const auto scroll = Ui::CreateChild<Ui::ScrollArea>(
 		_vertical,
 		st::chatTabsScroll);
@@ -253,10 +245,57 @@ void SubsectionTabs::setupVertical(not_null<QWidget*> parent) {
 	startFillingSlider(scroll, slider, true);
 }
 
+void SubsectionTabs::detachToggle() {
+	// The same toggle button object survives mode switches (the rest of the
+	// strip is recreated): detach it before the old strip is deleted, so
+	// keyboard focus - and the screen reader's focus - can stay on it
+	// without the button being re-announced after every press.
+	if (_toggle) {
+		_toggle->setParent(nullptr);
+	}
+}
+
+not_null<Ui::IconButton*> SubsectionTabs::ensureToggle(
+		not_null<QWidget*> widget) {
+	if (_toggle) {
+		_toggle->setParent(widget);
+	} else {
+		_toggle = Ui::CreateChild<Ui::IconButton>(widget, st::chatTabsToggle);
+		_toggle->setAccessibleName(tr::lng_sr_tabs_position(tr::now));
+		_toggle->setClickedCallback([=] {
+			toggleModes();
+		});
+	}
+	_toggle->show();
+	_toggle->move(0, 0);
+	return _toggle;
+}
+
+void SubsectionTabs::setToggleAccessibleState(SubsectionTabsMode mode) {
+	Expects(_toggle != nullptr);
+
+	// The button keeps its action name; the description carries the current
+	// position, so it is read after the name on focus and updated on every
+	// mode switch (the button object survives switches and stays focused).
+	const auto description = (mode == SubsectionTabsMode::Left)
+		? tr::lng_sr_tabs_position_left(tr::now)
+		: (mode == SubsectionTabsMode::Bottom)
+		? tr::lng_sr_tabs_position_bottom(tr::now)
+		: tr::lng_sr_tabs_position_top(tr::now);
+	if (_toggle->accessibleDescription() != description) {
+		_toggle->setAccessibleDescription(description);
+		_toggle->accessibilityDescriptionChanged();
+	}
+}
+
 void SubsectionTabs::setupSlider(
 		not_null<Ui::ScrollArea*> scroll,
 		not_null<Ui::SubsectionSlider*> slider,
 		bool vertical) {
+	slider->setAccessibleName(_history->amMonoforumAdmin()
+		? tr::lng_manage_monoforum(tr::now)
+		: tr::lng_forum_topics_switch(tr::now));
+
 	slider->sectionActivated() | rpl::on_next([=](int active) {
 		if (_reordering) {
 			return;
@@ -574,6 +613,37 @@ void SubsectionTabs::startFillingSlider(
 		_sectionsSlice = _slice;
 		Assert(slider->sectionsCount() == _slice.size());
 
+		const auto sectionsCount = slider->sectionsCount();
+		for (auto i = 0; i != sectionsCount; ++i) {
+			// Compose an accessible name from the data the visual tab
+			// shows: title, unread count and mention mark.
+			auto parts = QStringList();
+			const auto &item = _slice[i];
+			if (const auto sublist = item.thread->asSublist()) {
+				parts.push_back(sublist->sublistPeer()->shortName());
+			} else if (item.thread->asTopic()) {
+				parts.push_back(item.name);
+			} else {
+				parts.push_back(tr::lng_filters_all_short(tr::now));
+			}
+			const auto &badges = item.badges;
+			if (badges.unreadCounter > 0) {
+				parts.push_back(tr::lng_sr_chat_unread(
+					tr::now,
+					lt_count,
+					badges.unreadCounter));
+			}
+			if (badges.mention) {
+				parts.push_back(tr::lng_sr_chat_mention(tr::now));
+			}
+			const auto name = parts.join(u", "_q);
+			const auto tab = slider->buttonAt(i);
+			if (tab->accessibleName() != name) {
+				tab->setAccessibleName(name);
+				tab->accessibilityNameChanged();
+			}
+		}
+
 		_reorder->cancel();
 		if ((pinnedCount > 1) && _history->peer->canManageTopics()) {
 			_reorder->start();
@@ -653,12 +723,25 @@ void SubsectionTabs::toggleModes() {
 		qint32(next));
 	session().saveSettingsDelayed();
 
+	// The strip is recreated in the new position, but the toggle button
+	// object itself survives (the setup detaches and reparents it). Clear
+	// focus for the duration of the rebuild - so hiding it can't hand focus
+	// to another widget - and put it back on the very same button after:
+	// with no intermediate focus changes and an unchanged focus target, the
+	// screen reader stays silent instead of re-announcing the button.
+	const auto hadFocus = _toggle && _toggle->hasFocus();
+	if (hadFocus) {
+		_toggle->clearFocus();
+	}
 	if (next == SubsectionTabsMode::Left) {
 		setupVertical(parent);
 	} else if (next == SubsectionTabsMode::Bottom) {
 		setupHorizontal(parent, true);
 	} else {
 		setupHorizontal(parent, false);
+	}
+	if (hadFocus && _toggle) {
+		_toggle->setFocus();
 	}
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.h
+++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.h
@@ -118,7 +118,9 @@ private:
 		not_null<Ui::ScrollArea*> scroll,
 		not_null<Ui::SubsectionSlider*> slider,
 		bool vertical);
-	void showThreadContextMenu(not_null<Data::Thread*> thread);
+	void showThreadContextMenu(
+		not_null<Data::Thread*> thread,
+		QPoint position);
 	void applyReorder(
 		not_null<Ui::RpWidget*> widget,
 		int oldPosition,

--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.h
+++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.h
@@ -26,6 +26,7 @@ class SessionController;
 
 namespace Ui {
 class RpWidget;
+class IconButton;
 class PopupMenu;
 class ScrollArea;
 class SubsectionSlider;
@@ -87,6 +88,10 @@ private:
 	};
 
 	void track();
+	void detachToggle();
+	[[nodiscard]] not_null<Ui::IconButton*> ensureToggle(
+		not_null<QWidget*> widget);
+	void setToggleAccessibleState(SubsectionTabsMode mode);
 	void setupHorizontal(not_null<QWidget*> parent, bool bottom);
 	void setupVertical(not_null<QWidget*> parent);
 	void toggleModes();
@@ -128,6 +133,7 @@ private:
 	Ui::RpWidget *_vertical = nullptr;
 	Ui::RpWidget *_bottom = nullptr;
 	Ui::RpWidget *_shadow = nullptr;
+	Ui::IconButton *_toggle = nullptr;
 	std::unique_ptr<Ui::SubsectionSliderReorder> _reorder;
 	int _reordering = 0;
 

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "dialogs/dialogs_three_state_icon.h"
 #include "ui/effects/ripple_animation.h"
+#include "ui/screen_reader_mode.h"
 #include "ui/widgets/scroll_area.h"
 #include "ui/dynamic_image.h"
 #include "ui/unread_badge_paint.h"
@@ -473,6 +474,16 @@ SubsectionButton::SubsectionButton(
 : RippleButton(parent, st::defaultRippleAnimationBgOver)
 , _delegate(delegate)
 , _data(std::move(data)) {
+	setIsListItem(true);
+}
+
+AccessibilityState SubsectionButton::accessibilityState() const {
+	// The active tab is reported as selected persistently, independent of
+	// keyboard focus, like the folders sidebar items.
+	auto state = RippleButton::accessibilityState();
+	state.selectable = true;
+	state.selected = _delegate->buttonSelected(this);
+	return state;
 }
 
 SubsectionButton::~SubsectionButton() = default;
@@ -539,6 +550,19 @@ void SubsectionButton::contextMenuEvent(QContextMenuEvent *e) {
 	_delegate->buttonContextMenu(this, e);
 }
 
+void SubsectionButton::focusInEvent(QFocusEvent *e) {
+	_delegate->buttonFocused(this);
+	RippleButton::focusInEvent(e);
+}
+
+void SubsectionButton::keyPressEvent(QKeyEvent *e) {
+	// Arrows and Home/End move focus between the tabs; everything else
+	// (including Enter and Space, which activate) goes to the button.
+	if (!_delegate->buttonKeyPressed(this, e)) {
+		RippleButton::keyPressEvent(e);
+	}
+}
+
 SubsectionSlider::SubsectionSlider(not_null<QWidget*> parent, bool vertical)
 : RpWidget(parent)
 , _vertical(vertical)
@@ -548,6 +572,11 @@ SubsectionSlider::SubsectionSlider(not_null<QWidget*> parent, bool vertical)
 , _bar(CreateChild<RpWidget>(this))
 , _barRect(_barSt.radius, _barSt.fg) {
 	setupBar();
+
+	ScreenReaderModeActiveValue(
+	) | rpl::on_next([=](bool) {
+		refreshAccessibilityFocus();
+	}, lifetime());
 }
 
 SubsectionSlider::~SubsectionSlider() = default;
@@ -592,6 +621,10 @@ void SubsectionSlider::setSections(
 	_fixedCount = sections.fixed;
 	_pinnedCount = sections.pinned;
 	_reorderAllowed = sections.reorder;
+
+	const auto hadFocus = ranges::any_of(_tabs, [](const auto &tab) {
+		return tab->hasFocus();
+	});
 
 	auto old = base::take(_tabs);
 	_tabs.reserve(sections.tabs.size());
@@ -659,6 +692,19 @@ void SubsectionSlider::setSections(
 	}
 
 	_bar->raise();
+
+	refreshAccessibilityFocus();
+	if (hadFocus && !ranges::any_of(_tabs, [](const auto &tab) {
+			return tab->hasFocus(); })) {
+		// The focused button was destroyed by the rebuild; keep keyboard
+		// focus inside the list by moving it to the roving Tab stop.
+		for (const auto &tab : _tabs) {
+			if (tab->focusPolicy() == Qt::TabFocus) {
+				tab->setFocus();
+				break;
+			}
+		}
+	}
 }
 
 void SubsectionSlider::activate(int index) {
@@ -677,6 +723,7 @@ void SubsectionSlider::activate(int index) {
 			}
 		}
 	};
+	activeChangedForAccessibility(old);
 	const auto weak = base::make_weak(_bar);
 	_sectionActivated.fire_copy(index);
 	if (weak) {
@@ -687,13 +734,30 @@ void SubsectionSlider::activate(int index) {
 	}
 }
 
+void SubsectionSlider::activeChangedForAccessibility(int old) {
+	if (old == _active) {
+		return;
+	}
+	// The AccessibilityState argument is a mask of which states changed;
+	// screen readers query the current values themselves.
+	const auto count = int(_tabs.size());
+	if (old >= 0 && old < count) {
+		_tabs[old]->accessibilityStateChanged({ .selected = true });
+	}
+	if (_active >= 0 && _active < count) {
+		_tabs[_active]->accessibilityStateChanged({ .selected = true });
+	}
+	refreshAccessibilityFocus();
+}
+
 void SubsectionSlider::setActiveSectionFast(int active, bool ignoreScroll) {
 	Expects(active < int(_tabs.size()));
 
 	if (_active == active) {
 		return;
 	}
-	_active = active;
+	const auto old = std::exchange(_active, active);
+	activeChangedForAccessibility(old);
 	_activeFrom.stop();
 	_activeSize.stop();
 	if (_active >= 0 && !ignoreScroll) {
@@ -803,6 +867,126 @@ void SubsectionSlider::buttonContextMenu(
 
 Text::MarkedContext SubsectionSlider::buttonContext() {
 	return _context;
+}
+
+int SubsectionSlider::buttonIndex(
+		not_null<const SubsectionButton*> button) const {
+	const auto i = ranges::find(
+		_tabs,
+		button.get(),
+		&std::unique_ptr<SubsectionButton>::get);
+	return (i != end(_tabs)) ? int(i - begin(_tabs)) : -1;
+}
+
+bool SubsectionSlider::buttonSelected(
+		not_null<const SubsectionButton*> button) {
+	const auto index = buttonIndex(button);
+	return (index >= 0) && (index == _active);
+}
+
+void SubsectionSlider::buttonFocused(not_null<SubsectionButton*> button) {
+	// The roving Tab stop follows keyboard focus, folders-sidebar style, so
+	// Tab/Shift+Tab always leave the list from the focused tab.
+	refreshAccessibilityFocus();
+	// Bring the focused tab into view - the owner centers it through the
+	// same requestShown channel that is used on activation.
+	const auto from = _vertical ? button->y() : button->x();
+	const auto size = _vertical ? button->height() : button->width();
+	_requestShown.fire({ from, from + size });
+}
+
+bool SubsectionSlider::buttonKeyPressed(
+		not_null<SubsectionButton*> button,
+		not_null<QKeyEvent*> e) {
+	const auto count = int(_tabs.size());
+	const auto key = e->key();
+	const auto next = _vertical ? Qt::Key_Down : Qt::Key_Right;
+	const auto previous = _vertical ? Qt::Key_Up : Qt::Key_Left;
+	auto target = -1;
+	if (key == next || key == previous) {
+		const auto index = buttonIndex(button);
+		if (index < 0) {
+			return false;
+		}
+		target = std::clamp(index + ((key == next) ? 1 : -1), 0, count - 1);
+	} else if (key == Qt::Key_Home) {
+		target = 0;
+	} else if (key == Qt::Key_End) {
+		target = count - 1;
+	} else {
+		return false;
+	}
+	// Arrows only move focus, without activating; activation happens on
+	// Enter or Space. Consume the key even at the list bounds, so it does
+	// not fall through and scroll the chat behind the tabs.
+	if (target >= 0 && target < count && !_tabs[target]->hasFocus()) {
+		_tabs[target]->setFocus();
+	}
+	return true;
+}
+
+QAccessible::Role SubsectionSlider::accessibilityRole() {
+	return QAccessible::List;
+}
+
+Qt::FocusPolicy SubsectionSlider::accessibilityFocusPolicy() {
+	// Like the folders sidebar list: the container itself is never a Tab
+	// stop, the roving Tab stop lives on one of the tab buttons.
+	return Qt::ClickFocus;
+}
+
+std::optional<Qt::Orientation> SubsectionSlider::accessibilityOrientation() const {
+	return _vertical ? Qt::Vertical : Qt::Horizontal;
+}
+
+bool SubsectionSlider::accessibilitySelectionList() const {
+	// Opt in to the single-selection list behaviour (selection interface +
+	// container focus forwarding to the active tab).
+	return true;
+}
+
+auto SubsectionSlider::accessibilityChildWidgets() const
+-> std::vector<not_null<QWidget*>> {
+	// Report only the tab buttons - not the active-bar helper widget - in
+	// visual order, which can differ from creation order after reordering.
+	auto result = std::vector<not_null<QWidget*>>();
+	result.reserve(_tabs.size());
+	for (const auto &tab : _tabs) {
+		result.push_back(tab.get());
+	}
+	return result;
+}
+
+void SubsectionSlider::refreshAccessibilityFocus() {
+	if (_tabs.empty()) {
+		return;
+	}
+	// The tabs are focusable only in screen-reader mode, with a single
+	// roving Tab stop for the whole strip: the focused tab if any,
+	// otherwise the active one.
+	if (!ScreenReaderModeActive()) {
+		for (const auto &tab : _tabs) {
+			tab->setFocusPolicy(Qt::NoFocus);
+		}
+		return;
+	}
+	auto stop = (SubsectionButton*)nullptr;
+	for (const auto &tab : _tabs) {
+		if (tab->hasFocus()) {
+			stop = tab.get();
+			break;
+		}
+	}
+	if (!stop) {
+		stop = (_active >= 0 && _active < int(_tabs.size()))
+			? _tabs[_active].get()
+			: _tabs.front().get();
+	}
+	for (const auto &tab : _tabs) {
+		tab->setFocusPolicy((tab.get() == stop)
+			? Qt::TabFocus
+			: Qt::ClickFocus);
+	}
 }
 
 not_null<SubsectionButton*> SubsectionSlider::buttonAt(int index) {

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
@@ -474,7 +474,7 @@ SubsectionButton::SubsectionButton(
 : RippleButton(parent, st::defaultRippleAnimationBgOver)
 , _delegate(delegate)
 , _data(std::move(data)) {
-	setIsListItem(true);
+	setIsPageTab(true);
 }
 
 AccessibilityState SubsectionButton::accessibilityState() const {
@@ -926,7 +926,7 @@ bool SubsectionSlider::buttonKeyPressed(
 }
 
 QAccessible::Role SubsectionSlider::accessibilityRole() {
-	return QAccessible::List;
+	return QAccessible::PageTabList;
 }
 
 Qt::FocusPolicy SubsectionSlider::accessibilityFocusPolicy() {

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
@@ -555,6 +555,11 @@ void SubsectionButton::focusInEvent(QFocusEvent *e) {
 	RippleButton::focusInEvent(e);
 }
 
+void SubsectionButton::focusOutEvent(QFocusEvent *e) {
+	_delegate->buttonBlurred(this);
+	RippleButton::focusOutEvent(e);
+}
+
 void SubsectionButton::keyPressEvent(QKeyEvent *e) {
 	// Arrows and Home/End move focus between the tabs; everything else
 	// (including Enter and Space, which activate) goes to the button.
@@ -893,6 +898,17 @@ void SubsectionSlider::buttonFocused(not_null<SubsectionButton*> button) {
 	const auto from = _vertical ? button->y() : button->x();
 	const auto size = _vertical ? button->height() : button->width();
 	_requestShown.fire({ from, from + size });
+}
+
+void SubsectionSlider::buttonBlurred(not_null<SubsectionButton*> button) {
+	// Once focus leaves the strip, park the roving Tab stop back on the
+	// active tab, so the next Tab from outside enters on it and not on the
+	// tab the arrows last browsed. Deferred, because focus may be merely
+	// moving to another tab - by the time this runs that tab holds focus
+	// and keeps the stop.
+	crl::on_main(this, [=] {
+		refreshAccessibilityFocus();
+	});
 }
 
 bool SubsectionSlider::buttonKeyPressed(

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
@@ -987,6 +987,11 @@ void SubsectionSlider::refreshAccessibilityFocus() {
 			? Qt::TabFocus
 			: Qt::ClickFocus);
 	}
+	// The section widget above keeps its Tab chain in visual order, and a
+	// roving stop moving between tabs (or to a freshly rebuilt tab) is
+	// invisible to it - tell it, so a Tab entering the strip from outside
+	// finds the current stop and not a wiring to the previous one.
+	RefreshVisualTabOrder(this);
 }
 
 not_null<SubsectionButton*> SubsectionSlider::buttonAt(int index) {

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
@@ -10,6 +10,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "dialogs/dialogs_three_state_icon.h"
 #include "ui/effects/ripple_animation.h"
 #include "ui/screen_reader_mode.h"
+#include "ui/widgets/popup_menu.h"
 #include "ui/widgets/scroll_area.h"
 #include "ui/dynamic_image.h"
 #include "ui/unread_badge_paint.h"
@@ -788,7 +789,8 @@ rpl::producer<int> SubsectionSlider::sectionActivated() const {
 	return _sectionActivated.events();
 }
 
-rpl::producer<int> SubsectionSlider::sectionContextMenu() const {
+auto SubsectionSlider::sectionContextMenu() const
+-> rpl::producer<SubsectionTabMenuRequest> {
 	return _sectionContextMenu.events();
 }
 
@@ -866,7 +868,10 @@ void SubsectionSlider::buttonContextMenu(
 		&std::unique_ptr<SubsectionButton>::get);
 	Assert(i != end(_tabs));
 
-	_sectionContextMenu.fire(int(i - begin(_tabs)));
+	_sectionContextMenu.fire({
+		.index = int(i - begin(_tabs)),
+		.position = ContextMenuPosition(button, e),
+	});
 	e->accept();
 }
 

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.h
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.h
@@ -46,6 +46,12 @@ public:
 	virtual void buttonContextMenu(
 		not_null<SubsectionButton*> button,
 		not_null<QContextMenuEvent*> e) = 0;
+	virtual bool buttonSelected(
+		not_null<const SubsectionButton*> button) = 0;
+	virtual void buttonFocused(not_null<SubsectionButton*> button) = 0;
+	virtual bool buttonKeyPressed(
+		not_null<SubsectionButton*> button,
+		not_null<QKeyEvent*> e) = 0;
 };
 
 class SubsectionButton : public RippleButton {
@@ -58,6 +64,8 @@ public:
 
 	void setData(SubsectionTab &&data);
 	[[nodiscard]] DynamicImage *userpic() const;
+
+	AccessibilityState accessibilityState() const override;
 
 	void setActiveShown(float64 activeShown);
 	void setIsPinned(bool pinned);
@@ -73,6 +81,8 @@ protected:
 	virtual void invalidateCache() = 0;
 
 	void contextMenuEvent(QContextMenuEvent *e) override;
+	void focusInEvent(QFocusEvent *e) override;
+	void keyPressEvent(QKeyEvent *e) override;
 
 	const not_null<SubsectionButtonDelegate*> _delegate;
 	SubsectionTab _data;
@@ -107,6 +117,19 @@ public:
 		not_null<SubsectionButton*> button,
 		not_null<QContextMenuEvent*> e) override;
 	Text::MarkedContext buttonContext() override;
+	bool buttonSelected(not_null<const SubsectionButton*> button) override;
+	void buttonFocused(not_null<SubsectionButton*> button) override;
+	bool buttonKeyPressed(
+		not_null<SubsectionButton*> button,
+		not_null<QKeyEvent*> e) override;
+
+	// Accessibility: a single-select list of real tab buttons with one
+	// roving Tab stop, like the folders sidebar list.
+	QAccessible::Role accessibilityRole() override;
+	Qt::FocusPolicy accessibilityFocusPolicy() override;
+	std::optional<Qt::Orientation> accessibilityOrientation() const override;
+	bool accessibilitySelectionList() const override;
+	std::vector<not_null<QWidget*>> accessibilityChildWidgets() const override;
 	[[nodiscard]] not_null<SubsectionButton*> buttonAt(int index);
 	void setButtonShift(int index, int shift);
 	void reorderButtons(int from, int to);
@@ -136,6 +159,10 @@ protected:
 	[[nodiscard]] Range getFinalActiveRange() const;
 	[[nodiscard]] Range getCurrentActiveRange() const;
 	void activate(int index);
+	[[nodiscard]] int buttonIndex(
+		not_null<const SubsectionButton*> button) const;
+	void refreshAccessibilityFocus();
+	void activeChangedForAccessibility(int old);
 
 	[[nodiscard]] virtual std::unique_ptr<SubsectionButton> makeButton(
 		SubsectionTab &&data) = 0;

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.h
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.h
@@ -49,6 +49,7 @@ public:
 	virtual bool buttonSelected(
 		not_null<const SubsectionButton*> button) = 0;
 	virtual void buttonFocused(not_null<SubsectionButton*> button) = 0;
+	virtual void buttonBlurred(not_null<SubsectionButton*> button) = 0;
 	virtual bool buttonKeyPressed(
 		not_null<SubsectionButton*> button,
 		not_null<QKeyEvent*> e) = 0;
@@ -82,6 +83,7 @@ protected:
 
 	void contextMenuEvent(QContextMenuEvent *e) override;
 	void focusInEvent(QFocusEvent *e) override;
+	void focusOutEvent(QFocusEvent *e) override;
 	void keyPressEvent(QKeyEvent *e) override;
 
 	const not_null<SubsectionButtonDelegate*> _delegate;
@@ -119,6 +121,7 @@ public:
 	Text::MarkedContext buttonContext() override;
 	bool buttonSelected(not_null<const SubsectionButton*> button) override;
 	void buttonFocused(not_null<SubsectionButton*> button) override;
+	void buttonBlurred(not_null<SubsectionButton*> button) override;
 	bool buttonKeyPressed(
 		not_null<SubsectionButton*> button,
 		not_null<QKeyEvent*> e) override;

--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.h
+++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.h
@@ -38,6 +38,11 @@ struct SubsectionTabs {
 	bool reorder = false;
 };
 
+struct SubsectionTabMenuRequest {
+	int index = 0;
+	QPoint position; // Global coordinates for showing the menu.
+};
+
 class SubsectionButtonDelegate {
 public:
 	virtual bool buttonPaused() = 0;
@@ -110,7 +115,8 @@ public:
 
 	[[nodiscard]] int sectionsCount() const;
 	[[nodiscard]] rpl::producer<int> sectionActivated() const;
-	[[nodiscard]] rpl::producer<int> sectionContextMenu() const;
+	[[nodiscard]] auto sectionContextMenu() const
+		-> rpl::producer<SubsectionTabMenuRequest>;
 	[[nodiscard]] int lookupSectionPosition(int index) const;
 
 	bool buttonPaused() override;
@@ -191,7 +197,7 @@ protected:
 	bool _reorderAllowed = false;
 
 	rpl::event_stream<int> _sectionActivated;
-	rpl::event_stream<int> _sectionContextMenu;
+	rpl::event_stream<SubsectionTabMenuRequest> _sectionContextMenu;
 	Fn<bool()> _paused;
 
 	rpl::event_stream<ScrollToRequest> _requestShown;


### PR DESCRIPTION
﻿The topic tabs inside a forum chat (and the sender tabs in a channel's Direct Messages inbox) were invisible to screen readers: the tab buttons had no names, no list semantics and no keyboard access, so a blind user could not tell which topics exist, which one is active, or switch between them.

The tab strip is now a tab control - it is named tabs everywhere in the UI, so the screen reader calls it that too. Each tab is a named item (title with unread count, mention state and the pinned mark, updated as the badges change), the active one is reported as selected, and the strip is named "Topics" or "Direct Messages" with the right orientation for each position. In screen reader mode the strip gets one roving Tab stop on the active tab; arrows move focus between tabs (Up/Down when vertical, Left/Right when horizontal, Home/End for the edges) without switching - the browse-then-commit pattern for tabs whose panes load their content - Enter or Space activates, the context menu key opens the topic menu anchored on the tab (a mouse-invoked menu keeps opening at the cursor), and the focused tab is scrolled into view. Keyboard focus survives the frequent rebuilds of the strip on unread updates. The folders sidebar follows in #31176.

The position toggle button got an accessible name, with the current position reported in its description. It is also one persistent widget now, reused across mode switches instead of being recreated with the strip, so pressing it from the keyboard keeps focus on it without the screen reader re-announcing the button on every press. Sighted users are unaffected - the button is only focusable in screen reader mode.

The strip is created only once it is needed, long after the top bar, the list and the composer, so its Tab stops used to land at the end of the chain. The chat sections now keep their Tab chain in visual order (the lib_ui visual Tab order added for the chat list column), which places the strip at its reading-order position wherever it sits - left column, top or bottom - and follows it as the toggle moves it around. The one thing the container cannot see on its own is the roving stop moving between tabs deep inside the strip, so the slider tells it after each move; without that, a Tab entering the strip from outside would follow wiring to the previous stop. The composer inside a topic needed the same treatment: its buttons are created in an order unrelated to the row layout, so switching topics used to scramble their Tab order, and its send-as picker was missing its accessible name.

Needs desktop-app/lib_ui#348 for the PageTab button role.

Tested with NVDA on Windows 10 in a forum group with the tabs layout: browsing, activation, unread counts, context menus and cycling the tab bar through all three positions - after each move the next Tab finds the strip at its new place, and leaving the strip and Tabbing back in lands on the active tab - the arrows browse freely inside, but once focus leaves, the roving stop parks back on the current topic.




