### PR TITLE
Fix poll close timer day count

### DIFF
--- a/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
+++ b/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
@@ -4495,7 +4495,7 @@ QString Poll::Footer::closeTimerText() const {
 	const auto hideResults = (_owner->_flags
 		& PollData::Flag::HideResultsUntilClose);
 	if (left >= 86400) {
-		const auto days = (left + 86399) / 86400;
+		const auto days = left / 86400;
 		return hideResults
 			? tr::lng_polls_results_in_days(tr::now, lt_count, days)
 			: tr::lng_polls_ends_in_days(tr::now, lt_count, days);


### PR DESCRIPTION
## Summary
- Poll footers used ceiling division for remaining days (`(left + 86399) / 86400`), so any close time more than exactly 24 hours away showed at least "2 days".
- Switch to full days (`left / 86400`), matching other "in N days" UI (e.g. business hours) and the expected "ends tomorrow → 1 day" reading.
- Below 24 hours the existing `hh:mm:ss` path is unchanged.

Fixes #30955

## Test plan
- [ ] Create a poll that closes tomorrow afternoon; footer should say "1 day" (or "results in 1 day"), not "2 days"
- [ ] Create a poll that closes in ~30 hours; still "1 day"
- [ ] Create a poll that closes in ~50 hours; "2 days"
- [ ] Create a poll that closes in under 24 hours; still shows the countdown timer