### PR TITLE
Release audio device when an active track is destroyed

### DIFF
--- a/Telegram/SourceFiles/media/audio/media_audio_track.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio_track.cpp
@@ -244,6 +244,7 @@ void Track::reattachToDevice() {
 }
 
 Track::~Track() {
+	finish();
 	detachFromDevice();
 	_instance->unregisterTrack(this);
 }


### PR DESCRIPTION
Fixes #31203

Destroying an active `Media::Audio::Track` bypassed `trackFinished()`, so the audio instance did not schedule its idle device detach. Finish the track before it is detached and unregistered.

Tested with a self-built 6.8.1 binary on NixOS, KDE Plasma, and PipeWire:

- calling party hangs up while Desktop is ringing;
- recipient answers on another device, then ends the call.

The lingering OpenAL Soft playback stream was released in both cases.
