### PR TITLE
Order the chat controls and folders sidebar visually in the Tab chain

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -1192,8 +1192,10 @@ void Widget::scrollToDefaultChecked(bool verytop) {
 
 void Widget::setupScrollUpButton() {
 	// The button floats over the bottom of the list, but it is created long
-	// before it, so the scroll has to order the two by position.
+	// before it, so the scroll has to order the two - and it is an overlay,
+	// not something laid out beside the list.
 	_scroll->setVisualTabOrder(true);
+	_scrollToTop->setVisualTabOrderOverlay(true);
 
 	_scrollToTop->setClickedCallback([=] { scrollToDefaultChecked(); });
 	_scrollToTop->setAccessibleName(tr::lng_sr_scroll_to_top(tr::now));

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -1191,6 +1191,10 @@ void Widget::scrollToDefaultChecked(bool verytop) {
 }
 
 void Widget::setupScrollUpButton() {
+	// The button floats over the bottom of the list, but it is created long
+	// before it, so the scroll has to order the two by position.
+	_scroll->setVisualTabOrder(true);
+
 	_scrollToTop->setClickedCallback([=] { scrollToDefaultChecked(); });
 	_scrollToTop->setAccessibleName(tr::lng_sr_scroll_to_top(tr::now));
 	trackScroll(_scrollToTop);

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -372,6 +372,7 @@ HistoryWidget::HistoryWidget(
 	}))
 , _topShadow(this) {
 	setAcceptDrops(true);
+	setVisualTabOrder(true);
 
 	session().downloaderTaskFinished() | rpl::on_next([=] {
 		update();

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -374,10 +374,15 @@ HistoryWidget::HistoryWidget(
 	setAcceptDrops(true);
 	setVisualTabOrder(true);
 
-	// The bars inside are raised over each other in the reverse of their
-	// visual order, so they need their own ordering - the outer one above
-	// sees them as a single child and keeps whatever order they have.
+	// The controls inside these are created in an order of their own - the
+	// top bar's selection buttons start with the one placed last, the bars
+	// are raised over each other in the reverse of their visual order, and
+	// the gift button of the mute bar is set up before the one placed to
+	// its left. The outer ordering above sees each of them as a single
+	// child and keeps whatever order they have, so they arrange themselves.
+	_topBar->setVisualTabOrder(true);
 	_topBars->setVisualTabOrder(true);
+	_muteUnmute->setVisualTabOrder(true);
 
 	session().downloaderTaskFinished() | rpl::on_next([=] {
 		update();

--- a/Telegram/SourceFiles/history/history_widget.cpp
+++ b/Telegram/SourceFiles/history/history_widget.cpp
@@ -374,6 +374,11 @@ HistoryWidget::HistoryWidget(
 	setAcceptDrops(true);
 	setVisualTabOrder(true);
 
+	// The bars inside are raised over each other in the reverse of their
+	// visual order, so they need their own ordering - the outer one above
+	// sees them as a single child and keeps whatever order they have.
+	_topBars->setVisualTabOrder(true);
+
 	session().downloaderTaskFinished() | rpl::on_next([=] {
 		update();
 	}, lifetime());

--- a/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
@@ -81,8 +81,9 @@ CornerButtons::CornerButtons(
 	_column.setAttribute(Qt::WA_TransparentForMouseEvents);
 	_column.show();
 	_column.setVisualTabOrder(true);
+	_column.setVisualTabOrderOverlay(true);
 	if (const auto scroll = qobject_cast<Ui::RpWidget*>(_parent.get())) {
-		// Without this the column, created before the list, would come first.
+		// Otherwise the column, created before the list, would come first.
 		scroll->setVisualTabOrder(true);
 	}
 

--- a/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
@@ -59,18 +59,33 @@ CornerButtons::CornerButtons(
 : _parent(parent)
 , _scrollViewportEvent(std::move(scrollViewportEvent))
 , _delegate(delegate)
+, _column(parent)
 , _down(
-	parent,
+	&_column,
 	st->value(_stLifetime, st::historyToDown))
 , _mentions(
-	parent,
+	&_column,
 	st->value(_stLifetime, st::historyUnreadMentions))
 , _reactions(
-		parent,
+		&_column,
 		st->value(_stLifetime, st::historyUnreadReactions))
 , _pollVotes(
-		parent,
+		&_column,
 		st->value(_stLifetime, st::historyUnreadPollVotes)) {
+	// The buttons keep the positions they had as direct children, because the
+	// column has the parent's height and shares its edge. Only they take mouse
+	// input in it - the empty part of the strip is masked out in
+	// updatePositions, so that a click there reaches the list under it. Until
+	// the first button is shown there is nothing to mask, so the column stays
+	// out of the hit test entirely.
+	_column.setAttribute(Qt::WA_TransparentForMouseEvents);
+	_column.show();
+	_column.setVisualTabOrder(true);
+	if (const auto scroll = qobject_cast<Ui::RpWidget*>(_parent.get())) {
+		// Without this the column, created before the list, would come first.
+		scroll->setVisualTabOrder(true);
+	}
+
 	_down.widget->addClickHandler([=] { downClick(); });
 	_mentions.widget->addClickHandler([=] { mentionsClick(); });
 	_reactions.widget->addClickHandler([=] { reactionsClick(); });
@@ -332,7 +347,12 @@ void CornerButtons::updatePositions() {
 		return button.animation.value(button.shown ? 1. : 0.);
 	};
 
-	// All corner buttons is a child widgets of _scroll, not me.
+	// All corner buttons is a child widgets of _column over _scroll, not me.
+
+	const auto columnWidth = st::historyToDown.width
+		+ 2 * st::historyToDownPosition.x();
+	_column.resize(columnWidth, _parent->height());
+	_column.moveToRight(0, 0, _parent->width());
 
 	const auto historyDownShown = shown(_down);
 	const auto unreadMentionsShown = shown(_mentions);
@@ -410,6 +430,28 @@ void CornerButtons::updatePositions() {
 	checkVisibility(_mentions);
 	checkVisibility(_reactions);
 	checkVisibility(_pollVotes);
+
+	// Leave only the buttons in the column's hit test, so a click on the rest
+	// of the strip goes to the list under it. The attribute alone would not
+	// do - it drops the whole subtree out of the hit test, the buttons in it
+	// included - but an empty region means "no mask" to Qt, not "nothing to
+	// hit", so while there is no button to keep the column is made
+	// transparent instead.
+	auto mask = QRegion();
+	const auto addToMask = [&](CornerButton &button) {
+		if (!button.widget->isHidden()) {
+			mask += button.widget->geometry();
+		}
+	};
+	addToMask(_down);
+	addToMask(_mentions);
+	addToMask(_reactions);
+	addToMask(_pollVotes);
+	_column.setAttribute(Qt::WA_TransparentForMouseEvents, mask.isEmpty());
+	if (_columnMask != mask) {
+		_columnMask = mask;
+		_column.setMask(mask);
+	}
 }
 
 void CornerButtons::finishAnimations() {

--- a/Telegram/SourceFiles/history/view/history_view_corner_buttons.h
+++ b/Telegram/SourceFiles/history/view/history_view_corner_buttons.h
@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "ui/effects/animations.h"
+#include "ui/rp_widget.h"
 #include "base/object_ptr.h"
 
 class History;
@@ -117,6 +118,13 @@ private:
 	const not_null<CornerButtonsDelegate*> _delegate;
 
 	rpl::lifetime _stLifetime;
+
+	// The buttons stack upwards from the corner, so they are created in the
+	// reverse of their visual order. Keeping them in a column of their own
+	// lets that column sort them by position, and lets the parent place the
+	// whole group after the list instead of before it.
+	Ui::RpWidget _column;
+	QRegion _columnMask;
 
 	CornerButton _down;
 	CornerButton _mentions;

--- a/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
+++ b/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
@@ -266,6 +266,10 @@ void GroupCallBar::setupRightButton(not_null<RoundButton*> button) {
 	}, button->lifetime());
 
 	button->clicks() | rpl::start_to_stream(_joinClicks, button->lifetime());
+
+	// This button is created and replaced deeper in the tree than the bars
+	// container watches, so it wouldn't be placed in the visual Tab order.
+	RefreshVisualTabOrder(button);
 }
 
 void GroupCallBar::paint(Painter &p) {

--- a/Telegram/SourceFiles/ui/chat/pinned_bar.cpp
+++ b/Telegram/SourceFiles/ui/chat/pinned_bar.cpp
@@ -122,6 +122,10 @@ void PinnedBar::setRightButton(object_ptr<Ui::RpWidget> button) {
 			_right.button->setDuration(0);
 			_right.button->show(anim::type::instant);
 		}
+
+		// The button is created and replaced deeper in the tree than the bars
+		// container watches, so it wouldn't be placed in the visual Tab order.
+		RefreshVisualTabOrder(_right.button.data());
 	}
 	if (_bar) {
 		updateControlsGeometry(_wrap.geometry());

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -124,6 +124,13 @@ void FiltersMenu::setup() {
 
 	_outer.setAttribute(Qt::WA_OpaquePaintEvent);
 	_outer.show();
+
+	// Keep the sidebar's Tab chain in visual order: the main menu button
+	// above the scroll area, and inside it the folders list (entered at
+	// its roving Tab-stop), the favorite link and the edit button - even
+	// as folders are reordered and the favorite appears or disappears.
+	_outer.setVisualTabOrder(true);
+	_container->setVisualTabOrder(true);
 	_outer.paintRequest(
 	) | rpl::on_next([=](QRect clip) {
 		auto p = QPainter(&_outer);
@@ -309,23 +316,21 @@ void FiltersMenu::moveToFilterEdge(int delta) {
 }
 
 void FiltersMenu::setListTabStop(not_null<Ui::SideBarButton*> stop) {
-	// Single source of truth for the list's roving Tab-stop, wired between the
-	// main menu and the edit button. Promote `stop` to the only TabFocus item
-	// and demote the previous one, so Tab/Shift+Tab always leave the list the
-	// same way regardless of which folder is focused.
+	// Single source of truth for the list's roving Tab-stop: promote `stop`
+	// to the only TabFocus item and demote the previous one, so Tab always
+	// enters the list at the same folder. Its position in the Tab chain
+	// comes from the containers' visual order (see setup()).
 	if (const auto previous = _tabStop.get(); previous && previous != stop) {
 		previous->setFocusPolicy(Qt::ClickFocus);
 	}
 	stop->setFocusPolicy(Qt::TabFocus);
 	_tabStop = stop.get();
-	QWidget::setTabOrder(&_menu, stop.get());
-	const auto favorite = _favorite ? _favorite->entity() : nullptr;
-	if (favorite) {
-		QWidget::setTabOrder(stop.get(), favorite);
-		QWidget::setTabOrder(favorite, _setup.get());
-	} else {
-		QWidget::setTabOrder(stop.get(), _setup.get());
-	}
+
+	// The Tab-stop moved outside of any layout change, so a Tab entering
+	// the sidebar from outside would still walk to the demoted button's
+	// old chain position - rewire the visual order right away.
+	_outer.refreshVisualTabOrder();
+	_container->refreshVisualTabOrder();
 }
 
 bool FiltersMenu::listFocused() const {


### PR DESCRIPTION
Uses the new setVisualTabOrder from desktop-app/lib_ui#336 in two places:

- HistoryWidget: one line in the constructor replaces manual setTabOrder wiring for the write row. Several of its controls are created on demand, so creation order scattered them over the focus chain; now Tab follows the visual layout (top bar, pinned bar, message list, then attach - field - send row left to right), including buttons that appear later like silent broadcast or TTL.

- Folders sidebar: the manual wiring in setListTabStop is replaced by the visual order of the two containers, with refreshVisualTabOrder() called when the roving Tab-stop moves to another folder (arrows or activation change it without any Tab passing through the sidebar, which used to leave the chain pointing at the demoted button).

Verified with NVDA: composer order in all chat types, list position surviving chat switches, folders reachable from both Tab directions after reordering, and Tab still trapped inside boxes.

Depends on desktop-app/lib_ui#336.