### PR TITLE
Loop videos with sound in the media viewer

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -887,6 +887,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_system_integration" = "System integration";
 "lng_settings_performance" = "Performance";
 "lng_settings_enable_hwaccel" = "Hardware accelerated video decoding";
+"lng_settings_loop_video_in_viewer" = "Loop videos in the media viewer";
+"lng_mediaview_loop_video_on" = "Loop Video";
+"lng_mediaview_loop_video_off" = "Don't Loop Video";
 "lng_settings_enable_opengl" = "Enable OpenGL rendering for media";
 "lng_settings_angle_backend" = "ANGLE graphics backend";
 "lng_settings_angle_backend_auto" = "Auto";

--- a/Telegram/SourceFiles/core/core_settings.h
+++ b/Telegram/SourceFiles/core/core_settings.h
@@ -39,6 +39,8 @@ namespace Core {
 
 inline constexpr auto kScreenReaderModeDisabledKey
 	= "screen-reader-mode-disabled"_cs;
+inline constexpr auto kLoopVideoInMediaViewerKey
+	= "loop-video-in-media-viewer"_cs;
 
 struct WindowPosition {
 	int32 moncrc = 0;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -1336,6 +1336,21 @@ bool OverlayWidget::videoShown() const {
 		&& !_streamed->instance.info().video.cover.isNull();
 }
 
+// Both the context menu entry and the Finished handler use this, so that
+// the entry is never offered where toggling it would change nothing:
+// silent videos and GIFs are already looped natively by the player
+// (options.loop in restartAtSeekPosition), stories advance to the next
+// story instead, and looping is a seek to zero, which the player can't
+// do without a known duration (the same guard as in restartAtProgress).
+bool OverlayWidget::videoLoopAvailable() const {
+	if (_stories || !videoShown() || !_streamed->withSound) {
+		return false;
+	}
+	const auto duration = _streamed->instance.info().video.state.duration;
+	return (duration != kTimeUnknown)
+		&& (duration != kDurationUnavailable);
+}
+
 QSize OverlayWidget::videoSize() const {
 	Expects(videoShown());
 
@@ -2140,6 +2155,21 @@ void OverlayWidget::fillContextMenuActions(
 				[=] { copyMedia(); },
 				&st::mediaMenuIconCopy);
 		}
+	}
+	if (videoLoopAvailable()) {
+		const auto looping = Core::App().settings().readPref<bool>(
+			Core::kLoopVideoInMediaViewerKey);
+		addAction(
+			(looping
+				? tr::lng_mediaview_loop_video_off(tr::now)
+				: tr::lng_mediaview_loop_video_on(tr::now)),
+			[=] {
+				Core::App().settings().writePref<bool>(
+					Core::kLoopVideoInMediaViewerKey,
+					!looping);
+				Core::App().saveSettingsDelayed();
+			},
+			&st::mediaMenuIconLoop);
 	}
 	if ((_photo && _photo->hasAttachedStickers())
 		|| (_document && _document->hasAttachedStickers())) {
@@ -5104,7 +5134,21 @@ void OverlayWidget::handleStreamingUpdate(Streaming::Update &&update) {
 	}, [](SpeedEstimate) {
 	}, [](MutedByOther) {
 	}, [&](Finished) {
-		updatePlaybackState();
+		if (videoLoopAvailable()
+			&& Core::App().settings().readPref<bool>(
+				Core::kLoopVideoInMediaViewerKey)) {
+			// A video with sound can't be looped natively, options.loop is
+			// allowed only outside of Mode::Both (see the Expects() in
+			// Streaming::Player::play), so restart the player instead.
+			// Clearing the flag is what playbackPauseResume() does before
+			// its own restart: it survives from the last restart that was
+			// made while paused (a seek or a frame step), and would make
+			// the loop stop paused on the first frame.
+			_streamingStartPaused = false;
+			restartAtSeekPosition(0);
+		} else {
+			updatePlaybackState();
+		}
 	});
 }
 

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -589,6 +589,7 @@ private:
 
 	void applyVideoSize();
 	[[nodiscard]] bool videoShown() const;
