### PR TITLE
Throttle concurrent proxy checks

### DIFF
--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -67,6 +67,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace {
 
 constexpr auto kSaveSettingsDelayedTimeout = crl::time(1000);
+constexpr auto kMaxConcurrentProxyChecks = 50;
 
 using ProxyData = MTP::ProxyData;
 
@@ -2006,47 +2007,94 @@ auto ProxiesBoxController::proxySettingsValue() const
 
 void ProxiesBoxController::refreshChecker(Item &item) {
 	item.state = ItemState::Checking;
-	const auto id = item.id;
-	MTP::StartProxyCheck(
-		&_account->mtp(),
-		item.data,
-		Core::App().settings().proxy().tryIPv6(),
-		item.checker,
-		item.checkerv6,
-		[=](Connection *raw, int pingTime) {
-			const auto item = ranges::find(
-				_list,
-				id,
-				[](const Item &item) { return item.id; });
-			if (item == end(_list)) {
-				return;
-			}
-			MTP::DropProxyChecker(item->checker, item->checkerv6, raw);
-			MTP::ResetProxyCheckers(item->checker, item->checkerv6);
-			if (item->state == ItemState::Checking) {
-				item->state = ItemState::Available;
-				item->ping = pingTime;
-				updateView(*item);
-			}
-		},
-		[=](Connection *raw) {
-			const auto item = ranges::find(
-				_list,
-				id,
-				[](const Item &item) { return item.id; });
-			if (item == end(_list)) {
-				return;
-			}
-			MTP::DropProxyChecker(item->checker, item->checkerv6, raw);
-			if (!MTP::HasProxyCheckers(item->checker, item->checkerv6)
-				&& item->state == ItemState::Checking) {
-				item->state = ItemState::Unavailable;
-				updateView(*item);
-			}
-		});
-	if (!MTP::HasProxyCheckers(item.checker, item.checkerv6)) {
-		item.state = ItemState::Unavailable;
+	MTP::ResetProxyCheckers(item.checker, item.checkerv6);
+	_checkerQueue.push_back(item.id);
+	processCheckerQueue();
+}
+
+void ProxiesBoxController::processCheckerQueue() {
+	if (_processingCheckerQueue) {
+		return;
 	}
+	_processingCheckerQueue = true;
+	auto active = ranges::count_if(_list, [](const Item &item) {
+		return MTP::HasProxyCheckers(item.checker, item.checkerv6);
+	});
+	while (active < kMaxConcurrentProxyChecks && !_checkerQueue.empty()) {
+		const auto id = _checkerQueue.front();
+		_checkerQueue.pop_front();
+		const auto item = ranges::find(
+			_list,
+			id,
+			[](const Item &item) { return item.id; });
+		if (item == end(_list)
+			|| item->deleted
+			|| item->state != ItemState::Checking
+			|| MTP::HasProxyCheckers(item->checker, item->checkerv6)) {
+			continue;
+		}
+
+		MTP::StartProxyCheck(
+			&_account->mtp(),
+			item->data,
+			Core::App().settings().proxy().tryIPv6(),
+			item->checker,
+			item->checkerv6,
+			[=](Connection *raw, int pingTime) {
+				const auto item = ranges::find(
+					_list,
+					id,
+					[](const Item &item) { return item.id; });
+				if (item == end(_list)
+					|| (item->checker.get() != raw
+						&& item->checkerv6.get() != raw)) {
+					return;
+				}
+				MTP::DropProxyChecker(
+					item->checker,
+					item->checkerv6,
+					raw);
+				MTP::ResetProxyCheckers(item->checker, item->checkerv6);
+				if (item->state == ItemState::Checking) {
+					item->state = ItemState::Available;
+					item->ping = pingTime;
+					updateView(*item);
+				}
+				processCheckerQueue();
+			},
+			[=](Connection *raw) {
+				const auto item = ranges::find(
+					_list,
+					id,
+					[](const Item &item) { return item.id; });
+				if (item == end(_list)
+					|| (item->checker.get() != raw
+						&& item->checkerv6.get() != raw)) {
+					return;
+				}
+				MTP::DropProxyChecker(
+					item->checker,
+					item->checkerv6,
+					raw);
+				if (MTP::HasProxyCheckers(
+						item->checker,
+						item->checkerv6)) {
+					return;
+				}
+				if (item->state == ItemState::Checking) {
+					item->state = ItemState::Unavailable;
+					updateView(*item);
+				}
+				processCheckerQueue();
+			});
+		if (MTP::HasProxyCheckers(item->checker, item->checkerv6)) {
+			++active;
+		} else {
+			item->state = ItemState::Unavailable;
+			updateView(*item);
+		}
+	}
+	_processingCheckerQueue = false;
 }
 
 object_ptr<Ui::BoxContent> ProxiesBoxController::CreateOwningBox(

--- a/Telegram/SourceFiles/boxes/connection_box.h
+++ b/Telegram/SourceFiles/boxes/connection_box.h
@@ -119,6 +119,7 @@ private:
 	void share(const ProxyData &proxy, bool qr = false);
 	void saveDelayed();
 	void refreshChecker(Item &item);
+	void processCheckerQueue();
 
 	void replaceItemWith(
 		std::vector<Item>::iterator which,
@@ -131,6 +132,8 @@ private:
 	Core::SettingsProxy &_settings;
 	int _idCounter = 0;
 	std::vector<Item> _list;
+	std::deque<int> _checkerQueue;
+	bool _processingCheckerQueue = false;
 	rpl::event_stream<ItemView> _views;
 	base::Timer _saveTimer;
 	rpl::event_stream<ProxyData::Settings> _proxySettingsChanges;


### PR DESCRIPTION
Fixes #30776.

## Problem

Importing a very large proxy list can start availability checks for every proxy at once. Each logical check may create IPv4 and IPv6 connections, so thousands of proxies can exhaust the process file-descriptor limit. On Wayland this can also break the compositor connection and terminate Telegram Desktop.

## Solution

- Limit proxy availability checks to 50 logical proxies at a time.
- Place additional checks in a FIFO queue and start the next checks whenever capacity becomes available.
- Lazily discard queue entries for proxies that were deleted, replaced, or no longer need checking.
- Validate callback connection pointers before applying results, preventing callbacks from superseded checks from changing current proxy state.
- Guard queue processing against synchronous callback re-entry.

Queued proxies remain in the existing `Checking` state. Successful or final failed checks update the proxy normally and immediately refill the available check slots.

The limit applies to logical proxy checks rather than individual IPv4/IPv6 connections, preserving the existing dual-stack checking behavior.

## Safety and compatibility

- Deleting or replacing a queued proxy is safe.
- Stale callbacks cannot overwrite a newer check result.
- A synchronous connection failure cannot recursively corrupt queue processing.
- No storage format, networking protocol, or public API is changed.

## Relation to #30798

This addresses the same underlying resource-exhaustion problem as the earlier closed PR, while also covering queued-entry invalidation, superseded callbacks, and re-entrant completion handling.

## Testing

- `git diff --check`
- GitHub Actions Linux build passed
- GitHub Actions macOS and packaged macOS builds passed
- GitHub Actions Snap Ubuntu build passed
- GitHub Actions Windows x64/x86/ARM64 matrix passed
