### PR TITLE
ui: add experimental toggle for inverted trackpad gestures on Linux

### DIFF
--- a/Telegram/SourceFiles/settings/settings_experimental.cpp
+++ b/Telegram/SourceFiles/settings/settings_experimental.cpp
@@ -26,6 +26,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/gl/gl_detection.h"
 #include "ui/chat/chat_style_radius.h"
 #include "ui/controls/compose_ai_button_factory.h"
+#include "ui/controls/swipe_handler.h"
 #include "base/options.h"
 #include "boxes/moderate_messages_box.h"
 #include "core/application.h"
@@ -449,6 +450,7 @@ void SetupExperimental(
 				Ui::GL::kOptionEnableVulkanRhi,
 				Core::kOptionFreeType,
 				Ui::kOptionQScroller,
+				Ui::Controls::kOptionInvertGestures,
 				Window::kOptionDisableTouchbar,
 				Window::kOptionNewWindowsSizeAsFirst,
 			}

--- a/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
+++ b/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/platform/base_platform_info.h"
 #include "base/qt/qt_common_adapters.h"
 #include "base/event_filter.h"
+#include "base/options.h"
 #include "ui/chat/chat_style.h"
 #include "ui/controls/swipe_handler_data.h"
 #include "ui/painter.h"
@@ -24,6 +25,15 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace Ui::Controls {
 namespace {
+
+base::options::toggle InvertGestures({
+	.id = kOptionInvertGestures,
+	.name = "Invert gestures",
+	.description = "Swap left and right trackpad swipe direction. "
+		"Enable this if horizontal swipes go the wrong way with natural "
+		"scrolling on Wayland compositors such as GNOME or Sway.",
+	.scope = base::options::linux,
+});
 
 constexpr auto kSwipeSlow = 0.2;
 
@@ -73,6 +83,8 @@ private:
 };
 
 } // namespace
+
+const char kOptionInvertGestures[] = "invert-gestures";
 
 void SetupSwipeHandler(SwipeHandlerArgs &&args) {
 	static constexpr auto kThresholdWidth = 50;
@@ -378,7 +390,10 @@ void SetupSwipeHandler(SwipeHandlerArgs &&args) {
 			if (cancel) {
 				processEnd();
 			} else {
-				const auto invert = (w->inverted() ? -1 : 1);
+				const auto invert = (w->inverted()
+					== InvertGestures.value())
+					? 1
+					: -1;
 				const auto delta = Ui::ScrollDeltaF(w) * invert;
 				updateWith({
 					.globalCursor = w->globalPosition().toPoint(),

--- a/Telegram/SourceFiles/ui/controls/swipe_handler.h
+++ b/Telegram/SourceFiles/ui/controls/swipe_handler.h
@@ -17,6 +17,8 @@ class ScrollArea;
 
 namespace Ui::Controls {
 
+extern const char kOptionInvertGestures[];
+
 struct SwipeContextData;
 struct SwipeBackResult;
 struct SwipeHandlerInitData;


### PR DESCRIPTION
This PR adds an experimental option (Invert gestures) under Linux experimental settings that allows users to invert horizontal swipe gestures for chat navigation.

### Context & Motivation
Depending on the Wayland compositor setup (GNOME, Sway) and libinput configuration with natural scrolling enabled, horizontal trackpad swipes in tdesktop can act in reverse.

While the underlying root cause lies in how specific compositors or Qt handle inverted scroll deltas for swipe gestures, getting upstream changes or protocol-level fixes down to end-users will take significant time.

### Why an Experimental Option?

- Prevents upstream blame-shifting: We fully acknowledge that this issue originates at the compositor/Qt input layer rather than tdesktop itself.
 
- User workaround: Instead of waiting for ecosystem-wide protocol changes, this patch gives affected Linux users an explicit opt-in switch to correct navigation behavior locally.

- Non-intrusive: The toggle is isolated inside base::options::linux under Experimental Settings and defaults to disabled. It has zero impact on Windows, macOS, or Linux users who don't experience this issue.
 

### Related Issues & PRs
Fixes issue: #29573

Related PR: #30821 - unlike PR #30821, which forces gesture adjustments globally, this implementation exposes a safe, optional toggle in experimental settings without breaking existing defaults.