### PR TITLE
Open keyboard-invoked list menus on their rows

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -3954,7 +3954,34 @@ void InnerWidget::contextMenuEvent(QContextMenuEvent *e) {
 	if (_menu->empty()) {
 		_menu = nullptr;
 	} else {
-		_menu->popup(e->globalPos());
+		// A keyboard-invoked event carries the center of an empty input
+		// method rect for a position, which may sit nowhere near the row -
+		// anchor the menu under the selected row instead, at the position
+		// showPeerMenu computes for the events it synthesizes.
+		const auto rowBottom = [&] {
+			if (_state == WidgetState::Default) {
+				if (_selected) {
+					return _selected->top() + _selected->height();
+				}
+			} else if (_state == WidgetState::Filtered) {
+				if (base::in_range(_filteredSelected, 0, _filterResults.size())) {
+					const auto &result = _filterResults[_filteredSelected];
+					return filteredOffset() + result.top + result.row->height();
+				} else if (base::in_range(_previewSelected, 0, _previewResults.size())) {
+					return previewOffset() + (_previewSelected + 1) * _st->height;
+				} else if (base::in_range(_searchedSelected, 0, _searchResults.size())) {
+					return searchedOffset() + (_searchedSelected + 1) * _st->height;
+				}
+			}
+			return -1;
+		}();
+		const auto &padding = st::defaultDialogRow.padding;
+		const auto position = (fromMouse || rowBottom < 0)
+			? e->globalPos()
+			: mapToGlobal(QPoint(
+				width() - padding.right(),
+				rowBottom + padding.bottom()));
+		_menu->popup(position);
 		e->accept();
 	}
 }
@@ -5763,7 +5790,15 @@ bool InnerWidget::chooseRow(
 				? &st::mediaPlayerMenuCheck
 				: nullptr);
 		}
-		_menu->popup(QCursor::pos());
+		// The filter link is chosen with Enter as well as with a click, and
+		// there is no event here to tell them apart - anchor the menu on the
+		// link itself, which is where a click's cursor sits anyway.
+		const auto left = width()
+			- _chatTypeFilterWidth
+			- 2 * st::searchedBarPosition.x();
+		_menu->popup(mapToGlobal(QPoint(
+			left + _chatTypeFilterWidth / 2,
+			searchedOffset() - st::searchedBarHeight / 2)));
 		return true;
 	}
 	const auto modifyChosenRow = [&](

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -2748,6 +2748,37 @@ HistoryView::SelectedQuote HistoryInner::selectedQuote(
 }
 
 void HistoryInner::contextMenuEvent(QContextMenuEvent *e) {
+	// A keyboard-invoked event carries the center of an empty input method
+	// rect for a position, which may sit nowhere near the focused message -
+	// rebuild the event anchored on it, so everything in showContextMenu
+	// reading the event position (the menu, the reactions selector) lands
+	// on the message.
+	if (e->reason() == QContextMenuEvent::Keyboard
+		&& _accessibilityFocusedItem) {
+		const auto top = itemTop(_accessibilityFocusedItem);
+		const auto view = _accessibilityFocusedItem->mainView();
+		if (top >= 0 && view) {
+			auto rect = QRect(0, top, width(), view->height());
+			const auto visible = QRect(
+				0,
+				_visibleAreaTop,
+				width(),
+				_visibleAreaBottom - _visibleAreaTop);
+			if (rect.intersects(visible)) {
+				rect = rect.intersected(visible);
+			}
+			const auto global = Ui::ContextMenuPosition(this, e, rect);
+			auto adjusted = QContextMenuEvent(
+				QContextMenuEvent::Keyboard,
+				mapFromGlobal(global),
+				global);
+			showContextMenu(&adjusted);
+			if (adjusted.isAccepted()) {
+				e->accept();
+			}
+			return;
+		}
+	}
 	showContextMenu(e);
 }
 

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -3942,6 +3942,37 @@ void ListWidget::validateTrippleClickStartTime() {
 }
 
 void ListWidget::contextMenuEvent(QContextMenuEvent *e) {
+	// A keyboard-invoked event carries the center of an empty input method
+	// rect for a position, which may sit nowhere near the focused message -
+	// rebuild the event anchored on it, so everything in showContextMenu
+	// reading the event position (the menu, the reactions selector) lands
+	// on the message.
+	if (e->reason() == QContextMenuEvent::Keyboard
+		&& _accessibilityFocusedItem) {
+		const auto view = viewForItem(_accessibilityFocusedItem);
+		const auto top = view ? itemTop(view) : -1;
+		if (view && top >= 0) {
+			auto rect = QRect(0, top, width(), view->height());
+			const auto visible = QRect(
+				0,
+				_visibleTop,
+				width(),
+				_visibleBottom - _visibleTop);
+			if (rect.intersects(visible)) {
+				rect = rect.intersected(visible);
+			}
+			const auto global = Ui::ContextMenuPosition(this, e, rect);
+			auto adjusted = QContextMenuEvent(
+				QContextMenuEvent::Keyboard,
+				mapFromGlobal(global),
+				global);
+			showContextMenu(&adjusted);
+			if (adjusted.isAccepted()) {
+				e->accept();
+			}
+			return;
+		}
+	}
 	showContextMenu(e);
 }
 


### PR DESCRIPTION
﻿Pressing the context menu key on a focused chat or message already opened the menu of the right row - that part came with the earlier keyboard and screen reader work - but the menu itself popped at the position Qt puts into a keyboard-invoked event: the center of an empty input method rect, which lands near the top left corner of the list, nowhere near the row. For messages the reactions selector attaches based on the same position, so it drifted along.

The chat list menu now opens under the selected row, at the position the chat menu shortcut already computes for the events it synthesizes (that path is unchanged, and covers the default list and the search result rows). The message lists rebuild the keyboard event anchored on the visible part of the focused message before the shared handler runs, so everything reading the event position - the menu, the reactions selector, the poll option tabs - lands on the message. The chat type filter menu in search results also anchors on its link instead of the mouse cursor, which an Enter press may have left anywhere.

A mouse-invoked menu keeps opening at the cursor everywhere.

Needs desktop-app/lib_ui#348 for the Ui::ContextMenuPosition helper, the same policy the tab strips adopted. Only the placement of the popups changes - the reachability and content of the menus stay as they are, so screen reader interaction is unaffected.
