### PR TITLE
Expose value-picking sliders as a slider and a radio group

### DIFF
--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -1225,6 +1225,10 @@ void ProxiesBox::setupContent() {
 			_proxyRotationOptions->entity(),
 			st::settingsSlider),
 		st::settingsBigScalePadding);
+	// Picks one of a few textual timeout options, not a displayed section -
+	// a radio group to accessibility.
+	_proxyRotationTimeout->setAccessibilityMode(
+		Ui::DiscreteSlider::AccessibilityMode::Radio);
 	for (const auto seconds : Core::SettingsProxy::kProxyRotationTimeouts) {
 		_proxyRotationTimeout->addSection(
 			tr::lng_proxy_auto_switch_timeout(

--- a/Telegram/SourceFiles/settings/sections/settings_notifications.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_notifications.cpp
@@ -1567,6 +1567,9 @@ void BuildSystemIntegrationAndAdvancedSection(SectionBuilder &builder) {
 		const auto countSlider = advancedWrap->add(
 			object_ptr<Ui::SettingsSlider>(advancedWrap, st::settingsSlider),
 			st::settingsBigScalePadding);
+		// Picks a count, not a displayed section - a slider to accessibility.
+		countSlider->setAccessibilityMode(
+			Ui::DiscreteSlider::AccessibilityMode::Value);
 		for (int i = 0; i != kMaxNotificationsCount; ++i) {
 			countSlider->addSection(QString::number(i + 1));
 		}

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
@@ -91,6 +91,10 @@ rpl::producer<int> DiscreteSlider::accessibilitySectionBrowsed() const {
 	return _accessibilitySectionBrowsed.events();
 }
 
+void DiscreteSlider::setAccessibilityActivateOnBrowse(bool activate) {
+	_accessibilityActivateOnBrowse = activate;
+}
+
 int DiscreteSlider::sectionsCount() const {
 	return int(_sections.size());
 }
@@ -304,12 +308,27 @@ void DiscreteSlider::keyPressEvent(QKeyEvent *e) {
 		browseAndActivate(0);
 	} else if (key == Qt::Key_End && count > 0) {
 		browseAndActivate(count - 1);
+	} else if (!e->isAutoRepeat()
+		&& !_accessibilityActivateOnBrowse
+		&& (key == Qt::Key_Space
+			|| key == Qt::Key_Return
+			|| key == Qt::Key_Enter)
+		&& _accessibilitySelected >= 0
+		&& _accessibilitySelected < count) {
+		// Only an opted-out strip needs the explicit commit step.
+		activateSectionByAccessibility(_accessibilitySelected);
 	} else {
 		RpWidget::keyPressEvent(e);
 	}
 }
 
 void DiscreteSlider::browseAndActivate(int index) {
+	// An opted-out strip (see setAccessibilityActivateOnBrowse) only moves
+	// the browse position, keeping activation on Enter / Space.
+	if (!_accessibilityActivateOnBrowse) {
+		setAccessibilitySelected(index, Announce::Always);
+		return;
+	}
 	// A native Windows tab control switches to the tab the arrows land on
 	// right away, with no separate Enter / Space step, and what the screen
 	// reader announces is the focus moving onto that tab - which by then

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
@@ -323,6 +323,9 @@ void DiscreteSlider::keyPressEvent(QKeyEvent *e) {
 		}
 		return;
 	}
+	// A radio group moves with the same arrows as the tabs: Radiobutton only
+	// accepts the arrows matching the group's layout, and this strip is
+	// horizontal - Up / Down stay free, e.g. for scrolling the page.
 	if ((key == forward || key == backward) && count > 0) {
 		const auto current = (_accessibilitySelected >= 0)
 			? _accessibilitySelected
@@ -478,9 +481,11 @@ void DiscreteSlider::setAccessibilitySelected(int index, Announce announce) {
 }
 
 QAccessible::Role DiscreteSlider::accessibilityRole() {
-	return (_accessibilityMode == AccessibilityMode::Value)
-		? QAccessible::Slider
-		: QAccessible::PageTabList;
+	switch (_accessibilityMode) {
+	case AccessibilityMode::Value: return QAccessible::Slider;
+	case AccessibilityMode::Radio: return QAccessible::Grouping;
+	}
+	return QAccessible::PageTabList;
 }
 
 bool DiscreteSlider::accessibilitySelectionList() const {
@@ -499,7 +504,9 @@ std::optional<Qt::Orientation> DiscreteSlider::accessibilityOrientation() const 
 }
 
 QAccessible::Role DiscreteSlider::accessibilityChildRole() const {
-	return QAccessible::PageTab;
+	return (_accessibilityMode == AccessibilityMode::Radio)
+		? QAccessible::RadioButton
+		: QAccessible::PageTab;
 }
 
 QAccessible::State DiscreteSlider::accessibilityChildState(int index) const {
@@ -510,6 +517,11 @@ QAccessible::State DiscreteSlider::accessibilityChildState(int index) const {
 	}
 	if (index == _activeIndex) {
 		state.selected = true;
+		if (_accessibilityMode == AccessibilityMode::Radio) {
+			// The platform reads a radio button's checked flag where other
+			// selection items report selected; keep the two in sync.
+			state.checked = true;
+		}
 	}
 	if (index == _accessibilitySelected) {
 		state.active = true;

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/discrete_sliders.h"
 
 #include "ui/effects/ripple_animation.h"
+#include "ui/screen_reader_mode.h"
 #include "styles/style_widgets.h"
 
 namespace Ui {
@@ -86,6 +87,10 @@ void DiscreteSlider::setAdditionalContentWidthToSection(int index, int w) {
 	}
 }
 
+rpl::producer<int> DiscreteSlider::accessibilitySectionBrowsed() const {
+	return _accessibilitySectionBrowsed.events();
+}
+
 int DiscreteSlider::sectionsCount() const {
 	return int(_sections.size());
 }
@@ -154,6 +159,9 @@ void DiscreteSlider::refresh() {
 	}
 	if (_selected >= _sections.size()) {
 		_selected = 0;
+	}
+	if (_accessibilitySelected >= int(_sections.size())) {
+		_accessibilitySelected = -1;
 	}
 	resizeToWidth(width());
 	update();
@@ -257,6 +265,242 @@ int DiscreteSlider::getIndexFromPosition(QPoint pos) {
 		}
 	}
 	return count - 1;
+}
+
+void DiscreteSlider::focusInEvent(QFocusEvent *e) {
+	// On real Tab traversal always land on the active section: the
+	// accessibility SetFocus / Invoke actions leave a browse position behind,
+	// and keeping it here would move Tab focus to whatever section was last
+	// acted on instead. Those actions themselves come through with
+	// OtherFocusReason (plain setFocus()) and must keep the position they
+	// have just set.
+	const auto count = int(_sections.size());
+	const auto tab = (e->reason() == Qt::TabFocusReason)
+		|| (e->reason() == Qt::BacktabFocusReason);
+	if (count > 0 && (tab || _accessibilitySelected < 0)) {
+		setAccessibilitySelected(
+			std::clamp(_activeIndex, 0, count - 1),
+			Announce::No);
+	}
+	// Taking focus raises a focus event of its own, which the platform hands
+	// to focusChild() - the browsed section - so announcing it here as well
+	// would read it twice.
+	RpWidget::focusInEvent(e);
+}
+
+void DiscreteSlider::keyPressEvent(QKeyEvent *e) {
+	const auto count = int(_sections.size());
+	const auto key = e->key();
+	// Sections are painted mirrored in RTL, so arrows move by visual order.
+	const auto forward = style::RightToLeft() ? Qt::Key_Left : Qt::Key_Right;
+	const auto backward = style::RightToLeft() ? Qt::Key_Right : Qt::Key_Left;
+	if ((key == forward || key == backward) && count > 0) {
+		const auto current = (_accessibilitySelected >= 0)
+			? _accessibilitySelected
+			: _activeIndex;
+		const auto delta = (key == forward) ? 1 : -1;
+		browseAndActivate(std::clamp(current + delta, 0, count - 1));
+	} else if (key == Qt::Key_Home && count > 0) {
+		browseAndActivate(0);
+	} else if (key == Qt::Key_End && count > 0) {
+		browseAndActivate(count - 1);
+	} else {
+		RpWidget::keyPressEvent(e);
+	}
+}
+
+void DiscreteSlider::browseAndActivate(int index) {
+	// A native Windows tab control switches to the tab the arrows land on
+	// right away, with no separate Enter / Space step, and what the screen
+	// reader announces is the focus moving onto that tab - which by then
+	// already reports itself selected. So activate silently first, then
+	// announce through the focus move.
+	if (index != _activeIndex) {
+		setActiveSection(index);
+		accessibilityChildStateChanged(index, { .selected = true });
+		setAccessibilitySelected(index, Announce::Always);
+	} else {
+		// Nothing to switch (e.g. the edge tab again) - just keep the browse
+		// position in place, announcing only if it actually moved.
+		setAccessibilitySelected(index, Announce::OnChange);
+	}
+}
+
+void DiscreteSlider::activateSectionByAccessibility(int index) {
+	const auto previous = _activeIndex;
+	setActiveSection(index);
+	accessibilityChildStateChanged(index, { .selected = true });
+	// The state change alone stays silent on Windows, where the bridge reads
+	// only the checked flag out of it - the selection events below are the
+	// ones a screen reader hears, the way SideBarButton announces the active
+	// folder of the vertical strip.
+	if (previous != index
+		&& previous >= 0
+		&& previous < int(_sections.size())) {
+		accessibilityChildSelectionChanged(previous);
+	}
+	accessibilityChildSelectionChanged(index);
+}
+
+int DiscreteSlider::accessibilityBrowsedSection() const {
+	return (_accessibilitySelected >= 0
+		&& _accessibilitySelected < int(_sections.size()))
+		? _accessibilitySelected
+		: -1;
+}
+
+void DiscreteSlider::setAccessibilitySelected(int index, Announce announce) {
+	if (index >= int(_sections.size())) {
+		return;
+	}
+	const auto changed = (_accessibilitySelected != index);
+	_accessibilitySelected = index;
+	if (changed && index >= 0) {
+		_accessibilitySectionBrowsed.fire_copy(index);
+	}
+	const auto shouldAnnounce = (announce == Announce::Always)
+		|| (announce == Announce::OnChange && changed);
+	if (shouldAnnounce && index >= 0) {
+		accessibilityChildFocused(index);
+	}
+}
+
+QAccessible::Role DiscreteSlider::accessibilityRole() {
+	return QAccessible::PageTabList;
+}
+
+bool DiscreteSlider::accessibilitySelectionList() const {
+	// Grants the sections the platform selection item pattern, which is what
+	// a screen reader reads "selected" / "not selected" from while browsing.
+	return true;
+}
+
+Qt::FocusPolicy DiscreteSlider::accessibilityFocusPolicy() {
+	return Qt::TabFocus;
+}
+
+std::optional<Qt::Orientation> DiscreteSlider::accessibilityOrientation() const {
+	return Qt::Horizontal;
+}
+
+QAccessible::Role DiscreteSlider::accessibilityChildRole() const {
+	return QAccessible::PageTab;
+}
+
+QAccessible::State DiscreteSlider::accessibilityChildState(int index) const {
+	QAccessible::State state;
+	state.selectable = true;
+	if (ScreenReaderModeActive()) {
+		state.focusable = true;
+	}
+	if (index == _activeIndex) {
+		state.selected = true;
+	}
+	if (index == _accessibilitySelected) {
+		state.active = true;
+		if (hasFocus()) {
+			state.focused = true;
+		}
+	}
+	return state;
+}
+
+int DiscreteSlider::accessibilityChildCount() const {
+	return int(_sections.size());
+}
+
+QString DiscreteSlider::accessibilityChildName(int index) const {
+	if (index < 0 || index >= int(_sections.size())) {
+		return {};
+	}
+	return _sections[index].label.toString();
+}
+
+QRect DiscreteSlider::accessibilityChildRect(int index) const {
+	if (index < 0 || index >= int(_sections.size())) {
+		return {};
+	}
+	const auto &section = _sections[index];
+	return myrtlrect(section.left, 0, section.width, height());
+}
+
+bool DiscreteSlider::accessibilityChildSupportsActions(int index) const {
+	// Every section can be focused and activated, and each has a stable
+	// identity below. Tying the opt-in to a valid identity keeps the action
+	// interface off invalid indices.
+	return accessibilityChildIdentity(index) != 0;
+}
+
+quintptr DiscreteSlider::accessibilityChildIdentity(int index) const {
+	// The sections are rebuilt wholesale by setSections(), so an index is
+	// not stable by the time a queued action runs. The label text names a
+	// section within one slider; hash collisions (or duplicate labels) are
+	// possible but acceptable, same as in the language and country boxes.
+	// Shift instead of masking so that small hash values keep their
+	// distinguishing low bits; the tag bit keeps the token non-zero.
+	if (index < 0 || index >= int(_sections.size())) {
+		return 0;
+	}
+	const auto value = quintptr(qHash(_sections[index].label.toString()));
+	return value ? ((value << 3) | quintptr(1)) : quintptr(0);
+}
+
+int DiscreteSlider::accessibilityChildIndexByIdentity(
+		quintptr identity) const {
+	if (!identity) {
+		return -1;
+	}
+	const auto count = accessibilityChildCount();
+	for (auto i = 0; i != count; ++i) {
+		if (accessibilityChildIdentity(i) == identity) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+void DiscreteSlider::accessibilityChildSetFocus(quintptr identity) {
+	// UIA invokes provider actions (SetFocus) on a background thread, so hop
+	// to the main thread before touching any widget state. Resolve the stable
+	// identity to its current index here (not on the background thread) so a
+	// sections rebuild does not move focus to another section.
+	crl::on_main(this, [=] {
+		const auto index = accessibilityChildIndexByIdentity(identity);
+		if (index < 0) {
+			return;
+		}
+		// The sections are virtual (no real QWidget), so the screen reader's
+		// SetFocus can't move real keyboard focus to a section. Translate it
+		// into our browse position, then either announce it directly or grab
+		// keyboard focus (taking it announces the section by itself).
+		setAccessibilitySelected(
+			index,
+			hasFocus() ? Announce::Always : Announce::No);
+		if (!hasFocus()) {
+			setFocus();
+		}
+	});
+}
+
+void DiscreteSlider::accessibilityChildActivate(quintptr identity) {
+	// UIA invokes the press action on a background thread too; resolve the
+	// identity, move the browse position and activate the section on the
+	// main thread. Take focus onto the section first (as the SetFocus action
+	// does), so the "selected" announcement is heard from Invoke as well as
+	// from Space.
+	crl::on_main(this, [=] {
+		const auto index = accessibilityChildIndexByIdentity(identity);
+		if (index < 0) {
+			return;
+		}
+		setAccessibilitySelected(
+			index,
+			hasFocus() ? Announce::OnChange : Announce::No);
+		if (!hasFocus()) {
+			setFocus();
+		}
+		activateSectionByAccessibility(index);
+	});
 }
 
 DiscreteSlider::Section::Section(

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
@@ -95,6 +95,10 @@ void DiscreteSlider::setAccessibilityActivateOnBrowse(bool activate) {
 	_accessibilityActivateOnBrowse = activate;
 }
 
+void DiscreteSlider::setAccessibilityMode(AccessibilityMode mode) {
+	_accessibilityMode = mode;
+}
+
 int DiscreteSlider::sectionsCount() const {
 	return int(_sections.size());
 }
@@ -281,7 +285,9 @@ void DiscreteSlider::focusInEvent(QFocusEvent *e) {
 	const auto count = int(_sections.size());
 	const auto tab = (e->reason() == Qt::TabFocusReason)
 		|| (e->reason() == Qt::BacktabFocusReason);
-	if (count > 0 && (tab || _accessibilitySelected < 0)) {
+	if (count > 0
+		&& _accessibilityMode != AccessibilityMode::Value
+		&& (tab || _accessibilitySelected < 0)) {
 		setAccessibilitySelected(
 			std::clamp(_activeIndex, 0, count - 1),
 			Announce::No);
@@ -298,6 +304,25 @@ void DiscreteSlider::keyPressEvent(QKeyEvent *e) {
 	// Sections are painted mirrored in RTL, so arrows move by visual order.
 	const auto forward = style::RightToLeft() ? Qt::Key_Left : Qt::Key_Right;
 	const auto backward = style::RightToLeft() ? Qt::Key_Right : Qt::Key_Left;
+	if (_accessibilityMode == AccessibilityMode::Value && count > 0) {
+		// A native slider changes its value with the arrows right away (Up
+		// increases, like Right) and announces through the value change.
+		const auto delta = (key == forward || key == Qt::Key_Up)
+			? 1
+			: (key == backward || key == Qt::Key_Down)
+			? -1
+			: 0;
+		if (delta) {
+			changeValueTo(std::clamp(_activeIndex + delta, 0, count - 1));
+		} else if (key == Qt::Key_Home) {
+			changeValueTo(0);
+		} else if (key == Qt::Key_End) {
+			changeValueTo(count - 1);
+		} else {
+			RpWidget::keyPressEvent(e);
+		}
+		return;
+	}
 	if ((key == forward || key == backward) && count > 0) {
 		const auto current = (_accessibilitySelected >= 0)
 			? _accessibilitySelected
@@ -345,6 +370,74 @@ void DiscreteSlider::browseAndActivate(int index) {
 	}
 }
 
+void DiscreteSlider::changeValueTo(int index) {
+	if (index == _activeIndex) {
+		return;
+	}
+	setActiveSection(index);
+	accessibilityValueChanged();
+}
+
+QString DiscreteSlider::accessibilityValue() const {
+	const auto count = int(_sections.size());
+	if (_accessibilityMode != AccessibilityMode::Value || !count) {
+		return QString();
+	}
+	// A screen reader reads a slider's value from the textual Value pattern
+	// (the way the media volume slider reports "100%"), so the current label
+	// goes there as well as into the numeric range below.
+	return _sections[std::clamp(_activeIndex, 0, count - 1)].label.toString();
+}
+
+std::optional<AccessibilityValueRange> DiscreteSlider::accessibilityValueRange() const {
+	const auto count = int(_sections.size());
+	if (_accessibilityMode != AccessibilityMode::Value || !count) {
+		return std::nullopt;
+	}
+	return AccessibilityValueRange{
+		.current = sectionValue(std::clamp(_activeIndex, 0, count - 1)),
+		.minimum = sectionValue(0),
+		.maximum = sectionValue(count - 1),
+		.step = 1., // Steps between sections may be uneven; 1 is advisory.
+	};
+}
+
+void DiscreteSlider::accessibilitySetValue(double value) {
+	// UIA delivers RangeValue.SetValue on a background thread; hop to the
+	// main thread before touching any widget state.
+	crl::on_main(this, [=] {
+		if (_accessibilityMode != AccessibilityMode::Value
+			|| _sections.empty()) {
+			return;
+		}
+		changeValueTo(sectionByValue(value));
+	});
+}
+
+double DiscreteSlider::sectionValue(int index) const {
+	Expects(index >= 0 && index < _sections.size());
+
+	// A numeric scale usually labels its sections with the numbers
+	// themselves (e.g. 1..5); fall back to the ordinal position otherwise.
+	auto ok = false;
+	const auto parsed = _sections[index].label.toString().toDouble(&ok);
+	return ok ? parsed : (index + 1.);
+}
+
+int DiscreteSlider::sectionByValue(double value) const {
+	auto result = 0;
+	auto best = 0.;
+	const auto count = int(_sections.size());
+	for (auto i = 0; i != count; ++i) {
+		const auto distance = std::abs(sectionValue(i) - value);
+		if (!i || distance < best) {
+			best = distance;
+			result = i;
+		}
+	}
+	return result;
+}
+
 void DiscreteSlider::activateSectionByAccessibility(int index) {
 	const auto previous = _activeIndex;
 	setActiveSection(index);
@@ -385,13 +478,16 @@ void DiscreteSlider::setAccessibilitySelected(int index, Announce announce) {
 }
 
 QAccessible::Role DiscreteSlider::accessibilityRole() {
-	return QAccessible::PageTabList;
+	return (_accessibilityMode == AccessibilityMode::Value)
+		? QAccessible::Slider
+		: QAccessible::PageTabList;
 }
 
 bool DiscreteSlider::accessibilitySelectionList() const {
 	// Grants the sections the platform selection item pattern, which is what
 	// a screen reader reads "selected" / "not selected" from while browsing.
-	return true;
+	// A value slider has no child items to select.
+	return _accessibilityMode != AccessibilityMode::Value;
 }
 
 Qt::FocusPolicy DiscreteSlider::accessibilityFocusPolicy() {
@@ -425,7 +521,11 @@ QAccessible::State DiscreteSlider::accessibilityChildState(int index) const {
 }
 
 int DiscreteSlider::accessibilityChildCount() const {
-	return int(_sections.size());
+	// A value slider is a single element - its sections are points on the
+	// scale, not children to browse.
+	return (_accessibilityMode == AccessibilityMode::Value)
+		? 0
+		: int(_sections.size());
 }
 
 QString DiscreteSlider::accessibilityChildName(int index) const {

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
@@ -66,10 +66,13 @@ public:
 
 	// A slider whose sections form a numeric scale (e.g. a count of 1..5)
 	// presents itself as a single slider element with a range value instead
-	// of a strip of tabs.
+	// of a strip of tabs, and one whose sections are a few exclusive textual
+	// options presents them as a group of radio buttons, read the way a
+	// classic settings group announces its choices.
 	enum class AccessibilityMode {
 		Tabs,
 		Value,
+		Radio,
 	};
 	void setAccessibilityMode(AccessibilityMode mode);
 

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
@@ -57,6 +57,13 @@ public:
 	// owners of a scrollable slider can bring that section into view.
 	[[nodiscard]] rpl::producer<int> accessibilitySectionBrowsed() const;
 
+	// Whether the arrows switch to the tab they land on right away (the
+	// default - native Windows tab controls do) or only browse, committing
+	// on Enter / Space. Turn it off where a switch is expensive or has side
+	// effects, like the folder tabs: they reload the whole chat list, and a
+	// locked premium folder opens an upsell on activation.
+	void setAccessibilityActivateOnBrowse(bool activate);
+
 	[[nodiscard]] int sectionsCount() const;
 	[[nodiscard]] int lookupSectionLeft(int index) const;
 
@@ -165,6 +172,7 @@ private:
 	int _pressed = -1;
 	int _selected = 0;
 	int _accessibilitySelected = -1;
+	bool _accessibilityActivateOnBrowse = true;
 	Ui::Animations::Simple _a_left;
 	Ui::Animations::Simple _a_width;
 

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
@@ -64,6 +64,15 @@ public:
 	// locked premium folder opens an upsell on activation.
 	void setAccessibilityActivateOnBrowse(bool activate);
 
+	// A slider whose sections form a numeric scale (e.g. a count of 1..5)
+	// presents itself as a single slider element with a range value instead
+	// of a strip of tabs.
+	enum class AccessibilityMode {
+		Tabs,
+		Value,
+	};
+	void setAccessibilityMode(AccessibilityMode mode);
+
 	[[nodiscard]] int sectionsCount() const;
 	[[nodiscard]] int lookupSectionLeft(int index) const;
 
@@ -72,6 +81,9 @@ public:
 	bool accessibilitySelectionList() const override;
 	Qt::FocusPolicy accessibilityFocusPolicy() override;
 	std::optional<Qt::Orientation> accessibilityOrientation() const override;
+	QString accessibilityValue() const override;
+	std::optional<AccessibilityValueRange> accessibilityValueRange() const override;
+	void accessibilitySetValue(double value) override;
 	QAccessible::Role accessibilityChildRole() const override;
 	QAccessible::State accessibilityChildState(int index) const override;
 	int accessibilityChildCount() const override;
@@ -159,6 +171,9 @@ private:
 	void setSelectedSection(int index);
 	void setAccessibilitySelected(int index, Announce announce);
 	void browseAndActivate(int index);
+	void changeValueTo(int index);
+	[[nodiscard]] double sectionValue(int index) const;
+	[[nodiscard]] int sectionByValue(double value) const;
 
 	std::vector<Section> _sections;
 	Fn<bool()> _paused;
@@ -173,6 +188,7 @@ private:
 	int _selected = 0;
 	int _accessibilitySelected = -1;
 	bool _accessibilityActivateOnBrowse = true;
+	AccessibilityMode _accessibilityMode = AccessibilityMode::Tabs;
 	Ui::Animations::Simple _a_left;
 	Ui::Animations::Simple _a_width;
 

--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
+++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.h
@@ -53,14 +53,44 @@ public:
 		return _sectionActivated.events();
 	}
 
+	// Fired when the screen reader browse position moves to a section, so
+	// owners of a scrollable slider can bring that section into view.
+	[[nodiscard]] rpl::producer<int> accessibilitySectionBrowsed() const;
+
 	[[nodiscard]] int sectionsCount() const;
 	[[nodiscard]] int lookupSectionLeft(int index) const;
+
+	// Accessibility: a horizontal strip of painted tabs.
+	QAccessible::Role accessibilityRole() override;
+	bool accessibilitySelectionList() const override;
+	Qt::FocusPolicy accessibilityFocusPolicy() override;
+	std::optional<Qt::Orientation> accessibilityOrientation() const override;
+	QAccessible::Role accessibilityChildRole() const override;
+	QAccessible::State accessibilityChildState(int index) const override;
+	int accessibilityChildCount() const override;
+	QString accessibilityChildName(int index) const override;
+	QRect accessibilityChildRect(int index) const override;
+	bool accessibilityChildSupportsActions(int index) const override;
+	quintptr accessibilityChildIdentity(int index) const override;
+	int accessibilityChildIndexByIdentity(quintptr identity) const override;
+	void accessibilityChildSetFocus(quintptr identity) override;
+	void accessibilityChildActivate(quintptr identity) override;
 
 protected:
 	void timerEvent(QTimerEvent *e) override;
 	void mousePressEvent(QMouseEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;
 	void mouseReleaseEvent(QMouseEvent *e) override;
+	void keyPressEvent(QKeyEvent *e) override;
+	void focusInEvent(QFocusEvent *e) override;
+
+	// Activation coming from accessibility (keyboard or a screen reader
+	// action); subclasses can intercept it (e.g. locked premium folders).
+	virtual void activateSectionByAccessibility(int index);
+
+	// The section the browse position is on, or -1 when it isn't on any -
+	// a context menu opened from the keyboard has no position to look at.
+	[[nodiscard]] int accessibilityBrowsedSection() const;
 
 	int resizeGetHeight(int newWidth) override = 0;
 
@@ -108,12 +138,20 @@ protected:
 	[[nodiscard]] bool paused() const;
 
 private:
+	enum class Announce {
+		No,
+		OnChange,
+		Always,
+	};
+
 	void activateCallback();
 	virtual const style::TextStyle &getLabelStyle() const = 0;
 	virtual int getAnimationDuration() const = 0;
 
 	int getIndexFromPosition(QPoint pos);
 	void setSelectedSection(int index);
+	void setAccessibilitySelected(int index, Announce announce);
+	void browseAndActivate(int index);
 
 	std::vector<Section> _sections;
 	Fn<bool()> _paused;
@@ -122,9 +160,11 @@ private:
 	bool _snapToLabel = false;
 
 	rpl::event_stream<int> _sectionActivated;
+	rpl::event_stream<int> _accessibilitySectionBrowsed;
 
 	int _pressed = -1;
 	int _selected = 0;
+	int _accessibilitySelected = -1;
 	Ui::Animations::Simple _a_left;
 	Ui::Animations::Simple _a_width;
 


### PR DESCRIPTION
Two of the DiscreteSlider strips do not switch displayed content - they pick a value - so with #31097 in place they can get their real roles:

- The notifications count (Settings > Notifications and Sounds) picks a number of 1..5. It is now a single slider element: the arrows change the value right away and a screen reader reads and follows the number, the same way the volume slider works.
- The proxy auto-switch timeout picks one of a few textual durations. It is now read as a radio group: Left / Right check the option the arrows land on, matching how the Radiobutton groups behave (a horizontal group leaves Up / Down free).

All other strips keep the tab roles from #31097.

Depends on #31097 and on desktop-app/lib_ui#354 (the accessible value interface), so it compiles only on top of them.