### PR TITLE
Name the chat corner buttons for screen readers

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -5251,6 +5251,13 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_unread_bar#other" = "{count} Unread Messages";
 "lng_unread_bar_some" = "Unread messages";
 
+"lng_jump_to_bottom" = "Jump to bottom";
+"lng_jump_to_mention" = "Jump to mention";
+"lng_jump_to_reaction" = "Jump to reaction";
+"lng_jump_to_poll_votes" = "Jump to poll votes";
+"lng_jump_unread_count#one" = "{count} unread";
+"lng_jump_unread_count#other" = "{count} unread";
+
 "lng_maps_point" = "Location";
 "lng_maps_select_on_map" = "Select on the Map";
 "lng_maps_point_send" = "Send This Location";

--- a/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
@@ -76,6 +76,12 @@ CornerButtons::CornerButtons(
 	_reactions.widget->addClickHandler([=] { reactionsClick(); });
 	_pollVotes.widget->addClickHandler([=] { pollVotesClick(); });
 
+	_down.widget->setAccessibleName(tr::lng_jump_to_bottom(tr::now));
+	_mentions.widget->setAccessibleName(tr::lng_jump_to_mention(tr::now));
+	_reactions.widget->setAccessibleName(tr::lng_jump_to_reaction(tr::now));
+	_pollVotes.widget->setAccessibleName(
+		tr::lng_jump_to_poll_votes(tr::now));
+
 	const auto filterScroll = [&](CornerButton &button) {
 		button.widget->installEventFilter(this);
 	};
@@ -93,6 +99,14 @@ CornerButtons::CornerButtons(
 	SendMenu::SetupUnreadPollVotesMenu(_pollVotes.widget.data(), [=] {
 		return _delegate->cornerButtonsThread();
 	});
+}
+
+void CornerButtons::updateAccessibleDescription(CornerButton &button) {
+	const auto count = button.widget->unreadCount();
+	button.widget->setAccessibleDescription(count
+		? tr::lng_jump_unread_count(tr::now, lt_count, count)
+		: QString());
+	button.widget->accessibilityDescriptionChanged();
 }
 
 bool CornerButtons::eventFilter(QObject *o, QEvent *e) {
@@ -278,6 +292,7 @@ void CornerButtons::updateUnreadThingsVisibility() {
 		&& unreadThings.trackMentions(thread)) {
 		if (const auto count = thread->unreadMentions().count(0)) {
 			_mentions.widget->setUnreadCount(count);
+			updateAccessibleDescription(_mentions);
 		}
 		updateWithCount(
 			Type::Mentions,
@@ -290,6 +305,7 @@ void CornerButtons::updateUnreadThingsVisibility() {
 		&& unreadThings.trackReactions(thread)) {
 		if (const auto count = thread->unreadReactions().count(0)) {
 			_reactions.widget->setUnreadCount(count);
+			updateAccessibleDescription(_reactions);
 		}
 		updateWithCount(
 			Type::Reactions,
@@ -302,6 +318,7 @@ void CornerButtons::updateUnreadThingsVisibility() {
 		&& unreadThings.trackPollVotes(thread)) {
 		if (const auto count = thread->unreadPollVotes().count(0)) {
 			_pollVotes.widget->setUnreadCount(count);
+			updateAccessibleDescription(_pollVotes);
 		}
 		updateWithCount(
 			Type::PollVotes,
@@ -317,6 +334,7 @@ void CornerButtons::updateJumpDownVisibility(std::optional<int> counter) {
 	}
 	if (counter) {
 		_down.widget->setUnreadCount(*counter);
+		updateAccessibleDescription(_down);
 	}
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_corner_buttons.h
+++ b/Telegram/SourceFiles/history/view/history_view_corner_buttons.h
@@ -112,6 +112,10 @@ private:
 	[[nodiscard]] History *lookupHistory() const;
 	void showAt(MsgId id);
 
+	// The unread counter is painted as a badge, so a screen reader should
+	// have it too - as the description, next to the unchanging name.
+	void updateAccessibleDescription(CornerButton &button);
+
 	const not_null<QWidget*> _parent;
 	const Fn<bool(QEvent*)> _scrollViewportEvent;
 	const not_null<CornerButtonsDelegate*> _delegate;


### PR DESCRIPTION
The jump to bottom, mentions, reactions and poll votes buttons had no accessible name, so screen readers announced all four as just "button".

They now get a name each, and the unread counter that is painted on them as a badge is exposed as the description, so it is announced together with the name and updates with the badge.