### PR TITLE
Fix stuck window activity after a lost X11 focus event

### DIFF
--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
@@ -522,6 +522,9 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *evt) {
 		}
 	} else if (obj == this && t == QEvent::Hide) {
 		_exposed = false;
+		if (IsX11()) {
+			destroy();
+		}
 	} else if (obj == this && t == QEvent::ThemeChange) {
 		updateWindowIcon();
 	}

--- a/Telegram/SourceFiles/window/main_window.cpp
+++ b/Telegram/SourceFiles/window/main_window.cpp
@@ -899,13 +899,14 @@ QRect MainWindow::computeDesktopRect() const {
 }
 
 void MainWindow::savePosition(Qt::WindowState state) {
+	if (!isVisible() || !positionInited()) {
+		return;
+	}
+
 	if (state == Qt::WindowActive) {
 		state = windowHandle()->windowState();
 	}
-
-	if (state == Qt::WindowMinimized
-		|| !isVisible()
-		|| !positionInited()) {
+	if (state == Qt::WindowMinimized) {
 		return;
 	}
 	if (const auto saved = Core::App().savedWindows()) {


### PR DESCRIPTION
On X11 the window can get stuck in an inactive state while it is visible and actually holds the input focus. Messages in an opened chat are not marked as read, GIFs and animated stickers stay frozen, and the tray icon click toggles the window the wrong way. Clicking or scrolling inside the window does not help, only switching to another window and back does.

## Root cause

`Window::MainWindow::computeIsActive()` relies on `isActiveWindow()`, and the two halves of Qt keep two different ideas of it.

QtWidgets resets `active_window` straight from the `hide()` call, through `hide_sys()` and `deactivateWidgetCleanup()`. No window system event is involved, it happens on every hide of the active window.

QtGui keeps `focus_window` from X11 focus events, and nothing clears it when the window hides. That is left to a 100 ms timer the xcb plugin starts when the FocusOut arrives, and any FocusIn the plugin accepts stops that timer before it fires.

So if the window is shown again before that timer fires, `focus_window` never passes through null, `processFocusWindowEvent()` returns early on `previous == newFocus`, `notifyActiveWindowChange()` never runs, and `activeWindow()` stays null until the focus really changes. Everything reading `MainWindow::isActive()`, marking as read, animation pausing, the tray toggle, is stuck with it.

## Steps to reproduce

The gap between the hide and the show has to be shorter than what is left of those 100 ms, which is about 80 ms here, so this is hard to hit by hand and easy to hit from a script. `xev` on the window, a healthy cycle and a broken one from the same run:

```
15:57:15.752  FocusOut  NotifyNonlinear   hide, doFocusOut starts the timer
15:57:16.358  FocusIn   NotifyNonlinear   show 600 ms later, accepted, window goes active

15:57:17.669  FocusOut  NotifyNonlinear   hide again
15:57:17.708  FocusIn   NotifyNonlinear   show 39 ms later, accepted, but previous == newFocus
```

After the second cycle the window is on screen and holds the input focus, and the client considers itself inactive until the focus moves away for real. A way to do it by hand, plus the plain Qt reproduction with no Telegram code involved, is in the comments.

## Fix

Destroy the native window when hiding on X11. `QWindowPrivate::destroy()` clears the focused window right there, so the two halves of Qt stop disagreeing, and showing the window back creates it again and the activation is delivered as usual.

`savePosition()` needs its visibility check moved above the `windowHandle()` use, because there is no handle while the window is hidden now.

## Testing

Built and used on Kubuntu with KWin 5.27 on X11. On a build carrying only #31189 the scripted reproduction gets stuck on every run, four out of four. With this patch on top it stays clean, three runs with a 30 ms gap and three more with no gap at all.

Also checked what the destroyed window costs: geometry and maximized state survive the hide and show, the position still reaches the settings across a restart, and the rss, the fd count and the window count stay flat over 30 cycles.

## Related

Related to #31189, which fixes the window manager refusing to activate the window from the tray. That refusal was the most common path into the state described here, and with it fixed the scenario became much rarer. This is still a separate defect: the state is reachable from an ordinary hide and show cycle with nothing refusing the activation, which is what the reproduction in the comments does.
