### PR TITLE
Fix Delete shown as Change folder in chats list quick action

### DIFF
--- a/Telegram/SourceFiles/settings/sections/settings_chat.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_chat.cpp
@@ -2266,6 +2266,8 @@ void SetupChatListQuickAction(
 					? tr::lng_settings_quick_dialog_action_pin
 					: (value == Dialogs::Ui::QuickDialogAction::Read)
 					? tr::lng_settings_quick_dialog_action_read
+					: (value == Dialogs::Ui::QuickDialogAction::Delete)
+					? tr::lng_settings_quick_dialog_action_delete
 					: (value == Dialogs::Ui::QuickDialogAction::Archive)
 					? tr::lng_settings_quick_dialog_action_archive
 					: tr::lng_settings_quick_dialog_action_disabled)();


### PR DESCRIPTION
Picking **Delete** as the chats list quick action leaves the settings button saying **Change folder**, next to the delete icon.

The chain choosing the button label has no branch for `QuickDialogAction::Delete`, so it falls through to `lng_settings_quick_dialog_action_disabled`. The chain choosing the icon right below it does have one, which is why the row ends up showing the delete icon with the label of the disabled state.

The swipe itself, its color and its icon were always right — only the settings button lied about what is set.
