### PR TITLE
Name the hint dismiss buttons for screen readers

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -130,6 +130,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_cancel" = "Cancel";
 "lng_continue" = "Continue";
 "lng_close" = "Close";
+"lng_tooltip_dismiss" = "Dismiss";
 "lng_minimize_window" = "Minimize";
 "lng_maximize_window" = "Maximize";
 "lng_restore_window" = "Restore";

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
@@ -1042,6 +1042,7 @@ void List::setShowTooltip(
 			st::dialogsStoriesTooltipLabel,
 			st::importantTooltipHide,
 			st::defaultImportantTooltip.padding,
+			tr::lng_tooltip_dismiss(tr::now),
 			_tooltipHide),
 		st::dialogsStoriesTooltip);
 	const auto tooltip = _tooltip.get();

--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_ai_tooltip.cpp
+++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_ai_tooltip.cpp
@@ -34,6 +34,7 @@ ComposeTooltipManager::ComposeTooltipManager(
 			st::ttlMediaImportantTooltipLabel,
 			st::importantTooltipHide,
 			st::defaultImportantTooltip.padding,
+			tr::lng_tooltip_dismiss(tr::now),
 			[=] { hideAndRemember(); }),
 		st::historyRecordTooltip));
 	_tooltip->toggleFast(false);


### PR DESCRIPTION
The floating hints (the stories onboarding hint over the chats list and the AI compose hint) have a close button that permanently dismisses them. With a screen reader it was announced as just button, with no way to tell what it does.

This adds an lng_tooltip_dismiss (Dismiss) key and passes it as the accessible name of both hint close buttons.

Depends on desktop-app/lib_ui#335.