### PR TITLE
Leave the unread bar out of the message count for screen readers

### DIFF
--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -6635,6 +6635,20 @@ QAccessible::Role HistoryInner::accessibilityChildRoleAt(int index) const {
 		: accessibilityChildRole();
 }
 
+Ui::AccessibilitySetPosition HistoryInner::accessibilityChildSetPosition(
+		int index) const {
+	// The unread bar is not one of the messages: it has no position of its
+	// own and does not count, so the messages below it are not shifted.
+	const auto count = accessibilityChildCount();
+	const auto barIndex = accessibilityUnreadBarIndex();
+	if (barIndex < 0) {
+		return { index + 1, count };
+	} else if (index == barIndex) {
+		return {};
+	}
+	return { (index > barIndex) ? index : (index + 1), count - 1 };
+}
+
 QRect HistoryInner::accessibilityChildRect(int index) const {
 	const auto barIndex = accessibilityUnreadBarIndex();
 	if (barIndex >= 0 && index == barIndex) {

--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
@@ -6625,6 +6625,16 @@ QAccessible::Role HistoryInner::accessibilityChildRole() const {
 	return QAccessible::Role::ListItem;
 }
 
+QAccessible::Role HistoryInner::accessibilityChildRoleAt(int index) const {
+	// The unread bar divides the read messages from the unread ones, it
+	// is not a message itself - a separator to a screen reader, which also
+	// keeps it out of the selection and the item count.
+	const auto barIndex = accessibilityUnreadBarIndex();
+	return (barIndex >= 0 && index == barIndex)
+		? QAccessible::Role::Separator
+		: accessibilityChildRole();
+}
+
 QRect HistoryInner::accessibilityChildRect(int index) const {
 	const auto barIndex = accessibilityUnreadBarIndex();
 	if (barIndex >= 0 && index == barIndex) {

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -128,6 +128,7 @@ public:
 	QString accessibilityChildName(int index) const override;
 	QAccessible::State accessibilityChildState(int index) const override;
 	QAccessible::Role accessibilityChildRole() const override;
+	QAccessible::Role accessibilityChildRoleAt(int index) const override;
 	QRect accessibilityChildRect(int index) const override;
 	int accessibilityChildColumnCount(int row) const override;
 	QAccessible::Role accessibilityChildSubItemRole() const override;

--- a/Telegram/SourceFiles/history/history_inner_widget.h
+++ b/Telegram/SourceFiles/history/history_inner_widget.h
@@ -129,6 +129,8 @@ public:
 	QAccessible::State accessibilityChildState(int index) const override;
 	QAccessible::Role accessibilityChildRole() const override;
 	QAccessible::Role accessibilityChildRoleAt(int index) const override;
+	Ui::AccessibilitySetPosition accessibilityChildSetPosition(
+		int index) const override;
 	QRect accessibilityChildRect(int index) const override;
 	int accessibilityChildColumnCount(int row) const override;
 	QAccessible::Role accessibilityChildSubItemRole() const override;

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -6282,6 +6282,16 @@ QAccessible::Role ListWidget::accessibilityChildRole() const {
 	return QAccessible::Role::ListItem;
 }
 
+QAccessible::Role ListWidget::accessibilityChildRoleAt(int index) const {
+	// The unread bar divides the read messages from the unread ones, it
+	// is not a message itself - a separator to a screen reader, which also
+	// keeps it out of the selection and the item count.
+	const auto barIndex = accessibilityUnreadBarIndex();
+	return (barIndex >= 0 && index == barIndex)
+		? QAccessible::Role::Separator
+		: accessibilityChildRole();
+}
+
 QRect ListWidget::accessibilityChildRect(int index) const {
 	const auto barIndex = accessibilityUnreadBarIndex();
 	if (barIndex >= 0 && index == barIndex) {

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
@@ -6292,6 +6292,20 @@ QAccessible::Role ListWidget::accessibilityChildRoleAt(int index) const {
 		: accessibilityChildRole();
 }
 
+Ui::AccessibilitySetPosition ListWidget::accessibilityChildSetPosition(
+		int index) const {
+	// The unread bar is not one of the messages: it has no position of its
+	// own and does not count, so the messages below it are not shifted.
+	const auto count = accessibilityChildCount();
+	const auto barIndex = accessibilityUnreadBarIndex();
+	if (barIndex < 0) {
+		return { index + 1, count };
+	} else if (index == barIndex) {
+		return {};
+	}
+	return { (index > barIndex) ? index : (index + 1), count - 1 };
+}
+
 QRect ListWidget::accessibilityChildRect(int index) const {
 	const auto barIndex = accessibilityUnreadBarIndex();
 	if (barIndex >= 0 && index == barIndex) {

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -565,6 +565,7 @@ public:
 	QString accessibilityChildName(int index) const override;
 	QAccessible::State accessibilityChildState(int index) const override;
 	QAccessible::Role accessibilityChildRole() const override;
+	QAccessible::Role accessibilityChildRoleAt(int index) const override;
 	QRect accessibilityChildRect(int index) const override;
 	int accessibilityChildColumnCount(int row) const override;
 	QAccessible::Role accessibilityChildSubItemRole() const override;

--- a/Telegram/SourceFiles/history/view/history_view_list_widget.h
+++ b/Telegram/SourceFiles/history/view/history_view_list_widget.h
@@ -566,6 +566,8 @@ public:
 	QAccessible::State accessibilityChildState(int index) const override;
 	QAccessible::Role accessibilityChildRole() const override;
 	QAccessible::Role accessibilityChildRoleAt(int index) const override;
+	Ui::AccessibilitySetPosition accessibilityChildSetPosition(
+		int index) const override;
 	QRect accessibilityChildRect(int index) const override;
 	int accessibilityChildColumnCount(int row) const override;
 	QAccessible::Role accessibilityChildSubItemRole() const override;


### PR DESCRIPTION
Depends on #31211 and builds on top of it: that PR exposes the unread bar as a separator, this one keeps it out of the "x of y" a screen reader announces for the messages around it.

With desktop-app/lib_ui#359 a painted list item reports its position within its set, by default its index among all rows. The unread bar is not a message, so both message lists override that: the bar itself reports no position, and the messages are numbered without counting it, so the first unread message is "5 of 20" whether or not the bar sits above it.

Needs desktop-app/lib_ui#359 (and desktop-app/patches#265 for the Qt side of it).

Tested with NVDA on Windows 10: arrowing through a chat with unread messages announces every message with its number and the total, the numbers do not skip across the bar, and the bar is still announced as "Unread messages, separator" with no position of its own.
