### PR TITLE
pass proxy settings to webview

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -531,6 +531,8 @@ PRIVATE
     core/core_settings.h
     core/core_settings_proxy.cpp
     core/core_settings_proxy.h
+    core/core_webview_proxy.cpp
+    core/core_webview_proxy.h
     core/crash_report_window.cpp
     core/crash_report_window.h
     core/crash_reports.cpp

--- a/Telegram/SourceFiles/core/core_webview_proxy.cpp
+++ b/Telegram/SourceFiles/core/core_webview_proxy.cpp
@@ -1,0 +1,29 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "core/core_webview_proxy.h"
+
+#include "core/application.h"
+#include "core/core_settings.h"
+
+namespace Core {
+
+std::optional<Webview::ProxySettings> CurrentWebviewProxy() {
+	const auto &proxy = App().settings().proxy();
+	if (!proxy.isEnabled()) {
+		return std::nullopt;
+	}
+	const auto data = proxy.selected();
+	return Webview::ProxySettings{
+		.host = data.host.toStdString(),
+		.port = std::to_string(data.port),
+		.username = data.user.toStdString(),
+		.password = data.password.toStdString(),
+	};
+}
+
+} // namespace Core

--- a/Telegram/SourceFiles/core/core_webview_proxy.h
+++ b/Telegram/SourceFiles/core/core_webview_proxy.h
@@ -1,0 +1,18 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include "webview/webview_interface.h"
+
+#include <optional>
+
+namespace Core {
+
+[[nodiscard]] std::optional<Webview::ProxySettings> CurrentWebviewProxy();
+
+} // namespace Core

--- a/Telegram/SourceFiles/iv/iv_controller.cpp
+++ b/Telegram/SourceFiles/iv/iv_controller.cpp
@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/platform/base_platform_info.h"
 #include "base/qt/qt_key_modifiers.h"
 #include "base/qt_signal_producer.h"
+#include "core/core_webview_proxy.h"
 #include "core/file_utilities.h"
 #include "lang/lang_keys.h"
 #include "ui/chat/attach/attach_bot_webview.h"
@@ -297,6 +298,7 @@ void Controller::createWebview(const Webview::StorageId &storageId) {
 			.opaqueBg = st::windowBg->c,
 			.storageId = storageId,
 			.safe = true,
+			.proxySettings = Core::CurrentWebviewProxy(),
 		});
 	const auto raw = _webview.get();
 

--- a/Telegram/SourceFiles/iv/markdown/iv_markdown_embed_overlay.cpp
+++ b/Telegram/SourceFiles/iv/markdown/iv_markdown_embed_overlay.cpp
@@ -17,6 +17,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/buttons.h"
 #include "ui/widgets/labels.h"
 #include "ui/wrap/padding_wrap.h"
+#include "core/core_webview_proxy.h"
 #include "webview/webview_data_stream_memory.h"
 #include "webview/webview_embed.h"
 #include "webview/webview_interface.h"
@@ -499,6 +500,7 @@ Webview::WindowConfig EmbedOverlay::makeWindowConfig() const {
 		.initialSize = UsesExternalWindow(_mode)
 			? externalInitialSize()
 			: QSize(),
+		.proxySettings = Core::CurrentWebviewProxy(),
 	};
 }
 

--- a/Telegram/SourceFiles/payments/ui/payments_panel.cpp
+++ b/Telegram/SourceFiles/payments/ui/payments_panel.cpp
@@ -22,6 +22,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/effects/radial_animation.h"
 #include "ui/click_handler.h"
 #include "lang/lang_keys.h"
+#include "core/core_webview_proxy.h"
 #include "webview/webview_embed.h"
 #include "webview/webview_interface.h"
 #include "styles/style_payments.h"
@@ -552,6 +553,7 @@ bool Panel::createWebview(const Webview::ThemeParams &params) {
 		Webview::WindowConfig{
 			.opaqueBg = params.bodyBg,
 			.storageId = _delegate->panelWebviewStorageId(),
+			.proxySettings = Core::CurrentWebviewProxy(),
 		});
 
 	const auto raw = &_webview->window;

--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
@@ -29,6 +29,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/rect.h"
 #include "ui/ui_utility.h"
 #include "lang/lang_keys.h"
+#include "core/core_webview_proxy.h"
 #include "core/file_utilities.h"
 #include "webview/webview_embed.h"
 #include "webview/webview_dialog.h"
@@ -2132,6 +2133,7 @@ bool Panel::createWebview(const Webview::ThemeParams &params) {
 			.shellMessageToken = _externalShell
 				? _externalShellToken
 				: QString(),
+			.proxySettings = Core::CurrentWebviewProxy(),
 		});
 	const auto raw = &_webview->window;
 

--- a/Telegram/SourceFiles/ui/controls/location_picker.cpp
+++ b/Telegram/SourceFiles/ui/controls/location_picker.cpp
@@ -10,6 +10,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "apiwrap.h"
 #include "base/platform/base_platform_info.h"
 #include "boxes/peer_list_box.h"
+#include "core/core_webview_proxy.h"
 #include "core/current_geo_location.h"
 #include "core/file_utilities.h"
 #include "data/data_document.h"
@@ -894,6 +895,7 @@ void LocationPicker::setupWebview() {
 			.opaqueBg = st::windowBg->c,
 			.storageId = _webviewStorageId,
 			.safe = true,
+			.proxySettings = Core::CurrentWebviewProxy(),
 		});
 	const auto raw = _webview.get();
 	if (!raw->widget()) {

--- a/Telegram/SourceFiles/ui/webview_helpers.cpp
+++ b/Telegram/SourceFiles/ui/webview_helpers.cpp
@@ -8,6 +8,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/webview_helpers.h"
 
 #include "lang/lang_keys.h"
+#include "webview/webview_interface.h"
+#include <string>
 
 namespace Ui {
 namespace {

--- a/Telegram/SourceFiles/ui/webview_helpers.h
+++ b/Telegram/SourceFiles/ui/webview_helpers.h
@@ -8,6 +8,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "base/flat_map.h"
+#include "base/bytes.h"
+#include "mtproto/mtproto_proxy_data.h"
+#include "webview/webview_interface.h"
 
 namespace tr {
 template <typename ...Tags>


### PR DESCRIPTION
Partially fixes https://github.com/telegramdesktop/tdesktop/issues/28692 (for SOCKS5 proxies, but not for MTPROTO)

Meant to be used with https://github.com/desktop-app/lib_webview/pull/151