### PR TITLE
Keep empty global search focused on Backspace

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -4650,8 +4650,8 @@ void Widget::keyPressEvent(QKeyEvent *e) {
 		//} else {
 		//	e->ignore();
 		//}
-	} else if ((e->key() == Qt::Key_Backspace
-			|| (e->key() == Qt::Key_Tab && !Ui::ScreenReaderModeActive()))
+	} else if (e->key() == Qt::Key_Tab
+		&& !Ui::ScreenReaderModeActive()
 		&& _searchHasFocus
 		&& !_searchState.inChat
 		&& _searchState.query.isEmpty()) {


### PR DESCRIPTION
Fixes #29655.

Backspace on an already-empty global search field no longer enters the dialog escape path. Explicit Escape and the existing Tab navigation continue to behave as before.

Checks:
- git diff --check
- verified the key-handler predicate keeps the focus, global-search, empty-query, Tab, and screen-reader guards intact

A local application build was not run; the change is intended for the repository CI build matrix.