+	[[nodiscard]] bool videoLoopAvailable() const;
 	[[nodiscard]] QSize videoSize() const;
 	[[nodiscard]] bool streamingRequiresControls() const;
 	[[nodiscard]] QImage videoFrame() const; // ARGB (changes prepare format)

--- a/Telegram/SourceFiles/settings/sections/settings_advanced.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_advanced.cpp
@@ -911,6 +911,28 @@ void BuildPerformanceSection(SectionBuilder &builder) {
 		}, hwAccel->lifetime());
 	}
 
+	const auto loopVideo = builder.addButton({
+		.id = u"advanced/loop_video_in_viewer"_q,
+		.title = tr::lng_settings_loop_video_in_viewer(),
+		.st = &st::settingsButtonNoIcon,
+		.toggled = rpl::single(Core::App().settings().readPref<bool>(
+			Core::kLoopVideoInMediaViewerKey)),
+		.keywords = { u"loop"_q, u"video"_q, u"viewer"_q, u"repeat"_q },
+	});
+
+	if (loopVideo) {
+		loopVideo->toggledValue(
+		) | rpl::filter([](bool enabled) {
+			return (enabled != Core::App().settings().readPref<bool>(
+				Core::kLoopVideoInMediaViewerKey));
+		}) | rpl::on_next([=](bool enabled) {
+			Core::App().settings().writePref<bool>(
+				Core::kLoopVideoInMediaViewerKey,
+				enabled);
+			Core::App().saveSettingsDelayed();
+		}, loopVideo->lifetime());
+	}
+
 #ifdef DESKTOP_APP_USE_ANGLE
 	BuildANGLEOption(builder);
 #else

--- a/Telegram/SourceFiles/ui/menu_icons.style
+++ b/Telegram/SourceFiles/ui/menu_icons.style
@@ -252,6 +252,7 @@ mediaMenuIconStealth: icon {{ "menu/stealth", mediaviewMenuFg }};
 mediaMenuIconStats: icon {{ "menu/stats", mediaviewMenuFg }};
 mediaMenuIconRemove: icon {{ "menu/remove", mediaviewMenuFg }};
 mediaMenuIconRetractVote: icon {{ "menu/retract_vote", mediaviewMenuFg }};
+mediaMenuIconLoop: icon {{ "player/player_repeat", mediaviewMenuFg }};
 mediaMenuIconStar: icon {{ "menu/star", mediaviewMenuFg }};
 
 mediaMenuIconInfo: icon {{ "menu/info", mediaviewMenuFg }};


### PR DESCRIPTION
Closes #17401.

Videos without sound (GIFs, silent videos) are already looped natively by the streaming player through `options.loop`. Videos with sound stop on the last frame, because `options.loop` is not allowed in `Mode::Both` — there is an `Expects()` for exactly that in `Streaming::Player::play`. This adds an option that loops them by restarting the player at position 0 when the stream finishes.

That matches Telegram for Android, where short videos loop by default and longer ones loop when the option is on (see the thread in #17401).

The option is off by default and is toggled from two places:

* the media viewer context menu — "Loop Video" / "Don't Loop Video", shown only for videos the option actually affects: not for silent videos and GIFs that already loop, not for stories, and not without a known duration;
* Settings → Advanced → Performance.

Implementation notes:

* The value is stored through the generic KV prefs facility (`writePref` / `readPref`), so nothing is appended to the `Core::Settings` binary stream and there is no serialization ordering to preserve.
* `_streamingStartPaused` is cleared before the restart, the same way `playbackPauseResume()` clears it before its own. The flag survives from the last restart that was made while paused — a seek or a frame step — and without the reset the loop would stop paused on the first frame.
* The menu icon reuses the existing `player/player_repeat` asset, no new assets are added.
* Built and tested on Linux, Debug configuration, through the Docker `centos_env` environment.

I am aware of the "no new features, no new user interface elements" rule in CONTRIBUTING.md. This is a five-year-old feature request, so the implementation is attached as a starting point rather than as a finished proposal — happy to drop the settings toggle and keep only the context menu entry, to make looping unconditional with no option at all, or to change the wording, whatever fits the product decision.
