### PR TITLE
Fix Linux Mini App window shadow gutter

### DIFF
--- a/Telegram/Resources/bot_webview_shell_html/page.css
+++ b/Telegram/Resources/bot_webview_shell_html/page.css
@@ -33,10 +33,11 @@ select {
 	--shell-pad-right: 12px;
 	--shell-pad-bottom: 12px;
 	--shell-pad-left: 12px;
-	--shadow-pad-top: 12px;
-	--shadow-pad-right: 14px;
-	--shadow-pad-bottom: 16px;
-	--shadow-pad-left: 14px;
+	--shadow-pad-top: 0px;
+	--shadow-pad-right: 0px;
+	--shadow-pad-bottom: 0px;
+	--shadow-pad-left: 0px;
+	--resize-handle: 8px;
 	--header-height: 60px;
 	--title-pad-top: 0px;
 	--title-pad-right: 0px;
@@ -95,11 +96,7 @@ select {
 	flex-direction: column;
 	border-radius: var(--shell-radius);
 	background: var(--body-bg, #ffffff);
-	box-shadow:
-		0 0 0 1px rgba(0, 0, 0, 0.08),
-		0 1px 2px rgba(0, 0, 0, 0.18),
-		0 3px 8px -1px rgba(0, 0, 0, 0.16),
-		0 8px 14px -5px rgba(0, 0, 0, 0.20);
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.10);
 	overflow: hidden;
 }
 #root.no-window-alpha #shell {
@@ -431,58 +428,58 @@ select {
 }
 .resize-handle[data-resize-edge="top"] {
 	top: 0;
-	left: var(--shadow-pad-left);
-	right: var(--shadow-pad-right);
-	height: var(--shadow-pad-top);
+	left: var(--resize-handle);
+	right: var(--resize-handle);
+	height: var(--resize-handle);
 	cursor: ns-resize;
 }
 .resize-handle[data-resize-edge="bottom"] {
 	bottom: 0;
-	left: var(--shadow-pad-left);
-	right: var(--shadow-pad-right);
-	height: var(--shadow-pad-bottom);
+	left: var(--resize-handle);
+	right: var(--resize-handle);
+	height: var(--resize-handle);
 	cursor: ns-resize;
 }
 .resize-handle[data-resize-edge="left"] {
-	top: var(--shadow-pad-top);
-	bottom: var(--shadow-pad-bottom);
+	top: var(--resize-handle);
+	bottom: var(--resize-handle);
 	left: 0;
-	width: var(--shadow-pad-left);
+	width: var(--resize-handle);
 	cursor: ew-resize;
 }
 .resize-handle[data-resize-edge="right"] {
-	top: var(--shadow-pad-top);
-	bottom: var(--shadow-pad-bottom);
+	top: var(--resize-handle);
+	bottom: var(--resize-handle);
 	right: 0;
-	width: var(--shadow-pad-right);
+	width: var(--resize-handle);
 	cursor: ew-resize;
 }
 .resize-handle[data-resize-edge="top-left"] {
 	top: 0;
 	left: 0;
-	width: var(--shadow-pad-left);
-	height: var(--shadow-pad-top);
+	width: var(--resize-handle);
+	height: var(--resize-handle);
 	cursor: nwse-resize;
 }
 .resize-handle[data-resize-edge="top-right"] {
 	top: 0;
 	right: 0;
-	width: var(--shadow-pad-right);
-	height: var(--shadow-pad-top);
+	width: var(--resize-handle);
+	height: var(--resize-handle);
 	cursor: nesw-resize;
 }
 .resize-handle[data-resize-edge="bottom-left"] {
 	bottom: 0;
 	left: 0;
-	width: var(--shadow-pad-left);
-	height: var(--shadow-pad-bottom);
+	width: var(--resize-handle);
+	height: var(--resize-handle);
 	cursor: nesw-resize;
 }
 .resize-handle[data-resize-edge="bottom-right"] {
 	right: 0;
 	bottom: 0;
-	width: var(--shadow-pad-right);
-	height: var(--shadow-pad-bottom);
+	width: var(--resize-handle);
+	height: var(--resize-handle);
 	cursor: nwse-resize;
 }
 #menu.visible {

--- a/Telegram/SourceFiles/payments/ui/payments.style
+++ b/Telegram/SourceFiles/payments/ui/payments.style
@@ -159,7 +159,7 @@ botWebViewMenu: PopupMenu(popupMenuWithIcons) {
 }
 botWebViewShellRadius: 7px;
 botWebViewShellPadding: margins(12px, 12px, 12px, 12px);
-botWebViewShellShadowPadding: margins(14px, 12px, 14px, 16px);
+botWebViewShellShadowPadding: margins(0px, 0px, 0px, 0px);
 botWebViewShellHeaderHeight: 60px;
 botWebViewShellTitlePadding: margins(0px, 0px, 0px, 0px);
 botWebViewShellBadgeSkip: 4px;


### PR DESCRIPTION
## Summary

- remove the dedicated visual shadow gutter around Linux external Mini App windows;
- keep an independent transparent 8 px hit target for all edge and corner resize handles;
- retain a subtle 1 px inset outline around the actual shell surface.

## Problem

The external Linux WebView shell reserves client-side margins of 14 px left/right, 12 px top and 16 px bottom solely for a multi-layer HTML shadow. On GNOME Wayland this renders as a prominent dark rectangular frame around the Mini App instead of a native-looking window boundary.

The shadow padding is also used as the resize target, so simply zeroing the margins would otherwise make border resizing unavailable. This change separates the invisible resize hit target from the visual padding.

For the current `botWebViewPanelSize` (384 x 694) and 60 px header, the observed helper window changes from 412 x 782 to 384 x 754 while preserving the content area.

## Testing

- built the complete Telegram Desktop 7.0.9 Release package on CachyOS Linux / GNOME 50.4 / Wayland;
- installed and launched the patched package; the external Mini App helper restarted normally;
- verified live window extents through AT-SPI: 412 x 782 before, 384 x 754 after;
- verified all eight edge/corner handles use the independent 8 px hit target;
- ported the single commit onto the current `upstream/dev`; it applies without conflicts and `git diff --check` passes.
