### PR TITLE
Let Tab reach the settings and buttons of the poll and checklist boxes with a screen reader

### DIFF
--- a/Telegram/SourceFiles/boxes/add_contact_box.cpp
+++ b/Telegram/SourceFiles/boxes/add_contact_box.cpp
@@ -1579,14 +1579,22 @@ void EditNameBox::prepare() {
 	_last->submits(
 	) | rpl::on_next([=] { submit(); }, _last->lifetime());
 
+	// Tab switches between the two names. A request for the default order
+	// is left alone: the buttons of the box are Tab stops then.
 	using TabbedRequest = Ui::InputField::TabbedRequest;
 	_first->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			return;
+		}
 		_last->setFocus();
 		request->handled = true;
 	}, _first->lifetime());
 	_last->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			return;
+		}
 		_first->setFocus();
 		request->handled = true;
 	}, _last->lifetime());

--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
@@ -162,7 +162,10 @@ public:
 	[[nodiscard]] rpl::producer<int> usedCount() const;
 	[[nodiscard]] rpl::producer<not_null<QWidget*>> scrollToWidget() const;
 	[[nodiscard]] rpl::producer<> backspaceInFront() const;
-	[[nodiscard]] rpl::producer<bool> tabbed() const;
+	// Fired for a Tab that moves out of the options, so the box decides
+	// where it goes - or leaves it unhandled, to let Tab out of the fields.
+	[[nodiscard]] auto tabbed() const
+		-> rpl::producer<not_null<Ui::InputField::TabbedRequest*>>;
 
 	void handlePaste(
 		not_null<Ui::InputField*> field,
@@ -281,7 +284,7 @@ private:
 	bool _hasCorrect = false;
 	rpl::event_stream<not_null<QWidget*>> _scrollToWidget;
 	rpl::event_stream<> _backspaceInFront;
-	rpl::event_stream<bool> _tabbed;
+	rpl::event_stream<not_null<Ui::InputField::TabbedRequest*>> _tabbed;
 	rpl::lifetime _emojiPanelLifetime;
 
 };
@@ -830,7 +833,8 @@ rpl::producer<> Options::backspaceInFront() const {
 	return _backspaceInFront.events();
 }
 
