### PR TITLE
Name the tab strips for screen readers

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -8459,6 +8459,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_sr_bot_verified_badge" = "Verified Bot";
 "lng_sr_profile_menu" = "Profile menu";
 "lng_sr_close_panel" = "Close panel";
+"lng_sr_message_options" = "Message options";
 
 "lng_ai_compose_title" = "AI Editor";
 "lng_ai_compose_apply" = "Apply";

--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -1181,6 +1181,8 @@ void ProxiesBox::setupContent() {
 			_proxyRotationOptions->entity(),
 			st::settingsSlider),
 		st::settingsBigScalePadding);
+	_proxyRotationTimeout->setAccessibleName(
+		tr::lng_proxy_auto_switch(tr::now));
 	for (const auto seconds : Core::SettingsProxy::kProxyRotationTimeouts) {
 		_proxyRotationTimeout->addSection(
 			tr::lng_proxy_auto_switch_timeout(

--- a/Telegram/SourceFiles/boxes/stickers_box.cpp
+++ b/Telegram/SourceFiles/boxes/stickers_box.cpp
@@ -430,6 +430,7 @@ StickersBox::StickersBox(
 , _featured(_isMasks ? Tab() : Tab(1, this, _show, Section::Featured))
 , _archived((_isMasks ? 1 : 2), this, _show, Section::Archived) {
 	_tabs->setRippleTopRoundRadius(st::boxRadius);
+	_tabs->setAccessibleName(tr::lng_switch_stickers(tr::now));
 }
 
 StickersBox::StickersBox(

--- a/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
+++ b/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
@@ -1237,6 +1237,7 @@ void TabbedSelector::setAllowEmojiWithoutPremium(bool allow) {
 
 void TabbedSelector::createTabsSlider() {
 	_tabsSlider.create(this, _st.tabs);
+	_tabsSlider->setAccessibleName(tr::lng_settings_stickers_emoji(tr::now));
 
 	fillTabsSliderSections();
 

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
@@ -1410,6 +1410,7 @@ Suggestions::Suggestions(
 Suggestions::~Suggestions() = default;
 
 void Suggestions::setupTabs() {
+	_tabs->setAccessibleName(tr::lng_dlg_filter(tr::now));
 	_tabsScroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto pixelDelta = e->pixelDelta();
 		const auto angleDelta = e->angleDelta();

--- a/Telegram/SourceFiles/history/view/controls/history_view_draft_options.cpp
+++ b/Telegram/SourceFiles/history/view/controls/history_view_draft_options.cpp
@@ -787,6 +787,8 @@ void DraftOptionsBox(
 				object_ptr<Ui::SettingsSlider>(
 					box.get(),
 					st::defaultTabsSlider));
+			state->tabs->setAccessibleName(
+				tr::lng_sr_message_options(tr::now));
 			state->tabs->resizeToWidth(st::boxWideWidth);
 			state->tabs->move(0, 0);
 			state->tabs->setRippleTopRoundRadius(st::boxRadius);

--- a/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_inner_widget.cpp
+++ b/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_inner_widget.cpp
@@ -464,6 +464,7 @@ void InnerWidget::fill() {
 				object_ptr<Ui::CustomWidthSlider>(
 					inner,
 					st::dialogsSearchTabs)));
+		slider->entity()->setAccessibleName(tr::lng_boosts_title(tr::now));
 		if (!hasOneTab) {
 			const auto shadow = Ui::CreateChild<Ui::PlainShadow>(inner);
 			shadow->show();

--- a/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_list.cpp
+++ b/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_list.cpp
@@ -1008,6 +1008,8 @@ void InnerWidget::fill() {
 					listsContainer,
 					st::defaultTabsSlider)),
 			st::boxRowPadding);
+		slider->entity()->setAccessibleName(
+			tr::lng_channel_earn_history_title(tr::now));
 		slider->toggle(
 			((hasCurrencyTab ? 1 : 0) + (hasCreditsTab ? 1 : 0) > 1),
 			anim::type::instant);

--- a/Telegram/SourceFiles/settings/sections/settings_credits.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_credits.cpp
@@ -313,6 +313,8 @@ void Credits::setupHistory(not_null<Ui::VerticalLayout*> container) {
 					inner,
 					st::creditsHistoryTabsSlider)),
 			st::creditsHistoryTabsSliderPadding);
+		slider->entity()->setAccessibleName(
+			tr::lng_channel_earn_history_title(tr::now));
 		slider->toggle(!hasOneTab, anim::type::instant);
 		if (!hasOneTab) {
 			const auto shadow = Ui::CreateChild<Ui::RpWidget>(inner);

--- a/Telegram/SourceFiles/settings/sections/settings_notifications.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_notifications.cpp
@@ -1567,6 +1567,8 @@ void BuildSystemIntegrationAndAdvancedSection(SectionBuilder &builder) {
 		const auto countSlider = advancedWrap->add(
 			object_ptr<Ui::SettingsSlider>(advancedWrap, st::settingsSlider),
 			st::settingsBigScalePadding);
+		countSlider->setAccessibleName(
+			tr::lng_settings_notifications_count(tr::now));
 		for (int i = 0; i != kMaxNotificationsCount; ++i) {
 			countSlider->addSection(QString::number(i + 1));
 		}


### PR DESCRIPTION
Complements #31097: that PR turns the painted sections of Ui::DiscreteSlider into accessible tabs, but the containers themselves had no accessible names, so a screen reader landing on them announced a bare tab control. This PR names them at every call site - the chat list search tabs, the emoji / stickers / GIFs panel, the stickers box, the notifications count and proxy auto-switch sliders, the Stars transaction history, the channel earn history, the boosts list and the message options box.

Almost all names reuse existing keys near each slider (the subsection title or box context), so only one new key is added (lng_sr_message_options for the link / reply / forward options box, which has no single visible title when the tabs are shown). The folder tabs strip is not touched here - it is named in #31098.

Builds and runs fine without #31097 (an accessible name on a widget without an accessible role is simply unused), so there is no compile dependency, but the names only become audible together with it.
