### PR TITLE
Fixed word navigation splitting a word on an apostrophe.

### DIFF
--- a/Telegram/SourceFiles/history/view/history_view_keyboard_text_selection.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_keyboard_text_selection.cpp
@@ -67,10 +67,17 @@ std::optional<MessageSelection> KeyboardTextSelection::extend(
 	} else if (key == Qt::Key_End) {
 		wanted = maxOffset;
 	} else if (byWord) {
-		const auto separator = [&](int symbol) {
+		const auto at = [&](int symbol) {
 			const auto one = view->selectedText(
 				TextSelection(uint16(symbol), uint16(symbol + 1))).rich.text;
-			return one.isEmpty() || Ui::Text::IsWordSeparator(one[0]);
+
+			// A part that gives no text of its own is an object in the flow.
+			return one.isEmpty()
+				? QChar(QChar::ObjectReplacementCharacter)
+				: one[0];
+		};
+		const auto separator = [&](int symbol) {
+			return Ui::Text::IsWordSeparator(at, maxOffset, symbol);
 		};
 		auto symbol = position;
 		if (forward) {


### PR DESCRIPTION
Moving by words with Shift+Ctrl+Left/Right stops inside `don't`, while a double
click on the same word selects it whole: the two asked different questions.
Navigation looked at one character at a time with
`Ui::Text::IsWordSeparator(QChar)`, which has to call every apostrophe a
separator, having nothing to look around it with.

It now asks the overload that is given the neighbours, so the rule is the same
one the selection uses: an apostrophe separates only when it is doubled or when
it stands at the edge of a word. A part that gives no text of its own - a media,
an object in the flow - was treated as a separator by the empty check before,
and is passed as `ObjectReplacementCharacter` now, which the list already knows.

The number of `selectedText()` calls does not grow: counted over a whole text,
it is the same 5917 lookups as before on ordinary text and the same 8192 on a
text made of apostrophes. The old predicate looked at an apostrophe twice - once
to stop the run of word characters, once to skip it on the next press - and the
new one reads it once and pays with two looks at the neighbours.

Needs desktop-app/lib_ui#352.
