### PR TITLE
Handle FFmpeg logging

### DIFF
--- a/Telegram/SourceFiles/core/launcher.cpp
+++ b/Telegram/SourceFiles/core/launcher.cpp
@@ -24,6 +24,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include <QtCore/QStandardPaths>
 #include <QtCore/QLibraryInfo>
 
+extern "C" {
+#include <libavutil/log.h>
+} // extern "C"
+
 namespace Core {
 namespace {
 
@@ -395,6 +399,7 @@ int Launcher::exec() {
 
 	// Must be called after options are inited.
 	initHighDpi();
+	initFFmpegMessageLogging();
 
 	if (Logs::DebugEnabled()) {
 		const auto openalLogPath = QDir::toNativeSeparators(
@@ -522,6 +527,36 @@ void Launcher::initQtMessageLogging() {
 				// Sometimes Qt logs something inside our own logging.
 				LOG((msg));
 			}
+		}
+	});
+}
+
+void Launcher::initFFmpegMessageLogging() {
+	av_log_set_level(AV_LOG_WARNING);
+	av_log_set_callback([](void *ptr, int level, const char *fmt, va_list vl) {
+		va_list copy;
+		va_copy(copy, vl);
+		av_log_default_callback(ptr, level, fmt, copy);
+		va_end(copy);
+
+		// The callback is called for all the levels, we filter ourselves,
+		// the color tint is in the high byte of the level.
+		if (!Logs::DebugEnabled() || (level & 0xff) > av_log_get_level()) {
+			return;
+		}
+
+		// One message can be logged in several calls and it can be cut
+		// together with the trailing newline, so check the full length.
+		thread_local auto prefix = 1;
+		thread_local auto accumulated = QByteArray();
+		char line[1024] = { 0 };
+		const auto length = av_log_format_line2(
+			ptr, level, fmt, vl, line, sizeof(line), &prefix);
+		accumulated.append(line);
+		if (accumulated.endsWith('\n') || length >= int(sizeof(line))) {
+			const auto msg = accumulated.trimmed();
+			accumulated.clear();
+			LOG((QString::fromUtf8(msg)));
 		}
 	});
 }

--- a/Telegram/SourceFiles/core/launcher.h
+++ b/Telegram/SourceFiles/core/launcher.h
@@ -53,6 +53,7 @@ protected:
 private:
 	void prepareSettings();
 	void initQtMessageLogging();
+	void initFFmpegMessageLogging();
 	void processArguments();
 
 	QStringList readArguments(int argc, char *argv[]) const;


### PR DESCRIPTION
Raise log level to warning as info is to verbose printing libvpx version on each file and log to our log file when debug logging is enabled just like we do with Qt