### PR TITLE
Keep the search tabs on manual activation

### DIFF
--- a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
@@ -1410,6 +1410,9 @@ Suggestions::Suggestions(
 Suggestions::~Suggestions() = default;
 
 void Suggestions::setupTabs() {
+	// Switching a tab changes the search scope and can run new searches, so
+	// the arrows only browse these tabs, committing on Enter / Space.
+	_tabs->setAccessibilityActivateOnBrowse(false);
 	_tabsScroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto pixelDelta = e->pixelDelta();
 		const auto angleDelta = e->angleDelta();


### PR DESCRIPTION
With #31097 the tab strips switch to the tab the arrows land on, the way native Windows tab controls do. The Chats / Channels / Apps tabs above the search suggestions are an exception: switching them changes the search scope and can run new searches, so passing through them while browsing with a screen reader would fire intermediate searches. Keep these tabs on the browse-first model - the arrows move between them, Enter or Space commits.

Uses the opt-out added in #31097, so it compiles only on top of it.