### PR TITLE
Expose the folders sidebar as tabs, not a list

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -6096,6 +6096,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 "lng_sr_folder_locked" = "{text}, Premium required";
 "lng_sr_folder_locked_about" = "Press to view subscription options.";
+"lng_sr_menu_unread_other_accounts" = "Unread messages in other accounts";
 
 "lng_media_save_progress" = "{ready} of {total} {mb}";
 "lng_mediaview_save_as" = "Save As...";

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -1693,6 +1693,15 @@ void Widget::setupMainMenuToggle() {
 			? &st::dialogsMenuToggleUnread
 			: &st::dialogsMenuToggleUnreadMuted;
 		_mainMenu.toggle->setIconOverride(icon, icon);
+		// The unread dot is only painted - surface it to a screen reader
+		// through the button's description.
+		const auto description = state.count
+			? tr::lng_sr_menu_unread_other_accounts(tr::now)
+			: QString();
+		if (_mainMenu.toggle->accessibleDescription() != description) {
+			_mainMenu.toggle->setAccessibleDescription(description);
+			_mainMenu.toggle->accessibilityDescriptionChanged();
+		}
 	}, _mainMenu.toggle->lifetime());
 }
 

--- a/Telegram/SourceFiles/window/window_filters_favorite.cpp
+++ b/Telegram/SourceFiles/window/window_filters_favorite.cpp
@@ -458,6 +458,8 @@ void FolderFavoriteButton::applyPeer(not_null<PeerData*> peer) {
 		Data::PeerUpdate::Flag::Name
 	) | rpl::on_next([=] {
 		_label.setText(_st.style, peer->name());
+		setAccessibleName(peer->name());
+		accessibilityNameChanged();
 		resizeToWidth(width());
 		update();
 	}, _resolveLifetime);
@@ -466,6 +468,8 @@ void FolderFavoriteButton::applyPeer(not_null<PeerData*> peer) {
 void FolderFavoriteButton::apply(Presentation presentation) {
 	_thumbnail = std::move(presentation.thumbnail);
 	_label.setText(_st.style, presentation.label);
+	// The label is painted, so a screen reader needs it as the name too.
+	setAccessibleName(presentation.label);
 	if (_thumbnail) {
 		_thumbnail->subscribeToUpdates([=] { update(); });
 	}

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -733,15 +733,8 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 				return;
 			}
 			if (e->type() == QEvent::ContextMenu) {
-				// A menu asked for from the keyboard opens at the mouse
-				// cursor, which may sit nowhere near the folder (or outside
-				// the window altogether) - anchor it on the folder instead.
 				const auto event = static_cast<QContextMenuEvent*>(e.get());
-				const auto keyboard = (event->reason()
-					== QContextMenuEvent::Keyboard);
-				showMenu(keyboard
-					? raw->mapToGlobal(raw->rect().center())
-					: QCursor::pos(), id);
+				showMenu(Ui::ContextMenuPosition(raw, event), id);
 			} else if (e->type() == QEvent::DragEnter) {
 				using namespace Storage;
 				const auto d = static_cast<QDragEnterEvent*>(e.get());

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -239,6 +239,15 @@ void FiltersMenu::setupMainMenuIcon() {
 			? &st::windowFiltersMainMenuUnread
 			: &st::windowFiltersMainMenuUnreadMuted;
 		_menu.setIconOverride(icon, icon);
+		// The unread dot is only painted - surface it to a screen reader
+		// through the button's description.
+		const auto description = state.count
+			? tr::lng_sr_menu_unread_other_accounts(tr::now)
+			: QString();
+		if (_menu.accessibleDescription() != description) {
+			_menu.setAccessibleDescription(description);
+			_menu.accessibilityDescriptionChanged();
+		}
 	}, _outer.lifetime());
 }
 

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -52,13 +52,13 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 namespace Window {
 namespace {
 
-// The folder tabs container, exposed as a list to screen readers.
+// The folder tabs container, exposed as a tab control to screen readers.
 class TabListLayout final : public Ui::VerticalLayout {
 public:
 	using Ui::VerticalLayout::VerticalLayout;
 
 	QAccessible::Role accessibilityRole() override {
-		return QAccessible::List;
+		return QAccessible::PageTabList;
 	}
 	Qt::FocusPolicy accessibilityFocusPolicy() override {
 		// Let the accessibility layer decide focusability (like PopupMenu),
@@ -576,8 +576,8 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 		return On(PowerSaving::kEmojiChat)
 			|| _session->isGifPausedAtLeastFor(Window::GifPauseReason::Any);
 	};
-	// A real folder (id >= 0), locked or not, is a selectable list item; only
-	// the "Edit" button (id < 0) stays a plain button. Establish this before
+	// A real folder (id >= 0), locked or not, is a selectable tab; only the
+	// "Edit" button (id < 0) stays a plain button. Establish this before
 	// inserting the widget - insertion shows the child immediately, so
 	// configuring the role up front avoids a transient or separately-announced
 	// role change.
@@ -593,7 +593,7 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 		}),
 		paused);
 	prepared->setLocked(locked);
