### PR TITLE
Leave the painted list focus announcement to the platform

### DIFF
--- a/Telegram/SourceFiles/boxes/language_box.cpp
+++ b/Telegram/SourceFiles/boxes/language_box.cpp
@@ -363,15 +363,10 @@ void Rows::focusInEvent(QFocusEvent *e) {
 			setSelected(chosen >= 0 ? chosen : 0, Announce::No);
 		}
 	}
+	// The row is picked above, before the base class runs: taking focus raises
+	// a focus event of its own, which the platform hands to focusChild() - the
+	// selected row - so announcing it here as well would read it twice.
 	RpWidget::focusInEvent(e);
-	const auto index = selected();
-	if (index >= 0) {
-		InvokeQueued(this, [=] {
-			if (selected() == index && hasFocus()) {
-				accessibilityChildFocused(index);
-			}
-		});
-	}
 }
 
 void Rows::keyPressEvent(QKeyEvent *e) {
@@ -1173,7 +1168,7 @@ void Rows::accessibilityChildSetFocus(quintptr identity) {
 		// The rows are virtual (no real QWidget), so the screen reader's
 		// SetFocus can't move real keyboard focus to a row. Translate it
 		// into our internal selection, then either announce it directly or
-		// grab keyboard focus (focusInEvent announces the selected row).
+		// grab keyboard focus (taking it announces the row by itself).
 		setSelected(index, hasFocus() ? Announce::Always : Announce::No);
 		_mustScrollTo.fire(rowScrollRequest(index));
 		if (!hasFocus()) {
@@ -1195,9 +1190,9 @@ void Rows::accessibilityChildActivate(quintptr identity) {
 		// state change of the element it considers focused. Take focus onto
 		// the row (as the SetFocus action does) before activating, so the
 		// "checked" announcement is heard from Invoke as well as from Space:
-		// focusInEvent announces the row when focus moves here, OnChange
-		// covers an invoke on a not-focused row of the focused list, and an
-		// invoke on the already-focused row announces the change alone.
+		// taking focus announces the row by itself, OnChange covers an invoke
+		// on a not-focused row of the focused list, and an invoke on the
+		// already-focused row announces the change alone.
 		setSelected(index, hasFocus() ? Announce::OnChange : Announce::No);
 		if (!hasFocus()) {
 			setFocus();

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -6458,11 +6458,9 @@ void InnerWidget::focusInEvent(QFocusEvent *e) {
 			selectSkip(1);
 		}
 	}
-	InvokeQueued(this, [=] {
-		if (hasFocus()) {
-			announceSelectedFocus();
-		}
-	});
+	// The row is only picked here, not announced: taking focus raises a focus
+	// event of its own, which the platform hands to focusChild() - the
+	// selected row - so announcing it here as well would read it twice.
 }
 
 bool InnerWidget::processKeyDispatch(QKeyEvent *e) {
@@ -6638,7 +6636,7 @@ void InnerWidget::accessibilityChildSetFocus(quintptr identity) {
 		// The rows are virtual (no real QWidget), so the screen reader's
 		// SetFocus can't move real keyboard focus to a row. Translate it
 		// into our internal selection, then either grab keyboard focus
-		// (focusInEvent announces the row) or announce it directly.
+		// (taking it announces the row by itself) or announce it directly.
 		if (index < 0 || !selectChildByIndex(index)) {
 			return;
 		}

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -6758,6 +6758,12 @@ void HistoryInner::checkAnnounceFirstMessages() {
 }
 
 void HistoryInner::announceAccessibilityFocusedChild() {
+	if (resolveAccessibilityFocusedChild()) {
+		announceAccessibilityFocus(_accessibilityFocusedIndex);
+	}
+}
+
+bool HistoryInner::resolveAccessibilityFocusedChild() {
 	const auto count = accessibilityChildCount();
 	if (count <= 0) {
 		// One-shot for chats focused before their first messages arrived:
@@ -6771,7 +6777,7 @@ void HistoryInner::announceAccessibilityFocusedChild() {
 		// allowlist, while the deferred announcement is a no-op without
 		// an accessibility client and never moves ordinary keyboard focus.
 		_announceFirstMessages = true;
-		return;
+		return false;
 	}
 	_announceFirstMessages = false;
 	if (_accessibilityFocusedItem) {
@@ -6789,8 +6795,7 @@ void HistoryInner::announceAccessibilityFocusedChild() {
 		}
 		if (found >= 0 && found < count) {
 			_accessibilityFocusedIndex = found;
-			announceAccessibilityFocus(found);
-			return;
+			return true;
 		}
 		// The cached focused item is no longer in the list (it
 		// was removed or fell out of the loaded slice since we
@@ -6811,29 +6816,30 @@ void HistoryInner::announceAccessibilityFocusedChild() {
 	}
 	if (_accessibilityFocusedIndex >= 0
 		&& _accessibilityFocusedIndex < count) {
-		announceAccessibilityFocus(_accessibilityFocusedIndex);
-		return;
+		return true;
 	}
 	const auto barIndex = accessibilityUnreadBarIndex();
 	const auto index = (barIndex >= 0 && barIndex + 1 < count)
 		? (barIndex + 1)
 		: (count - 1);
 	const auto elements = accessibleElements();
-	const auto item = accessibilityItemAtIndex(
+	_accessibilityFocusedIndex = index;
+	_accessibilityFocusedItem = accessibilityItemAtIndex(
 		index,
 		elements,
 		barIndex);
-	setAccessibilityFocusedItem(index, item);
+	return true;
 }
 
 void HistoryInner::focusInEvent(QFocusEvent *e) {
 	RpWidget::focusInEvent(e);
 
-	InvokeQueued(this, [=] {
-		if (hasFocus()) {
-			announceAccessibilityFocusedChild();
-		}
-	});
+	// Point the accessible focus at the message it belongs on, without
+	// announcing it: taking focus raises a focus event of its own, which the
+	// platform hands to focusChild() - the message resolved here - so
+	// announcing it as well would read it twice. This has to happen before
+	// returning, while that event is still pending.
+	resolveAccessibilityFocusedChild();
 }
 
 bool HistoryInner::accessibilityChildSupportsActions(int index) const {
@@ -6909,8 +6915,8 @@ void HistoryInner::applyAccessibilityFocus(
 	_accessibilitySelectionAnchor = nullptr;
 	_accessibilityFocusedIndex = index;
 	_accessibilityFocusedItem = item;
-	// Exactly one announcement: directly when the widget already has
-	// focus, via focusInEvent when keyboard focus is being taken.
+	// Exactly one announcement: directly when the widget already has focus,
+	// by the platform itself when keyboard focus is being taken.
 	if (hasFocus()) {
 		if (changed || announceAlways) {
 			announceAccessibilityFocus(index);

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -321,6 +321,12 @@ private:
 	void setAccessibilityFocusedItem(int index, HistoryItem *item);
 	void announceAccessibilityFocus(int index);
 	void checkAnnounceFirstMessages();
+	// Brings the accessible focus back onto a valid message - the cached one
+	// where it is still in the list, the unread bar, or a fresh pick - and
+	// tells whether it landed on one. Silent, so it can run while a focus
+	// event the platform announces by itself is pending; the announcing
+	// variant below is for the times when there is no such event.
+	bool resolveAccessibilityFocusedChild();
 	void announceAccessibilityFocusedChild();
 	void applyAccessibilityFocus(int index, bool announceAlways);
 	[[nodiscard]] auto computeActiveColumns(int row) const

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -6318,6 +6318,12 @@ void ListWidget::checkAnnounceFirstMessages() {
 }
 
 void ListWidget::announceAccessibilityFocusedChild() {
+	if (resolveAccessibilityFocusedChild()) {
+		announceAccessibilityFocus(_accessibilityFocusedIndex);
+	}
+}
+
+bool ListWidget::resolveAccessibilityFocusedChild() {
 	const auto count = accessibilityChildCount();
 	if (count <= 0) {
 		// One-shot for chats focused before their first messages arrived:
@@ -6331,7 +6337,7 @@ void ListWidget::announceAccessibilityFocusedChild() {
 		// allowlist, while the deferred announcement is a no-op without
 		// an accessibility client and never moves ordinary keyboard focus.
 		_announceFirstMessages = true;
-		return;
+		return false;
 	}
 	_announceFirstMessages = false;
 	if (_accessibilityFocusedItem) {
@@ -6349,8 +6355,7 @@ void ListWidget::announceAccessibilityFocusedChild() {
 		}
 		if (found >= 0 && found < count) {
 			_accessibilityFocusedIndex = found;
-			announceAccessibilityFocus(found);
-			return;
+			return true;
 		}
 		// The cached focused item is no longer in the list (it
 		// was removed or fell out of the loaded slice since we
@@ -6371,29 +6376,30 @@ void ListWidget::announceAccessibilityFocusedChild() {
 	}
 	if (_accessibilityFocusedIndex >= 0
 		&& _accessibilityFocusedIndex < count) {
-		announceAccessibilityFocus(_accessibilityFocusedIndex);
-		return;
+		return true;
 	}
 	const auto barIndex = accessibilityUnreadBarIndex();
 	const auto index = (barIndex >= 0 && barIndex + 1 < count)
 		? (barIndex + 1)
 		: accessibilityNewestIndex(count);
 	const auto elements = accessibleElements();
-	const auto item = accessibilityItemAtIndex(
+	_accessibilityFocusedIndex = index;
+	_accessibilityFocusedItem = accessibilityItemAtIndex(
 		index,
 		elements,
 		barIndex);
-	setAccessibilityFocusedItem(index, item);
+	return true;
 }
 
 void ListWidget::focusInEvent(QFocusEvent *e) {
 	RpWidget::focusInEvent(e);
 
-	InvokeQueued(this, [=] {
-		if (hasFocus()) {
-			announceAccessibilityFocusedChild();
-		}
-	});
+	// Point the accessible focus at the message it belongs on, without
+	// announcing it: taking focus raises a focus event of its own, which the
+	// platform hands to focusChild() - the message resolved here - so
+	// announcing it as well would read it twice. This has to happen before
+	// returning, while that event is still pending.
+	resolveAccessibilityFocusedChild();
 }
 
 bool ListWidget::accessibilityChildSupportsActions(int index) const {
@@ -6492,8 +6498,8 @@ void ListWidget::applyAccessibilityFocus(
 	_accessibilitySelectionAnchor = nullptr;
 	_accessibilityFocusedIndex = index;
 	_accessibilityFocusedItem = item;
-	// Exactly one announcement: directly when the widget already has
-	// focus, via focusInEvent when keyboard focus is being taken.
+	// Exactly one announcement: directly when the widget already has focus,
+	// by the platform itself when keyboard focus is being taken.
 	if (hasFocus()) {
 		if (changed || announceAlways) {
 			announceAccessibilityFocus(index);

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -620,6 +620,12 @@ private:
 	void setAccessibilityFocusedItem(int index, HistoryItem *item);
 	void announceAccessibilityFocus(int index);
 	void checkAnnounceFirstMessages();
+	// Brings the accessible focus back onto a valid message - the cached one
+	// where it is still in the list, the unread bar, or a fresh pick - and
+	// tells whether it landed on one. Silent, so it can run while a focus
+	// event the platform announces by itself is pending; the announcing
+	// variant below is for the times when there is no such event.
+	bool resolveAccessibilityFocusedChild();
 	void announceAccessibilityFocusedChild();
 	void applyAccessibilityFocus(int index, bool announceAlways);
 	void pruneAccessibilityIdentities();

--- a/Telegram/SourceFiles/ui/boxes/country_select_box.cpp
+++ b/Telegram/SourceFiles/ui/boxes/country_select_box.cpp
@@ -8,7 +8,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/boxes/country_select_box.h"
 
 #include "base/event_filter.h"
-#include "base/invoke_queued.h"
 #include "countries/countries_instance.h"
 #include "lang/lang_keys.h"
 #include "ui/accessible/ui_accessible_item.h"
@@ -335,18 +334,13 @@ void CountrySelectBox::Inner::setSelected(int index, Announce announce) {
 }
 
 void CountrySelectBox::Inner::focusInEvent(QFocusEvent *e) {
+	// Pick the row before the base class runs: taking focus raises a focus
+	// event of its own, which the platform hands to focusChild() - the
+	// selected row - so announcing it here as well would read it twice.
 	if (_selected < 0 && !current().empty()) {
 		setSelected(0, Announce::No);
 	}
 	RpWidget::focusInEvent(e);
-	if (_selected >= 0) {
-		const auto index = _selected;
-		InvokeQueued(this, [=] {
-			if (_selected == index && hasFocus()) {
-				accessibilityChildFocused(index);
-			}
-		});
-	}
 }
 
 void CountrySelectBox::Inner::paintEvent(QPaintEvent *e) {
@@ -746,7 +740,7 @@ void CountrySelectBox::Inner::accessibilityChildSetFocus(quintptr identity) {
 		// The rows are virtual (no real QWidget), so the screen reader's
 		// SetFocus can't move real keyboard focus to a row. Translate it
 		// into our internal selection, then either announce it directly or
-		// grab keyboard focus (focusInEvent announces the selected row).
+		// grab keyboard focus (taking it announces the row by itself).
 		_mouseSelection = false;
 		setSelected(index, hasFocus() ? Announce::Always : Announce::No);
 		_mustScrollTo.fire(ScrollToRequest(


### PR DESCRIPTION
Tabbing into the chat list, a message list, the countries list or the languages list announces the current row twice. Taking keyboard focus raises a focus event which the platform resolves through focusChild() - the current row - and each of these lists announced that row from focusInEvent as well.

Only the platform's announcement is left. What focus-in still has to do is point at the right row before it returns: the chat list, the countries and the languages lists already pick it there, and for the two message lists the helper that resolves the focused message - following it across slice changes, or picking the first unread / the newest one - is split from the announcing one, whose other caller (a chat focused before its first messages arrived) has no focus event to rely on and keeps announcing directly.

Needs desktop-app/patches#263 on Windows: Qt 5.15 forwards a focus event to focusChild() only for an accessible exposing a table interface, upstream generalized that to any element with children in 6.2.

Tested with NVDA on Windows 10 against a Qt 5.15.19 build with that patch: all five lists announce their current row once when focus arrives, and browsing inside them with the arrows is unchanged. The list container keeps reporting the focused state, since it is the widget that actually holds keyboard focus - the row is what the focus event and GetFocus resolve to.