### PR TITLE
Fix mouse back in community chats list

### DIFF
--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -2881,6 +2881,7 @@ void MainWidget::handleHistoryBack() {
 	}
 	const auto openedFolder = _controller->openedFolder().current();
 	const auto openedForum = _controller->shownForum().current();
+	const auto openedCommunity = _controller->openedCommunity().current();
 	const auto rootPeer = !_stack.empty()
 		? _stack.front()->peer()
 		: _history->peer()
@@ -2896,6 +2897,9 @@ void MainWidget::handleHistoryBack() {
 		&& _stack.empty()
 		&& (!rootPeer || rootPeer->forum() != openedForum)) {
 		_controller->closeForum();
+	} else if (openedCommunity
+		&& !_controller->windowId().community()) {
+		_controller->closeCommunity();
 	} else if (!openedFolder
 		|| (rootFolder == openedFolder)
 		|| (!_dialogs || _dialogs->isHidden())) {


### PR DESCRIPTION
## Summary
- Mouse Back in the community chats list did nothing because `handleHistoryBack()` handled forums and archive folders, but not communities, then fell through to `showBackFromStack()`.
- Close the opened community on Back (when not in a separate community window), matching Escape and swipe-back behavior.

Fixes #30981

## Test plan
- [ ] Open a community from the main chat list
- [ ] Press mouse Back (XButton1) while the community list is focused → returns to the previous list (same as the top-left back arrow)
- [ ] Open a forum / archive folder and confirm mouse Back still works as before
- [ ] If using a separate community window, mouse Back is unchanged there