-	prepared->setIsListItem(listItem);
+	prepared->setIsPageTab(listItem);
 	prepared->setShowIcon(mode != Ui::ChatsFiltersTabsMode::TextOnly);
 	prepared->setShowText(mode != Ui::ChatsFiltersTabsMode::IconsOnly);
 	auto added = toBeginning

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -342,6 +342,23 @@ bool FiltersMenu::listFocused() const {
 	return false;
 }
 
+void FiltersMenu::parkListTabStop() {
+	// Once focus leaves the list, park the roving Tab-stop back on the
+	// active folder, so the next Tab from outside enters the list on it and
+	// not on the folder the arrows last browsed. Deferred, because focus
+	// may be merely moving to another folder - by the time this runs that
+	// folder holds focus and has taken the stop already.
+	crl::on_main(&_outer, [=] {
+		if (listFocused()) {
+			return;
+		}
+		const auto i = _filters.find(_activeFilterId);
+		if (i != end(_filters)) {
+			setListTabStop(i->second.get());
+		}
+	});
+}
+
 void FiltersMenu::refresh() {
 	const auto filters = &_session->session().data().chatsFilters();
 	if (!filters->has() || _ignoreRefresh) {
@@ -662,6 +679,9 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 		base::install_event_filter(raw, [=](not_null<QEvent*> event) {
 			if (event->type() == QEvent::FocusIn) {
 				setListTabStop(raw);
+				return base::EventFilterResult::Continue;
+			} else if (event->type() == QEvent::FocusOut) {
+				parkListTabStop();
 				return base::EventFilterResult::Continue;
 			} else if (event->type() != QEvent::KeyPress) {
 				return base::EventFilterResult::Continue;

--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
@@ -724,7 +724,15 @@ base::unique_qptr<Ui::SideBarButton> FiltersMenu::prepareButton(
 				return;
 			}
 			if (e->type() == QEvent::ContextMenu) {
-				showMenu(QCursor::pos(), id);
+				// A menu asked for from the keyboard opens at the mouse
+				// cursor, which may sit nowhere near the folder (or outside
+				// the window altogether) - anchor it on the folder instead.
+				const auto event = static_cast<QContextMenuEvent*>(e.get());
+				const auto keyboard = (event->reason()
+					== QContextMenuEvent::Keyboard);
+				showMenu(keyboard
+					? raw->mapToGlobal(raw->rect().center())
+					: QCursor::pos(), id);
 			} else if (e->type() == QEvent::DragEnter) {
 				using namespace Storage;
 				const auto d = static_cast<QDragEnterEvent*>(e.get());

--- a/Telegram/SourceFiles/window/window_filters_menu.h
+++ b/Telegram/SourceFiles/window/window_filters_menu.h
@@ -69,6 +69,7 @@ private:
 	void moveToFilter(int delta);
 	void moveToFilterEdge(int delta);
 	void setListTabStop(not_null<Ui::SideBarButton*> stop);
+	void parkListTabStop();
 	[[nodiscard]] bool listFocused() const;
 	void openFiltersSettings();
 	void setupDragAndDrop();


### PR DESCRIPTION
﻿The folders sidebar was exposed to screen readers as a list, but the UI calls these folders tabs, so a screen reader user expects the tab role - the topic tabs strip and the horizontal folder tabs already report it. The sidebar container is a tab control now and every real folder a tab, the active one reported as selected; a locked (premium) folder is a tab that opens the Premium box on Enter instead of becoming current, which reads fine in practice. Only the "Edit" button stays a plain button.

The second fix is about where Tab enters the strip: browsing with the arrows used to leave the roving Tab stop on the last browsed folder, so Tabbing back into the sidebar landed there instead of on the active folder. Once focus leaves the list, the stop parks back on the active one, matching the topic tabs strip.

The context menu key also used to open the folder menu at the mouse cursor, which may sit nowhere near the folder or outside the window altogether; a menu asked for from the keyboard is anchored on the folder button now.

The favorite link button (the experimental button at the bottom of the strip that opens a configured link) only painted its label, so a screen reader announced it as an anonymous button - the label doubles as its accessible name now.

The unread dot on the main menu button - unread messages in other accounts - is only painted too; the button carries it as its accessible description now, both on the sidebar variant and on the chat list toggle shown without the sidebar.

Needs desktop-app/lib_ui#348 for the PageTab button role and for the selection state of SideBarButton tabs.

Tested with NVDA on Windows 10: the strip announces as a tab control, folders as tabs with the active one selected, selection is announced on Enter, locked folders open the Premium box, and leaving the sidebar and Tabbing back in lands on the active folder.



