### PR TITLE
Clear monoforum data when channelForbidden arrives

### DIFF
--- a/Telegram/SourceFiles/data/data_saved_messages.cpp
+++ b/Telegram/SourceFiles/data/data_saved_messages.cpp
@@ -376,6 +376,12 @@ SavedMessages::ApplyResult SavedMessages::applyReceivedSublists(
 	for (const auto &dialog : *list) {
 		dialog.match([&](const MTPDsavedDialog &data) {
 			const auto peer = _owner->peer(peerFromMTP(data.vpeer()));
+			if (const auto channel = peer->asChannel()) {
+				if (channel->isForbidden()) {
+					lastValid = false;
+					return;
+				}
+			}
 			const auto entryPinned = pinned || data.is_pinned();
 			const auto topId = MsgId(data.vtop_message().v);
 			if (entryPinned) {
@@ -402,6 +408,12 @@ SavedMessages::ApplyResult SavedMessages::applyReceivedSublists(
 			}
 		}, [&](const MTPDmonoForumDialog &data) {
 			const auto peer = _owner->peer(peerFromMTP(data.vpeer()));
+			if (const auto channel = peer->asChannel()) {
+				if (channel->isForbidden()) {
+					lastValid = false;
+					return;
+				}
+			}
 			if (pinned) {
 				serverPinnedPeers.emplace(peer);
 			}

--- a/Telegram/SourceFiles/data/data_session.cpp
+++ b/Telegram/SourceFiles/data/data_session.cpp
@@ -1239,13 +1239,15 @@ not_null<PeerData*> Session::processChat(const MTPChat &data) {
 		const auto flagsMask = Flag::Broadcast
 			| Flag::Megagroup
 			| Flag::Forbidden
-			| Flag::Monoforum;
+			| Flag::Monoforum
+			| Flag::MonoforumAdmin;
 		const auto flagsSet = (data.is_broadcast() ? Flag::Broadcast : Flag())
 			| (data.is_megagroup() ? Flag::Megagroup : Flag())
 			| (data.is_monoforum() ? Flag::Monoforum : Flag())
 			| Flag::Forbidden;
 		channel->setFlags((channel->flags() & ~flagsMask) | flagsSet);
 
+		savedMessages().applySublistDeleted(channel);
 		if (channel->hasAdminRights()) {
 			channel->setAdminRights(ChatAdminRights());
 		}


### PR DESCRIPTION
Fixes #31105

## Problem

When the parent channel of a Direct Message (Sublist) chat gets deleted, the server starts returning `channelForbidden` for it. The `MonoforumAdmin` flag was not included in the flags mask in `Session::processChat`, so the monoforum `SavedMessages` object with its sublists survived channel deletion and was rebuilt after app restart, since server-side deletion requests fail with CHANNEL_INVALID / PEER_ID_INVALID.

## Changes

- Include `Flag::MonoforumAdmin` in the flags mask of the `channelForbidden` handler in `Session::processChat`. Clearing it triggers the existing `takeMonoforumData()` cleanup path in `ChannelData::setFlags`, destroying the monoforum SavedMessages object together with its sublists.
- Remove a sublist of the deleted channel from the personal Saved Messages list via `savedMessages().applySublistDeleted()`.
- Skip saved dialogs pointing to a forbidden channel while applying received sublists (`SavedMessages::applyReceivedSublists`), so a stale server-side dialog cannot re-create the ghost sublist on the next app start.
