### PR TITLE
Fix crash when clicking current song after switching accounts

### DIFF
--- a/Telegram/SourceFiles/mainwidget.cpp
+++ b/Telegram/SourceFiles/mainwidget.cpp
@@ -952,14 +952,28 @@ void MainWidget::createPlayer() {
 		});
 		_player->entity()->setShowItemCallback([=](
 				not_null<const HistoryItem*> item) {
+			// Defer: showMessage may activate another account and destroy
+			// this MainWidget while still inside the player mouse-release.
 			const auto peer = item->history()->peer;
-			if (const auto window = Core::App().windowFor(peer)) {
-				if (const auto controller = window->sessionController()) {
-					controller->showMessage(item);
+			const auto itemId = item->fullId();
+			crl::on_main([=] {
+				const auto window = Core::App().windowFor(peer);
+				if (!window) {
 					return;
 				}
-			}
-			_controller->showMessage(item);
+				window->invokeForSessionController(
+					&peer->session().account(),
+					peer,
+					[=](not_null<Window::SessionController*> controller) {
+						const auto resolved = controller->session().data().message(
+							itemId);
+						if (resolved) {
+							controller->content()->showMessage(
+								resolved,
+								SectionShow::Way::ClearStack);
+						}
+					});
+			});
 		});
 
 		_player->entity()->togglePlaylistRequests(


### PR DESCRIPTION
Play a song, open/close chats, switch account, then click the now-playing title in the top player.

`Media::Player::instance()` keeps the track from the previous session. Clicking the title calls `showMessage` from the player mouse-release. That path runs `domain().activate()` / `Window::Controller::showAccount`, which destroys `MainWidget` (and the player widget) while Qt is still in `mouseReleaseEvent`. Result on Windows 7.0.9: `c0000005` `NULL_CLASS_PTR_READ`.

Opening and leaving chats first is only setup: `MainWidget` already has a live history when the click starts the account switch. Same path without that setup.

Defer the jump with `crl::on_main`, then `invokeForSessionController` on the window (survives the account switch) and resolve the item again before `content()->showMessage`.

Repro:
1. Play a song on account A.
2. Open a few chats and leave them (same window, music still playing).
3. Switch to account B in the same window.
4. Click the song title in the top player (not play/pause).

`nlansp_c.dll` `8007277C` in the dump is unrelated.