### PR TITLE
Restore chats folder after closing a community

### DIFF
--- a/Telegram/SourceFiles/window/window_session_controller.cpp
+++ b/Telegram/SourceFiles/window/window_session_controller.cpp
@@ -2105,6 +2105,9 @@ void SessionController::openCommunity(not_null<Data::CommunityInfo*> info) {
 	} else if (_openedCommunity.current() != info) {
 		resetFakeUnreadWhileOpened();
 	}
+	if (!_openedCommunity.current()) {
+		_openedCommunityReturnFilter = activeChatsFilterCurrent();
+	}
 	if (activeChatsFilterCurrent() != 0) {
 		setActiveChatsFilter(0);
 	} else if (adaptive().isOneColumn()) {
@@ -2149,6 +2152,10 @@ void SessionController::closeCommunity() {
 	}
 	_openedCommunityLifetime.destroy();
 	_openedCommunity = nullptr;
+	const auto restore = base::take(_openedCommunityReturnFilter);
+	if (restore && !activeChatsFilterCurrent()) {
+		setActiveChatsFilter(restore);
+	}
 }
 
 const rpl::variable<Data::CommunityInfo*> &

--- a/Telegram/SourceFiles/window/window_session_controller.h
+++ b/Telegram/SourceFiles/window/window_session_controller.h
@@ -869,6 +869,7 @@ private:
 	rpl::lifetime _shownForumLifetime;
 	rpl::variable<Data::CommunityInfo*> _openedCommunity;
 	rpl::lifetime _openedCommunityLifetime;
+	FilterId _openedCommunityReturnFilter = 0;
 
 	rpl::event_stream<> _filtersMenuChanged;
 


### PR DESCRIPTION
## Summary
- Opening a community forces the active chats filter to All Chats (`0`), so Back left users on All Chats even if they opened the community from a folder.
- Remember the previous filter when entering a community and restore it on close when the user is still on All Chats.
- Switching communities keeps the original return filter; if the user already changed folders while inside, we do not override that choice.

Fixes #31115

## Test plan
- [ ] Select a custom chats folder → open a community → Back → land in that same folder (not All Chats)
- [ ] From All Chats → open a community → Back → stay on All Chats
- [ ] Open community A from a folder, then open community B → Back → return to the original folder
- [ ] Separate community window close path unchanged