-rpl::producer<bool> Options::tabbed() const {
+auto Options::tabbed() const
+-> rpl::producer<not_null<Ui::InputField::TabbedRequest*>> {
 	return _tabbed.events();
 }
 
@@ -1101,19 +1105,26 @@ void Options::initOptionField(not_null<Ui::InputField*> field) {
 	}, field->lifetime());
 	field->tabbed(
 	) | rpl::on_next([=](not_null<Ui::InputField::TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			// Left to the box, which leaves it alone as well: the default
+			// order passes through the buttons beside each answer.
+			_tabbed.fire_copy(request);
+			return;
+		}
 		const auto index = findField(field);
 		if (request->backward) {
 			if (index > 0) {
 				_list[index - 1]->setFocus();
+				request->handled = true;
 			} else {
-				_tabbed.fire(true);
+				_tabbed.fire_copy(request);
 			}
 		} else if (index + 1 < _list.size()) {
 			_list[index + 1]->setFocus();
+			request->handled = true;
 		} else {
-			_tabbed.fire(false);
+			_tabbed.fire_copy(request);
 		}
-		request->handled = true;
 	}, field->lifetime());
 	base::install_event_filter(field, [=](not_null<QEvent*> event) {
 		if (event->type() != QEvent::KeyPress
@@ -2771,10 +2782,18 @@ object_ptr<Ui::RpWidget> CreatePollBox::setupContent() {
 				st::boxDividerLabel),
 			st::createPollLimitPadding));
 
+	// Tab walks the fields of the box in the order they are shown and
+	// turns back to the first one at the end. A request for the default
+	// order is left alone: the attach buttons beside the fields, the
+	// settings, the correct answer buttons and the buttons of the box are
+	// Tab stops then, and the ring closed on the fields would keep the
+	// keyboard from ever reaching them.
 	using TabbedRequest = Ui::InputField::TabbedRequest;
 	description->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
-		if (request->backward) {
+		if (request->defaultOrder) {
+			return;
+		} else if (request->backward) {
 			question->setFocus();
 		} else {
 			options->focusFirst();
@@ -3080,7 +3099,9 @@ object_ptr<Ui::RpWidget> CreatePollBox::setupContent() {
 
 	question->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
-		if (!request->backward) {
+		if (request->defaultOrder) {
+			return;
+		} else if (!request->backward) {
 			description->setFocus();
 		} else if (quiz->toggled()) {
 			solution->setFocus();
@@ -3091,19 +3112,24 @@ object_ptr<Ui::RpWidget> CreatePollBox::setupContent() {
 	}, question->lifetime());
 
 	options->tabbed(
-	) | rpl::on_next([=](bool backward) {
-		if (backward) {
+	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			return;
+		} else if (request->backward) {
 			description->setFocus();
 		} else if (quiz->toggled()) {
 			solution->setFocus();
 		} else {
 			question->setFocus();
 		}
+		request->handled = true;
 	}, question->lifetime());
 
 	solution->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
-		if (request->backward) {
+		if (request->defaultOrder) {
+			return;
+		} else if (request->backward) {
 			options->focusLast();
 		} else {
 			question->setFocus();

--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
@@ -781,6 +781,9 @@ Options::Options(
 	: nullptr) {
 	auto optionsObj = object_ptr<Ui::VerticalLayout>(container);
 	_optionsLayout = optionsObj.data();
+	// The answers are created as they are needed and can be reordered by
+	// dragging them, so Tab follows the order they are shown in as well.
+	_optionsLayout->setVisualTabOrder(true);
 	container->add(std::move(optionsObj));
 	setupReorder();
 	checkLastOption();
@@ -1623,6 +1626,12 @@ object_ptr<Ui::RpWidget> CreatePollBox::setupContent() {
 
 	auto result = object_ptr<Ui::VerticalLayout>(this);
 	const auto container = result.data();
+
+	// The box fills itself while it is open - an option row is created for
+	// every answer typed - and those rows land at the end of the focus
+	// chain, past the settings below them. Tab follows the box as it is
+	// shown instead: the question, the answers, the settings under them.
+	container->setVisualTabOrder(true);
 
 	const auto updateMedia = [=](
 			const std::shared_ptr<PollMediaState> &media) {

--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
@@ -663,6 +663,16 @@ void Options::Option::enableChooseCorrect(
 	}, button->lifetime());
 	_correct.reset(button);
 	_hasCorrect = true;
+
+	// The answer beside the control is its label.
+	const auto field = this->field();
+	rpl::single(rpl::empty) | rpl::then(
+		field->changes()
+	) | rpl::on_next([=] {
+		button->entity()->setAccessibleName(field->getLastText());
+		button->entity()->accessibilityNameChanged();
+	}, button->lifetime());
+
 	if (multiCorrect && checkboxChanged) {
 		button->entity()->checkedChanges(
 		) | rpl::on_next([=](bool) {

--- a/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
@@ -74,7 +74,10 @@ public:
 	[[nodiscard]] rpl::producer<int> addedCount() const;
 	[[nodiscard]] rpl::producer<not_null<QWidget*>> scrollToWidget() const;
 	[[nodiscard]] rpl::producer<> backspaceInFront() const;
-	[[nodiscard]] rpl::producer<> tabbed() const;
+	// Fired for a Tab that moves out of the tasks, so the box decides
+	// where it goes - or leaves it alone, for the default order.
+	[[nodiscard]] auto tabbed() const
+		-> rpl::producer<not_null<Ui::InputField::TabbedRequest*>>;
 
 private:
 	class Task {
@@ -173,7 +176,7 @@ private:
 	bool _isValid = false;
 	rpl::event_stream<not_null<QWidget*>> _scrollToWidget;
 	rpl::event_stream<> _backspaceInFront;
-	rpl::event_stream<> _tabbed;
+	rpl::event_stream<not_null<Ui::InputField::TabbedRequest*>> _tabbed;
 	rpl::lifetime _emojiPanelLifetime;
 
 };
@@ -537,7 +540,8 @@ rpl::producer<> Tasks::backspaceInFront() const {
 	return _backspaceInFront.events();
 }
 
-rpl::producer<> Tasks::tabbed() const {
+auto Tasks::tabbed() const
+-> rpl::producer<not_null<Ui::InputField::TabbedRequest*>> {
 	return _tabbed.events();
 }
 
@@ -771,20 +775,26 @@ void Tasks::initTaskField(not_null<Task*> task, TextWithEntities text) {
 	}, field->lifetime());
 	field->tabbed(
 	) | rpl::on_next([=](not_null<Ui::InputField::TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			// Left to the box, which leaves it alone as well.
+			_tabbed.fire_copy(request);
+			return;
+		}
 		const auto index = findField(field);
 		if (request->backward) {
 			const auto locked = _existingLocked ? _existingCount : 0;
 			if (index > locked) {
 				_list[index - 1]->setFocus();
+				request->handled = true;
 			} else {
-				_tabbed.fire({});
+				_tabbed.fire_copy(request);
 			}
 		} else if (index + 1 < _list.size()) {
 			_list[index + 1]->setFocus();
+			request->handled = true;
 		} else {
-			_tabbed.fire({});
+			_tabbed.fire_copy(request);
 		}
-		request->handled = true;
 	}, field->lifetime());
 	base::install_event_filter(field, [=](not_null<QEvent*> event) {
 		if (event->type() != QEvent::KeyPress
@@ -1054,9 +1064,14 @@ object_ptr<Ui::RpWidget> EditTodoListBox::setupContent() {
 				st::boxDividerLabel),
 			st::createPollLimitPadding));
 
+	// Tab walks the title and the tasks in a ring. A request for the
+	// default order is left alone: the settings and the buttons of the
+	// box are Tab stops then, out of reach of the ring.
 	title->tabbed(
 	) | rpl::on_next([=](not_null<Ui::InputField::TabbedRequest*> request) {
-		if (request->backward) {
+		if (request->defaultOrder) {
+			return;
+		} else if (request->backward) {
 			tasks->focusLast();
 		} else {
 			tasks->focusFirst();
@@ -1083,8 +1098,12 @@ object_ptr<Ui::RpWidget> EditTodoListBox::setupContent() {
 		st::createPollCheckboxMargin);
 
 	tasks->tabbed(
-	) | rpl::on_next([=] {
+	) | rpl::on_next([=](not_null<Ui::InputField::TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			return;
+		}
 		title->setFocus();
+		request->handled = true;
 	}, title->lifetime());
 
 	const auto isValidTitle = [=] {

--- a/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
+++ b/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
@@ -364,6 +364,7 @@ void Tasks::Task::createRemove() {
 	const auto remove = Ui::CreateChild<Ui::CrossButton>(
 		field.get(),
 		st::createPollOptionRemove);
+	remove->setAccessibleName(tr::lng_box_remove(tr::now));
 	remove->show(anim::type::instant);
 
 	const auto toggle = lifetime.make_state<rpl::variable<bool>>(false);
@@ -434,7 +435,10 @@ bool Tasks::Task::isTooLong() const {
 }
 
 bool Tasks::Task::hasFocus() const {
-	return field()->hasFocus();
+	// The remove button counts: it holds the focus when it is pressed
+	// from the keyboard, and the task removed with it should pass the
+	// focus on the same way.
+	return field()->hasFocus() || (_remove && _remove->hasFocus());
 }
 
 void Tasks::Task::setFocus() const {
@@ -1026,6 +1030,12 @@ object_ptr<Ui::RpWidget> EditTodoListBox::setupContent() {
 	auto result = object_ptr<Ui::VerticalLayout>(this);
 	const auto container = result.data();
 
+	// The box fills itself while it is open - a task row is created for
+	// every task typed - and those rows land at the end of the focus
+	// chain, past the settings below them. Tab follows the box as it is
+	// shown instead: the title, the tasks, the settings under them.
+	container->setVisualTabOrder(true);
+
 	const auto title = setupTitle(container);
 	Ui::AddDivider(container);
 	Ui::AddSkip(container);
@@ -1256,6 +1266,10 @@ void AddTodoListTasksBox::prepare() {
 object_ptr<Ui::RpWidget> AddTodoListTasksBox::setupContent() {
 	auto result = object_ptr<Ui::VerticalLayout>(this);
 	const auto container = result.data();
+
+	// The new tasks are created as they are typed, so Tab follows the
+	// order they are shown in as well.
+	container->setVisualTabOrder(true);
 
 	if (_controller->session().premium()) {
 		_emojiPanel = MakeEmojiPanel(

--- a/Telegram/SourceFiles/chat_helpers/message_field.cpp
+++ b/Telegram/SourceFiles/chat_helpers/message_field.cpp
@@ -284,9 +284,15 @@ void EditLinkBox(
 		}
 	};
 
+	// Tab switches between the link and its text. A request for the
+	// default order is left alone: the buttons of the box are Tab stops
+	// then.
 	using TabbedRequest = Ui::InputField::TabbedRequest;
 	url->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			return;
+		}
 		clearFullSelection(url);
 		text->setFocus();
 		request->handled = true;
@@ -294,6 +300,9 @@ void EditLinkBox(
 
 	text->tabbed(
 	) | rpl::on_next([=](not_null<TabbedRequest*> request) {
+		if (request->defaultOrder) {
+			return;
+		}
 		if (!url->empty()) {
 			url->selectAll();
 		}

--- a/Telegram/SourceFiles/poll/poll_media_upload.cpp
+++ b/Telegram/SourceFiles/poll/poll_media_upload.cpp
@@ -174,6 +174,7 @@ PollMediaButton::PollMediaButton(
 	};
 	resize(_st.width, _st.height);
 	setPointerCursor(true);
+	setAccessibleName(tr::lng_attach(tr::now));
 	updateMediaSubscription();
 }
 

--- a/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
+++ b/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
@@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "chat_helpers/message_field.h"
 #include "chat_helpers/tabbed_panel.h"
 #include "chat_helpers/tabbed_selector.h"
+#include "lang/lang_keys.h"
 #include "ui/controls/emoji_button.h"
 #include "ui/effects/fade_animation.h"
 #include "ui/layers/box_content.h"
@@ -19,6 +20,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/fields/input_field.h"
 #include "window/window_session_controller.h"
 #include "styles/style_chat_helpers.h" // defaultComposeFiles.
+
+#include <QtWidgets/QApplication>
 
 namespace Ui {
 
@@ -48,21 +51,34 @@ namespace Ui {
 			fade->paint(p);
 		}, fadeTarget->lifetime());
 		if (fadeOnFocusChange) {
-			rpl::single(false) | rpl::then(
-				field->focusedChanges()
-			) | rpl::on_next([=](bool shown) {
+			// Shown while the keyboard is in the field: its text, a button
+			// inside it, or the toggle itself. With a screen reader those
+			// are Tab stops, and a toggle fading out as soon as the text
+			// loses the focus would hide right under the Tab on its way to
+			// it, leaving the keyboard on a widget that is not there.
+			const auto refresh = [=] {
 				crl::on_main(emojiToggle, [=] {
-					if (shown) {
+					const auto focused = QApplication::focusWidget();
+					const auto inside = focused
+						&& (focused == emojiToggle
+							|| field->isAncestorOf(focused));
+					if (inside) {
 						fade->fadeIn(st::universalDuration);
 					} else if (emojiToggle->isVisible()) {
 						fade->fadeOut(st::universalDuration);
 					}
 				});
-			}, emojiToggle->lifetime());
+			};
+			QObject::connect(
+				qApp,
+				&QApplication::focusChanged,
+				emojiToggle,
+				[=] { refresh(); });
 		}
 		fade->fadeOut(1);
 		fade->finish();
 	}
+	emojiToggle->setAccessibleName(tr::lng_switch_emoji(tr::now));
 
 
 	const auto outer = box->getDelegate()->outerContainer();


### PR DESCRIPTION
With a screen reader, Tab could not leave the text fields of the Create Poll box: every field passed Tab on to the next one and back to the first, so the settings (Show Who Voted, Set Correct Answer, …), the correct answer buttons, the attach and emoji buttons and Create/Cancel were reachable only by object navigation. The checklist, "Edit your name" and "Add link" boxes had the same ring.

- The fields leave a Tab request for the default order alone (see desktop-app/lib_ui#361), so in screen reader mode Tab walks each box in the order it is shown. Without a screen reader the rings behave as before.
- The poll content, the answers list and the checklist content order their Tab stops by position — rows created while the box is open landed at the end of the focus chain, past the settings.
- The emoji toggle of a field stays shown while the keyboard is in the field (its text, the attach button inside it, or the toggle itself) instead of fading out under the focus that arrives on it; it also gets the name "Emoji". Note: this applies to every box using `AddEmojiToggleToField`, not only the poll box.
- Names: the poll media button ("Add attachment"), the checklist task remove button ("Remove"), and the correct answer radio buttons/checkboxes of a quiz (the text of their answer, kept up to date). A task removed with its button from the keyboard passes the focus on to the next task.

Depends on desktop-app/lib_base#291 and desktop-app/lib_ui#361. Testing the attach menu path additionally needs desktop-app/lib_ui#363.
