### PR TITLE
Keep the unread counter in the tray icon tooltip

### DIFF
--- a/Telegram/SourceFiles/platform/linux/tray_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/tray_linux.cpp
@@ -14,6 +14,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "core/sandbox.h"
 #include "core/version.h"
 #include "platform/platform_specific.h"
+#include "tray.h"
 #include "ui/ui_utility.h"
 #include "ui/widgets/popup_menu.h"
 #include "window/window_controller.h"
@@ -292,7 +293,7 @@ void Tray::createIcon() {
 
 		_icon = base::make_unique_q<QSystemTrayIcon>(nullptr);
 		_icon->setIcon(_iconGraphic->trayIcon());
-		_icon->setToolTip(AppName.utf16());
+		_icon->setToolTip(Core::TrayIconToolTip());
 
 		using Reason = QSystemTrayIcon::ActivationReason;
 		base::qt_signal_producer(
@@ -335,6 +336,7 @@ void Tray::updateIcon() {
 	if (_iconGraphic->isRefreshNeeded()) {
 		_icon->setIcon(_iconGraphic->trayIcon());
 	}
+	_icon->setToolTip(Core::TrayIconToolTip());
 }
 
 void Tray::createMenu() {

--- a/Telegram/SourceFiles/platform/win/tray_win.cpp
+++ b/Telegram/SourceFiles/platform/win/tray_win.cpp
@@ -14,6 +14,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "lang/lang_keys.h"
 #include "main/main_session.h"
 #include "storage/localstorage.h"
+#include "tray.h"
 #include "ui/painter.h"
 #include "ui/ui_utility.h"
 #include "ui/widgets/popup_menu.h"
@@ -169,7 +170,6 @@ void Tray::createIcon() {
 		}
 		_icon->init();
 		updateIcon();
-		_icon->updateToolTip(AppName.utf16());
 
 		using Reason = QPlatformSystemTrayIcon::ActivationReason;
 		base::qt_signal_producer(
@@ -229,6 +229,7 @@ void Tray::updateIcon() {
 			Core::App().settings().trayIconMonochrome(),
 			session && session->supportMode()));
 	_icon->updateIcon(forTrayIcon);
+	_icon->updateToolTip(Core::TrayIconToolTip());
 }
 
 void Tray::createMenu() {

--- a/Telegram/SourceFiles/tray.cpp
+++ b/Telegram/SourceFiles/tray.cpp
@@ -10,6 +10,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "core/application.h"
 #include "core/core_settings.h"
+#include "core/version.h"
 #include "platform/platform_notifications_manager.h"
 #include "platform/platform_specific.h"
 #include "lang/lang_keys.h"
@@ -17,6 +18,13 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtWidgets/QApplication>
 
 namespace Core {
+
+QString TrayIconToolTip() {
+	const auto counter = Core::App().unreadBadge();
+	return (counter > 0)
+		? u"%1 (%2)"_q.arg(AppName.utf16()).arg(counter)
+		: AppName.utf16();
+}
 
 Tray::Tray() {
 }

--- a/Telegram/SourceFiles/tray.h
+++ b/Telegram/SourceFiles/tray.h
@@ -39,4 +39,9 @@ private:
 
 };
 
+// The tray icon paints the unread counter, a screen reader reads the
+// tooltip instead - so the tooltip carries the counter too, in the
+// window title's format: "Telegram Desktop (3)".
+[[nodiscard]] QString TrayIconToolTip();
+
 } // namespace Core


### PR DESCRIPTION
The tray icon paints the unread counter, but its tooltip was set once to "Telegram Desktop" and never updated - so a screen reader user, who gets the tooltip text as the icon's name, never heard the counter that a sighted user sees on the icon.

The tooltip now carries the counter in the window title's format - "Telegram Desktop (121)", plain "Telegram Desktop" at zero - and is refreshed together with the icon, so it follows the badge settings (muted chats, messages vs chats) the same way the painted badge does. One shared helper builds the text; the Windows tray sets it from updateIcon() instead of the one-time call in createIcon(), and the Linux QSystemTrayIcon does the same in its two spots (identical one-liner, not tested here).

Verified on Windows 10: the notification area button is named "Telegram Desktop (121)" (read through MSAA and by NVDA), the hover tooltip shows the same text, and both match the "Telegram (121)" window title.
