### PR TITLE
Announce selecting and deselecting a message

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -6106,6 +6106,10 @@ void HistoryInner::changeAccessibilitySelection(
 	repaintItem(item);
 	_widget->updateTopBarSelection();
 	accessibilityChildStateChanged(index, { .selected = true });
+	// The state change above only says which state changed, and a screen
+	// reader on Windows hears nothing of it - the selection event below is
+	// what tells it the message became selected, or stopped being.
+	accessibilityChildSelectionChanged(index);
 	accessibilityChildNameChanged(index);
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -6066,6 +6066,10 @@ void ListWidget::changeAccessibilitySelection(
 	repaintItem(view);
 	pushSelectedItems();
 	accessibilityChildStateChanged(index, { .selected = true });
+	// The state change above only says which state changed, and a screen
+	// reader on Windows hears nothing of it - the selection event below is
+	// what tells it the message became selected, or stopped being.
+	accessibilityChildSelectionChanged(index);
 	accessibilityChildNameChanged(index);
 }
 


### PR DESCRIPTION
Pressing Space on a message, or extending the selection with Shift and the arrows, changes the selection without a screen reader saying anything about it.

The change was reported with a state change event carrying the selected flag. That flag is right as a "this is what changed" mask, but the Windows bridge reads only the checked flag out of a state change (qwindowsuiamainprovider.cpp, notifyStateChange), so nothing came out of it. Both message lists now also raise the selection event that does reach a screen reader; the state change is kept for the platforms that do read it.

Needs desktop-app/lib_ui#345 for accessibilityChildSelectionChanged().

Tested with NVDA on Windows 10: selecting a message announces "selected", deselecting it announces "not selected", and the same holds for the messages a Shift+arrow range grows over or gives back.