### PR TITLE
Show back button in fullscreen mini apps on Linux

### DIFF
--- a/Telegram/Resources/bot_webview_shell_html/page.css
+++ b/Telegram/Resources/bot_webview_shell_html/page.css
@@ -390,9 +390,13 @@ select {
 	border-bottom: 0;
 	pointer-events: none;
 }
-#root.fullscreen #back,
 #root.fullscreen #title-row {
 	display: none !important;
+}
+#root.fullscreen #back {
+	position: fixed;
+	top: var(--fullscreen-control-top);
+	left: var(--fullscreen-control-right);
 }
 #root.fullscreen .title-control {
 	width: var(--fullscreen-control-width);


### PR DESCRIPTION
Before:
<img width="451" height="59" alt="image" src="https://github.com/user-attachments/assets/319679bd-7d69-4b59-8164-26ed1973b1ef" />
After:
<img width="451" height="60" alt="image" src="https://github.com/user-attachments/assets/cbd59691-c958-44cd-abd5-c8ac30d85025" />
