### PR TITLE
Fix rich message expandable rendering

### DIFF
--- a/Telegram/SourceFiles/iv/markdown/iv_markdown_document.cpp
+++ b/Telegram/SourceFiles/iv/markdown/iv_markdown_document.cpp
@@ -78,6 +78,7 @@ namespace {
 	case HtmlBlockKind::None: return u"None"_q;
 	case HtmlBlockKind::Comment: return u"Comment"_q;
 	case HtmlBlockKind::Details: return u"Details"_q;
+	case HtmlBlockKind::Blockquote: return u"Blockquote"_q;
 	case HtmlBlockKind::Unsupported: return u"Unsupported"_q;
 	}
 	return u"None"_q;
@@ -232,6 +233,7 @@ void DumpNode(
 	AddBoolAttribute(&line, u"autolink"_q, node.autolink);
 	AddBoolAttribute(&line, u"tableHeader"_q, node.tableHeader);
 	AddBoolAttribute(&line, u"detailsOpen"_q, node.detailsOpen);
+	AddBoolAttribute(&line, u"quoteCollapsed"_q, node.quoteCollapsed);
 	if (!node.tableAlignments.empty()) {
 		AddStringAttribute(
 			&line,

--- a/Telegram/SourceFiles/iv/markdown/iv_markdown_document.h
+++ b/Telegram/SourceFiles/iv/markdown/iv_markdown_document.h
@@ -81,6 +81,7 @@ enum class HtmlBlockKind {
 	None,
 	Comment,
 	Details,
+	Blockquote,
 	Unsupported,
 };
 
@@ -122,6 +123,7 @@ struct MarkdownNode {
 	bool autolink = false;
 	bool tableHeader = false;
 	bool detailsOpen = false;
+	bool quoteCollapsed = false;
 };
 
 struct MathFormula {

--- a/Telegram/SourceFiles/iv/markdown/iv_markdown_parse_convert.cpp
+++ b/Telegram/SourceFiles/iv/markdown/iv_markdown_parse_convert.cpp
@@ -472,6 +472,41 @@ void RecordCapabilities(cmark_node *node, ParserState *state) {
 	return result;
 }
 
+struct ParsedBlockquoteBlock {
+	QString body;
+	bool collapsed = false;
+	bool ok = false;
+};
+
+[[nodiscard]] bool ParseBlockquoteCollapsedAttribute(QString attributes) {
+	const auto trimmed = attributes.trimmed();
+	if (trimmed.isEmpty()) {
+		return false;
+	}
+	const auto lower = trimmed.toLower();
+	return lower.contains(u"expandable"_q) || lower.contains(u"collapsed"_q);
+}
+
+[[nodiscard]] ParsedBlockquoteBlock ParseBlockquoteHtmlBlock(QString raw) {
+	auto result = ParsedBlockquoteBlock();
+	raw = raw.trimmed();
+	if (!raw.startsWith(u"<blockquote"_q, Qt::CaseInsensitive)
+		|| !raw.endsWith(u"</blockquote>"_q, Qt::CaseInsensitive)) {
+		return result;
+	}
+	const auto openingEnd = raw.indexOf(QChar('>'));
+	if (openingEnd < 0) {
+		return result;
+	}
+	const auto openingAttributes = raw.mid(11, openingEnd - 11);
+	result.collapsed = ParseBlockquoteCollapsedAttribute(openingAttributes);
+	result.body = raw.mid(
+		openingEnd + 1,
+		raw.size() - openingEnd - 14).trimmed();
+	result.ok = true;
+	return result;
+}
+
 [[nodiscard]] QString PlainText(const MarkdownNode &node) {
 	auto result = node.text;
 	for (const auto &child : node.children) {
@@ -523,6 +558,21 @@ void FillNodeAttributes(
 				AddWarning(
 					state,
 					u"Malformed details block at %1:%2"_q.arg(
+						out->range.startLine
+					).arg(
+						out->range.startColumn));
+			}
+		} else if (trimmed.startsWith(u"<blockquote"_q, Qt::CaseInsensitive)) {
+			const auto quote = ParseBlockquoteHtmlBlock(out->raw);
+			if (quote.ok) {
+				out->htmlBlockKind = HtmlBlockKind::Blockquote;
+				out->detailsBody = quote.body;
+				out->quoteCollapsed = quote.collapsed;
+			} else {
+				out->htmlBlockKind = HtmlBlockKind::Unsupported;
+				AddWarning(
+					state,
+					u"Malformed blockquote block at %1:%2"_q.arg(
 						out->range.startLine
 					).arg(
 						out->range.startColumn));

--- a/Telegram/SourceFiles/iv/markdown/iv_markdown_prepare_blocks.cpp
+++ b/Telegram/SourceFiles/iv/markdown/iv_markdown_prepare_blocks.cpp
@@ -23,6 +23,10 @@ namespace {
 	return u"details-"_q + QString::number(++state->nextGeneratedId);
 }
 
+[[nodiscard]] QString QuoteToggleId(PrepareState *state) {
+	return u"quote-"_q + QString::number(++state->nextGeneratedId);
+}
+
 [[nodiscard]] int CappedListDepth(int depth) {
 	return std::min(depth, std::max(PrepareLimitsForIv().visualListDepth, 0));
 }
@@ -675,6 +679,30 @@ void PrepareFootnotes(PrepareState *state) {
 	return block;
 }
 
+[[nodiscard]] std::vector<PreparedBlock> PrepareBlockquoteHtmlBlocks(
+		const MarkdownNode &node,
+		PrepareContext context,
+		PrepareState *state) {
+	auto block = PreparedBlock();
+	block.kind = PreparedBlockKind::Quote;
+	block.actualDepth = context.quoteDepth;
+	block.visualDepth = CappedQuoteDepth(block.actualDepth);
+	block.depthClamped = (block.actualDepth > block.visualDepth);
+	if (node.quoteCollapsed) {
+		block.collapseToggleId = QuoteToggleId(state);
+		block.collapsed = true;
+	}
+	if (!node.detailsBody.isEmpty()) {
+		AppendRichBlock(
+			&block.children,
+			PreparedBlockKind::Paragraph,
+			0,
+			TextWithEntities::Simple(node.detailsBody),
+			std::vector<PreparedLink>());
+	}
+	return { std::move(block) };
+}
+
 [[nodiscard]] std::vector<PreparedBlock> PrepareFallbackBlocks(
 		const MarkdownNode &node,
 		PrepareContext context,
@@ -684,6 +712,8 @@ void PrepareFootnotes(PrepareState *state) {
 			return {};
 		} else if (node.htmlBlockKind == HtmlBlockKind::Details) {
 			return PrepareDetailsBlocks(node, state);
+		} else if (node.htmlBlockKind == HtmlBlockKind::Blockquote) {
+			return PrepareBlockquoteHtmlBlocks(node, context, state);
 		}
 	}
 	if (!node.children.empty()) {


### PR DESCRIPTION
Fixes #31178

Expandable blockquotes in RichMessage (such as `<blockquote expandable>` in HTML or `pageBlockBlockquote` with `collapsed: true`) were always rendered fully expanded and could not be collapsed. Adds support for parsing the expandable and collapsed attributes across HTML and wires them up with the collapse toggle ID, bringing behavior into parity with regular MessageEntity blockquotes. HTML export is also updated to preserve the expandable attribute.