### PR TITLE
Fix the first tray icon click not raising the window on X11

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -14,6 +14,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/platform/linux/base_linux_xcb_utilities.h"
 #include "base/platform/linux/base_linux_xdp_utilities.h"
 #include "base/platform/linux/base_linux_app_launch_context.h"
+#include "base/platform/base_platform_process.h"
 #include "lang/lang_keys.h"
 #include "core/launcher.h"
 #include "core/sandbox.h"
@@ -836,6 +837,16 @@ void NewVersionLaunched(int oldVersion) {
 
 QImage DefaultApplicationIcon() {
 	return Window::Logo();
+}
+
+void ActivateThisProcess() {
+	const auto window = Core::IsAppLaunched()
+		? Core::App().activeWindow()
+		: nullptr;
+	if (window) {
+		base::Platform::ActivateThisProcessWindow(
+			window->widget()->winId());
+	}
 }
 
 QString ApplicationIconName() {

--- a/Telegram/SourceFiles/platform/linux/specific_linux.h
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.h
@@ -24,8 +24,7 @@ inline bool PreventsQuit(Core::QuitReason reason) {
 	return false;
 }
 
-inline void ActivateThisProcess() {
-}
+void ActivateThisProcess();
 
 inline uint64 ActivationWindowId(not_null<QWidget*> window) {
 	return 1;


### PR DESCRIPTION
On X11 the first click on the tray icon often does not raise the window — it only gets marked as demanding attention (highlighted in the task bar), and it takes a second click to actually bring it up.

## Steps to reproduce

Reproduces reliably with KWin on X11:

1. Leave Telegram running behind other windows.
2. Switch between tabs in Google Chrome a few times.
3. Click the tray icon — nothing visible happens, the task bar entry is only highlighted.
4. Click it again — now the window comes up.

Any application that updates its user time frequently will do; Chrome is simply the easiest, because switching tabs is enough.

## Root cause

`Window::MainWindow::activate()` calls `Platform::ActivateThisProcess()`, which on Linux is empty:

```cpp
inline void ActivateThisProcess() {
}
```

So the only `_NET_ACTIVE_WINDOW` request comes from Qt, in `QXcbWindow::requestActivateWindow()`, and it carries `connection()->time()` — the timestamp of the last X11 event the application itself received. For a window sitting in the background, that time is stale.

The window manager compares this timestamp against `_NET_WM_USER_TIME` of the currently active window to tell a genuine user action from focus stealing. A stale timestamp loses that comparison, so the activation is refused and `demandAttention()` is called instead — hence the highlight and the need for a second click.

`base::Platform::ActivateThisProcessWindow()` already does the right thing: it obtains a fresh timestamp from the X server through `XCB::GetTimestamp()`. On Linux nothing ever called it.

## Fix

Implement `ActivateThisProcess()` for Linux through that function, mirroring how it is done on macOS.

The source indication stays `1` (application) — it never needed changing, the timestamp was the only problem:

```
19:07:44.019  X11:  active window belongs to another application
19:07:47      sent: source 1, timestamp 30607646
19:07:47.327  X11:  active window is Telegram, _NET_WM_STATE_FOCUSED is set
```

## Testing

Built and used on Kubuntu with KWin 5.27 on X11. Before the change the steps above reproduce the issue every time; after it, the window comes up on the first click.

## Related

Related to #31185, which fixes a desynchronization between `QApplication::activeWindow()` and the actual X11 focus state. The refused activation described here appears to be the most common path into that state — the scenario above leads to it directly. #31185 covers a rarer path as well: the same desynchronization was observed with no tray activation involved at all, in the opposite direction.
