### PR TITLE
Media viewer: add audio track selection for videos

### DIFF
--- a/Telegram/SourceFiles/media/streaming/media_streaming_common.h
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_common.h
@@ -39,12 +39,22 @@ enum class Mode {
 	Inspection,
 };
 
+// Describes one selectable audio stream inside a media file. Filled in for
+// every audio stream that libavformat reports, so the UI can offer a way to
+// switch between them (for example multi-language tracks).
+struct AudioTrackInfo {
+	int index = -1; // AVStream index inside the format context.
+	QString language; // ISO code from the "language" metadata, if any.
+	QString title; // "title" metadata, if any.
+};
+
 struct PlaybackOptions {
 	Mode mode = Mode::Both;
 	crl::time position = 0;
 	crl::time durationOverride = 0;
 	float64 speed = 1.; // Valid values between 0.5 and 2.
 	AudioMsgId audioId;
+	int audioStreamIndex = -1; // -1 means automatic best-audio selection.
 	bool syncVideoByAudio = true;
 	bool waitForMarkAsShown = false;
 	bool hwAllowed = false;
@@ -70,6 +80,8 @@ struct VideoInformation {
 
 struct AudioInformation {
 	TrackState state;
+	std::vector<AudioTrackInfo> tracks; // All selectable audio streams.
+	int currentIndex = -1; // Index (in the file) of the playing audio stream.
 };
 
 struct Information {

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
@@ -32,6 +32,37 @@ constexpr auto kMaxQueuedPackets = 1024;
 		).split(QChar(',')).contains(u"webm");
 }
 
+// Collects every audio stream in the file together with its language / title
+// metadata, so the player can expose them and let the user switch tracks.
+[[nodiscard]] std::vector<AudioTrackInfo> EnumerateAudioTracks(
+		not_null<AVFormatContext*> format) {
+	auto result = std::vector<AudioTrackInfo>();
+	for (auto i = 0; i != int(format->nb_streams); ++i) {
+		const auto stream = format->streams[i];
+		if (!stream->codecpar
+			|| stream->codecpar->codec_type != AVMEDIA_TYPE_AUDIO) {
+			continue;
+		}
+		auto info = AudioTrackInfo{ .index = i };
+		if (const auto entry = av_dict_get(
+				stream->metadata,
+				"language",
+				nullptr,
+				0)) {
+			info.language = QString::fromUtf8(entry->value).trimmed();
+		}
+		if (const auto entry = av_dict_get(
+				stream->metadata,
+				"title",
+				nullptr,
+				0)) {
+			info.title = QString::fromUtf8(entry->value).trimmed();
+		}
+		result.push_back(std::move(info));
+	}
+	return result;
+}
+
 } // namespace
 
 File::Context::Context(
@@ -152,10 +183,23 @@ Stream File::Context::initStream(
 		Mode mode,
 		StartOptions options) {
 	auto result = Stream();
+
+	// For audio we allow the caller to request a specific stream (for
+	// example when the user picked a different track in the UI). We only
+	// honor it when it really points at an audio stream, otherwise we fall
+	// back to the automatic "best stream" selection.
+	const auto wanted = (type == AVMEDIA_TYPE_AUDIO
+		&& options.audioStreamIndex >= 0
+		&& options.audioStreamIndex < int(format->nb_streams)
+		&& format->streams[options.audioStreamIndex]->codecpar
+		&& (format->streams[options.audioStreamIndex]->codecpar->codec_type
+			== AVMEDIA_TYPE_AUDIO))
+		? options.audioStreamIndex
+		: -1;
 	const auto index = result.index = av_find_best_stream(
 		format,
 		type,
-		-1,
+		wanted,
 		-1,
 		nullptr,
 		0);
@@ -316,6 +360,8 @@ void File::Context::start(StartOptions options) {
 		return;
 	}
 
+	auto audioTracks = EnumerateAudioTracks(format.get());
+
 	_reader->headerDone();
 	if (_reader->isRemoteLoader()) {
 		sendFullInCache(true);
@@ -338,7 +384,11 @@ void File::Context::start(StartOptions options) {
 	}
 
 	const auto header = _reader->headerSize();
-	if (!_delegate->fileReady(header, std::move(video), std::move(audio))) {
+	if (!_delegate->fileReady(
+			header,
+			std::move(video),
+			std::move(audio),
+			std::move(audioTracks))) {
 		return fail(Error::OpenFailed);
 	}
 	_format = std::move(format);

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.h
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.h
@@ -24,6 +24,7 @@ class FileDelegate;
 struct StartOptions {
 	crl::time position = 0;
 	crl::time durationOverride = 0;
+	int audioStreamIndex = -1; // -1 means automatic best-audio selection.
 	bool seekable = true;
 	bool hwAllow = false;
 };

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file_delegate.h
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file_delegate.h
@@ -23,7 +23,8 @@ public:
 	[[nodiscard]] virtual bool fileReady(
 		int headerSize,
 		Stream &&video,
-		Stream &&audio) = 0;
+		Stream &&audio,
+		std::vector<AudioTrackInfo> audioTracks) = 0;
 	virtual void fileError(Error error) = 0;
 	virtual void fileWaitingForData() = 0;
 	virtual void fileFullInCache(bool fullInCache) = 0;

--- a/Telegram/SourceFiles/media/streaming/media_streaming_player.cpp
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_player.cpp
@@ -241,8 +241,13 @@ Mode Player::fileOpenMode() {
 	return _options.mode;
 }
 
-bool Player::fileReady(int headerSize, Stream &&video, Stream &&audio) {
+bool Player::fileReady(
+		int headerSize,
+		Stream &&video,
+		Stream &&audio,
+		std::vector<AudioTrackInfo> audioTracks) {
 	_waitingForData = false;
+	_audioTracks = std::move(audioTracks);
 
 	const auto weak = base::make_weak(&_sessionGuard);
 	const auto ready = [=](const Information &data) {
@@ -268,6 +273,7 @@ bool Player::fileReady(int headerSize, Stream &&video, Stream &&audio) {
 		LOG(("Streaming Error: Audio stream with unknown duration."));
 		return false;
 	} else if (audio.codec) {
+		_audioTrackIndex = audio.index;
 		if (_options.audioId.audio() != nullptr) {
 			_audioId = AudioMsgId(
 				_options.audioId.audio(),
@@ -450,6 +456,8 @@ bool Player::fileReadMore() {
 
 void Player::streamReady(Information &&information) {
 	SaveValidStartInformation(_information, std::move(information));
+	_information.audio.tracks = _audioTracks;
+	_information.audio.currentIndex = _audioTrackIndex;
 	provideStartInformation();
 }
 
@@ -553,6 +561,7 @@ void Player::play(const PlaybackOptions &options) {
 	_file->start(delegate(), {
 		.position = _options.position,
 		.durationOverride = options.durationOverride,
+		.audioStreamIndex = _options.audioStreamIndex,
 		.seekable = _options.seekable,
 		.hwAllow = _options.hwAllowed,
 	});
@@ -808,6 +817,8 @@ void Player::stop(bool stillActive) {
 	_durationByPackets = 0;
 	_durationByLastAudioPacket = 0;
 	_durationByLastVideoPacket = 0;
+	_audioTracks.clear();
+	_audioTrackIndex = -1;
 	const auto header = _information.headerSize;
 	_information = Information();
 	_information.headerSize = header;

--- a/Telegram/SourceFiles/media/streaming/media_streaming_player.h
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_player.h
@@ -101,7 +101,11 @@ private:
 
 	// FileDelegate methods are called only from the File thread.
 	Mode fileOpenMode() override;
-	bool fileReady(int headerSize, Stream &&video, Stream &&audio) override;
+	bool fileReady(
+		int headerSize,
+		Stream &&video,
+		Stream &&audio,
+		std::vector<AudioTrackInfo> audioTracks) override;
 	void fileError(Error error) override;
 	void fileWaitingForData() override;
 	void fileFullInCache(bool fullInCache) override;
@@ -184,6 +188,11 @@ private:
 	bool _waitingForData = false;
 
 	std::atomic<bool> _pauseReading = false;
+
+	// Set on the File thread inside fileReady(), read on the main thread
+	// after the streamReady() dispatch (same pattern as _totalDuration).
+	std::vector<AudioTrackInfo> _audioTracks;
+	int _audioTrackIndex = -1;
 
 	// Belongs to the main thread.
 	Information _information;

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
@@ -2078,6 +2078,35 @@ void OverlayWidget::fillContextMenuActions(
 			[=] { saveCancel(); },
 			&st::mediaMenuIconCancel);
 	}
+	if (_streamed && _streamed->withSound) {
+		const auto &audio = _streamed->instance.info().audio;
+		if (audio.tracks.size() > 1) {
+			const auto current = audio.currentIndex;
+			auto number = 0;
+			for (const auto &track : audio.tracks) {
+				++number;
+				// TODO: use a proper tr:: key for the fallback label once
+				// audio-track switching lands (needs a new lang string).
+				auto text = track.title;
+				if (!track.language.isEmpty()) {
+					text = text.isEmpty()
+						? track.language
+						: (text
+							+ QString::fromUtf8(" (")
+							+ track.language
+							+ QString::fromUtf8(")"));
+				}
+				text = text.isEmpty()
+					? QString::fromUtf8("Audio track %1").arg(number)
+					: (QString::fromUtf8("Audio: ") + text);
+				if (track.index == current) {
+					text = QString::fromUtf8("\xE2\x9C\x93 ") + text;
+				}
+				const auto index = track.index;
+				addAction(text, [=] { applyAudioTrack(index); }, nullptr);
+			}
+		}
+	}
 	if (_message && _message->isRegular()) {
 		addAction(
 			tr::lng_context_to_msg(tr::now),
@@ -2856,6 +2885,7 @@ void OverlayWidget::assignMediaPointer(DocumentData *document) {
 	if (_document != document) {
 		_streamedQualityChangeFrame = QImage();
 		_streamedQualityChangeFinished = false;
+		_chosenAudioTrack = -1;
 		if ((_document = document)) {
 			_quality = _document->initialPlaybackVideoQuality(
 				Core::App().settings().videoQuality());
@@ -5415,6 +5445,7 @@ void OverlayWidget::restartAtSeekPosition(crl::time position) {
 		Assert(_document != nullptr);
 		const auto messageId = _message ? _message->fullId() : FullMsgId();
 		options.audioId = AudioMsgId(_document, messageId);
+		options.audioStreamIndex = _chosenAudioTrack;
 		options.speed = _stories
 			? 1.
 			: Core::App().settings().videoPlaybackSpeed();
@@ -5432,6 +5463,22 @@ void OverlayWidget::restartAtSeekPosition(crl::time position) {
 	_streamed->pausedBySeek = false;
 
 	updatePlaybackState();
+}
+
+void OverlayWidget::applyAudioTrack(int index) {
+	Expects(_streamed != nullptr);
+
+	if (_chosenAudioTrack == index) {
+		return;
+	}
+	_chosenAudioTrack = index;
+
+	// Reopen the stream at the current position with the newly chosen audio
+	// track, preserving the current play / pause state across the switch.
+	_streamingStartPaused = _streamed->instance.player().paused()
+		&& !_streamed->instance.player().finished();
+	restartAtSeekPosition(_streamedPosition);
+	activateControls();
 }
 
 void OverlayWidget::playbackControlsSeekProgress(crl::time position) {

--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.h
@@ -608,6 +608,7 @@ private:
 	[[nodiscard]] bool canInitStreaming() const;
 	[[nodiscard]] bool saveControlLocked() const;
 	void applyVideoQuality(VideoQuality value);
+	void applyAudioTrack(int index);
 
 	[[nodiscard]] bool topShadowOnTheRight() const;
 	void applyHideWindowWorkaround();
@@ -636,6 +637,7 @@ private:
 	PhotoData *_photo = nullptr;
 	DocumentData *_document = nullptr;
 	DocumentData *_chosenQuality = nullptr;
+	int _chosenAudioTrack = -1; // -1 means automatic best-audio selection.
 	PhotoData *_videoCover = nullptr;
 	Media::VideoQuality _quality;
 	QString _documentLoadingTo;


### PR DESCRIPTION
## Problem

A video file can contain more than one audio stream — most commonly multiple
language tracks. The desktop media viewer always selects a single "best" audio
stream via `av_find_best_stream()` in the streaming `File` and drops packets
from every other audio stream, so there is currently **no way to switch the
audio track** while watching a video. (This is also the root of the wrong-track
behaviour reported in #26749.)

## Solution

Add an open-time audio-track selector, reusing the existing stream-restart path
rather than introducing live mid-stream switching:

- **Enumerate** every audio stream in `File::Context::start()` together with its
  `language`/`title` metadata into a new `AudioTrackInfo`, and carry the list up
  through `Information::audio` (`tracks` + `currentIndex`).
- **Select**: `PlaybackOptions::audioStreamIndex` / `StartOptions::audioStreamIndex`
  let a caller request a specific audio stream. `initStream()` passes it as the
  `wanted_stream_nb` of `av_find_best_stream()` after validating it points at an
  audio stream, otherwise it falls back to automatic selection.
- **UI**: the media-viewer context menu now lists the available audio tracks when
  a video has sound and more than one audio stream. Choosing a track sets
  `_chosenAudioTrack` and reopens the stream at the current position on that track
  via the existing `restartAtSeekPosition()`.

**Default behaviour is unchanged.** With `audioStreamIndex == -1` the code path is
identical to before (`av_find_best_stream(..., -1, ...)`), and single-track videos
show no extra menu entry.

## Files touched

- `media/streaming/media_streaming_common.h` — `AudioTrackInfo`, `PlaybackOptions::audioStreamIndex`, `AudioInformation::tracks/currentIndex`
- `media/streaming/media_streaming_file.{h,cpp}` — `StartOptions::audioStreamIndex`, track enumeration, requested-stream selection
- `media/streaming/media_streaming_file_delegate.h` + `media_streaming_player.{h,cpp}` — plumb the track list through `fileReady()` into `Information`
- `media/view/media_view_overlay_widget.{h,cpp}` — context-menu selector + `applyAudioTrack()`

## How to test

1. Open a video that has ≥2 audio streams (e.g. a file muxed with two language
   tracks, or an NVIDIA ShadowPlay "separate tracks" capture).
2. Right-click the video in the media viewer → the audio tracks are listed, the
   active one marked.
3. Pick another track → playback resumes at the same position with the selected
   audio.
4. Single-track videos are unaffected (no menu entry).

## Status / notes for reviewers

- Opened as a **draft**: I was unable to run a full local build of the client to
  compile- and runtime-verify this, so I'd appreciate a sanity check on the
  approach before polishing.
- The track labels are placeholder strings — if the direction is acceptable I'll
  add a proper `tr::` lang key for the "Audio track N" fallback and, if preferred,
  move the selector into the playback-controls dropdown next to the quality/speed
  menus instead of (or in addition to) the context menu.
- Threading: `_audioTracks` / `_audioTrackIndex` are written on the File thread in
  `fileReady()` and read on the main thread after the `streamReady()` dispatch,
  matching the existing pattern used for `_totalDuration`.

Related: #26749
