### PR TITLE
Walk the emoji panel with the keyboard and a screen reader

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
@@ -29,6 +29,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/emoji_config.h"
 #include "ui/painter.h"
 #include "ui/power_saving.h"
+#include "ui/screen_reader_mode.h"
 #include "ui/ui_utility.h"
 #include "ui/cached_round_corners.h"
 #include "boxes/share_box.h"
@@ -1696,12 +1697,26 @@ void EmojiListWidget::afterShown() {
 		|| (_mode == Mode::UserpicBuilder);
 	if (_search && steal) {
 		_search->stealFocus();
+	} else if (Ui::ScreenReaderModeActive() && !hasFocus()) {
+		// The panel is opened from the keyboard and has no one to talk
+		// to: take the focus into the list, so the emoji are announced
+		// and walked with the arrows, and remember where it came from.
+		_focusReturn = window()->focusWidget();
+		setFocus();
 	}
 }
 
 void EmojiListWidget::beforeHiding() {
 	if (_search) {
 		_search->returnFocus();
+	}
+	returnFocus();
+}
+
+void EmojiListWidget::returnFocus() {
+	const auto was = base::take(_focusReturn);
+	if (was && hasFocus()) {
+		was->setFocus();
 	}
 }
 
@@ -3401,15 +3416,21 @@ void EmojiListWidget::mouseMoveEvent(QMouseEvent *e) {
 			_picker->clearSelection();
 		}
 	}
+	_keyboardSelection = false;
 	updateSelected();
 }
 
 void EmojiListWidget::leaveEventHook(QEvent *e) {
-	clearSelection();
+	// A selection made from the keyboard stays where the mouse is not.
+	if (!_keyboardSelection) {
+		clearSelection();
+	}
 }
 
 void EmojiListWidget::leaveToChildEvent(QEvent *e, QWidget *child) {
-	clearSelection();
+	if (!_keyboardSelection) {
+		clearSelection();
+	}
 }
 
 void EmojiListWidget::enterFromChildEvent(QEvent *e, QWidget *child) {
@@ -3420,7 +3441,393 @@ void EmojiListWidget::enterFromChildEvent(QEvent *e, QWidget *child) {
 void EmojiListWidget::clearSelection() {
 	setPressed(v::null);
 	setSelected(v::null);
+	_keyboardSelection = false;
 	_lastMousePos = mapToGlobal(QPoint(-10, -10));
+}
+
+rpl::producer<> EmojiListWidget::hideRequests() const {
+	return _hideRequests.events();
+}
+
+int EmojiListWidget::shownCount(const SectionInfo &info) const {
+	return info.collapsed
+		? std::min(info.count, _columnCount * kCollapsedRows)
+		: info.count;
+}
+
+bool EmojiListWidget::isExpandCell(
+		const SectionInfo &info,
+		int index) const {
+	return info.collapsed && (index + 1 == _columnCount * kCollapsedRows);
+}
+
+std::optional<EmojiListWidget::OverEmoji> EmojiListWidget::accessibleChild(
+		int index) const {
+	if (index < 0 || _columnCount <= 0) {
+		return std::nullopt;
+	}
+	auto result = std::optional<OverEmoji>();
+	enumerateSections([&](const SectionInfo &info) {
+		const auto count = shownCount(info);
+		if (index < count) {
+			result = OverEmoji{ .section = info.section, .index = index };
+			return false;
+		}
+		index -= count;
+		return true;
+	});
+	return result;
+}
+
+int EmojiListWidget::accessibleIndex(const OverEmoji &over) const {
+	if (_columnCount <= 0) {
+		return -1;
+	}
+	auto result = -1;
+	auto before = 0;
+	enumerateSections([&](const SectionInfo &info) {
+		if (info.section == over.section) {
+			if (over.index >= 0 && over.index < shownCount(info)) {
+				result = before + over.index;
+			}
+			return false;
+		}
+		before += shownCount(info);
+		return true;
+	});
+	return result;
+}
+
+QString EmojiListWidget::accessibleEmojiText(const OverEmoji &over) const {
+	const auto info = sectionInfo(over.section);
+	if (isExpandCell(info, over.index)) {
+		// The last cell of a collapsed section shows how many more there
+		// are, and opens the section.
+		return u"+%1"_q.arg(info.count - _columnCount * kCollapsedRows + 1);
+	} else if (const auto emoji = lookupOverEmoji(&over)) {
+		// The emoji itself: the screen reader names it in its own words.
+		return emoji->text();
+	} else if (const auto custom = lookupCustomEmoji(&over)) {
+		const auto sticker = custom.document->sticker();
+		return sticker ? sticker->alt : QString();
+	}
+	return QString();
+}
+
+QString EmojiListWidget::sectionTitle(int section) const {
+	if (_searchMode) {
+		return (section > 0) ? searchSetBySection(section).title : QString();
+	} else if (section == int(Section::Recent)) {
+		return tr::lng_recent_stickers(tr::now);
+	} else if (section < _staticCount) {
+		return EmojiCategoryTitle(section)(tr::now);
+	} else if (section - _staticCount < int(_custom.size())) {
+		return _custom[section - _staticCount].title;
+	}
+	return QString();
+}
+
+QAccessible::Role EmojiListWidget::accessibilityRole() {
+	return QAccessible::List;
+}
+
+Qt::FocusPolicy EmojiListWidget::accessibilityFocusPolicy() {
+	return Qt::TabFocus;
+}
+
+int EmojiListWidget::accessibilityChildCount() const {
+	if (_columnCount <= 0) {
+		return 0;
+	}
+	auto result = 0;
+	enumerateSections([&](const SectionInfo &info) {
+		result += shownCount(info);
+		return true;
+	});
+	return result;
+}
+
+QAccessible::Role EmojiListWidget::accessibilityChildRole() const {
+	return QAccessible::ListItem;
+}
+
+QString EmojiListWidget::accessibilityChildName(int index) const {
+	const auto over = accessibleChild(index);
+	return over ? accessibleEmojiText(*over) : QString();
+}
+
+QString EmojiListWidget::accessibilityChildDescription(int index) const {
+	// The section the emoji is in, heard on landing in it.
+	const auto over = accessibleChild(index);
+	return over ? sectionTitle(over->section) : QString();
+}
+
+QRect EmojiListWidget::accessibilityChildRect(int index) const {
+	const auto over = accessibleChild(index);
+	return over ? myrtlrect(emojiRect(over->section, over->index)) : QRect();
+}
+
+QAccessible::State EmojiListWidget::accessibilityChildState(
+		int index) const {
+	auto state = QAccessible::State();
+	if (Ui::ScreenReaderModeActive()) {
+		state.focusable = true;
+		state.selectable = true;
+	}
+	const auto over = accessibleChild(index);
+	const auto selected = std::get_if<OverEmoji>(&_selected);
+	if (over && selected && *selected == *over) {
+		state.active = true;
+		// The item the keyboard is on is the selection of the list - or a
+		// screen reader reports every item as "not selected".
+		state.selected = true;
+		if (hasFocus()) {
+			state.focused = true;
+		}
+	}
+	return state;
+}
+
+bool EmojiListWidget::accessibilityChildSupportsActions(int index) const {
+	return accessibilityChildIdentity(index) != 0;
+}
+
+quintptr EmojiListWidget::accessibilityChildIdentity(int index) const {
+	// The cell itself names the item: its section and its place in it.
+	// The tag bit keeps the token non-zero.
+	const auto over = accessibleChild(index);
+	return over
+		? ((quintptr(over->section + 1) << 24)
+			| (quintptr(over->index + 1) << 1)
+			| quintptr(1))
+		: quintptr(0);
+}
+
+int EmojiListWidget::accessibilityChildIndexByIdentity(
+		quintptr identity) const {
+	if (!identity) {
+		return -1;
+	}
+	return accessibleIndex(OverEmoji{
+		.section = int(identity >> 24) - 1,
+		.index = int((identity >> 1) & 0x7FFFFF) - 1,
+	});
+}
+
+void EmojiListWidget::accessibilityChildSetFocus(quintptr identity) {
+	// UIA invokes the action on a background thread: resolve and touch
+	// the widget on the main one, like the other painted lists do.
+	crl::on_main(this, [=] {
+		const auto index = accessibilityChildIndexByIdentity(identity);
+		const auto over = accessibleChild(index);
+		if (!over) {
+			return;
+		}
+		keyboardSelect(*over, hasFocus());
+		if (!hasFocus()) {
+			_focusReturn = window()->focusWidget();
+			setFocus();
+		}
+	});
+}
+
+void EmojiListWidget::accessibilityChildActivate(quintptr identity) {
+	crl::on_main(this, [=] {
+		const auto index = accessibilityChildIndexByIdentity(identity);
+		const auto over = accessibleChild(index);
+		if (!over) {
+			return;
+		}
+		keyboardSelect(*over, false);
+		activateKeyboardSelected();
+	});
+}
+
+void EmojiListWidget::keyboardSelect(const OverEmoji &over, bool announce) {
+	_keyboardSelection = true;
+	setSelected(over);
+	ensureCellVisible(over);
+	if (announce) {
+		const auto index = accessibleIndex(over);
+		if (index >= 0) {
+			accessibilityChildFocused(index);
+		}
+	}
+}
+
+void EmojiListWidget::ensureCellVisible(const OverEmoji &over) {
+	const auto rect = emojiRect(over.section, over.index);
+	const auto top = getVisibleTop();
+	const auto bottom = getVisibleBottom();
+	if (bottom <= top) {
+		return;
+	} else if (rect.y() < top) {
+		// Show the header of the section the cell opens.
+		const auto info = sectionInfo(over.section);
+		scrollTo((rect.y() < info.rowsTop + _singleSize.height())
+			? info.top
+			: rect.y());
+	} else if (rect.y() + rect.height() > bottom) {
+		scrollTo(rect.y() + rect.height() - (bottom - top));
+	}
+}
+
+void EmojiListWidget::keyboardMoveBy(int delta) {
+	const auto count = accessibilityChildCount();
+	if (!count) {
+		return;
+	}
+	const auto selected = std::get_if<OverEmoji>(&_selected);
+	const auto current = selected ? accessibleIndex(*selected) : -1;
+	const auto index = (current < 0)
+		? ((delta > 0) ? 0 : count - 1)
+		: std::clamp(current + delta, 0, count - 1);
+	if (const auto over = accessibleChild(index)) {
+		keyboardSelect(*over, true);
+	}
+}
+
+std::optional<EmojiListWidget::OverEmoji> EmojiListWidget::neighborRow(
+		const OverEmoji &over,
+		int step) const {
+	// The same column one row up or down, on into the next section
+	// that has anything to show - its first or its last row.
+	const auto info = sectionInfo(over.section);
+	const auto column = over.index % _columnCount;
+	const auto row = over.index / _columnCount;
+	const auto rows = (shownCount(info) + _columnCount - 1) / _columnCount;
+	if (row + step >= 0 && row + step < rows) {
+		const auto index = std::min(
+			(row + step) * _columnCount + column,
+			shownCount(info) - 1);
+		return OverEmoji{ .section = over.section, .index = index };
+	}
+	const auto sections = sectionsCount();
+	auto section = over.section + step;
+	while (section >= 0 && section < sections) {
+		const auto count = shownCount(sectionInfo(section));
+		if (count > 0) {
+			const auto lastRow = (count + _columnCount - 1) / _columnCount - 1;
+			const auto index = std::min(
+				((step > 0) ? 0 : lastRow) * _columnCount + column,
+				count - 1);
+			return OverEmoji{ .section = section, .index = index };
+		}
+		section += step;
+	}
+	return std::nullopt;
+}
+
+void EmojiListWidget::keyboardMoveRows(int rows) {
+	const auto selected = std::get_if<OverEmoji>(&_selected);
+	if (!selected || accessibleIndex(*selected) < 0) {
+		keyboardMoveBy(rows > 0 ? 1 : -1);
+		return;
+	}
+	auto over = *selected;
+	const auto step = (rows > 0) ? 1 : -1;
+	for (auto i = 0; i != std::abs(rows); ++i) {
+		const auto next = neighborRow(over, step);
+		if (!next) {
+			break;
+		}
+		over = *next;
+	}
+	keyboardSelect(over, true);
+}
+
+void EmojiListWidget::expandSection(int section) {
+	if (_searchMode && section > 0) {
+		searchSetBySection(section).expanded = true;
+	} else if (section >= _staticCount) {
+		_custom[section - _staticCount].expanded = true;
+	}
+	resizeToWidth(width());
+	update();
+}
+
+void EmojiListWidget::activateKeyboardSelected() {
+	const auto selected = std::get_if<OverEmoji>(&_selected);
+	if (!selected || accessibleIndex(*selected) < 0) {
+		return;
+	}
+	const auto over = *selected;
+	if (isExpandCell(sectionInfo(over.section), over.index)) {
+		expandSection(over.section);
+		keyboardSelect(over, true);
+		return;
+	}
+	// The field the emoji goes to tells itself apart by the focus, so
+	// the focus goes back before the choice is made - and the panel is
+	// done: hide it, as Escape would.
+	returnFocus();
+	if (const auto emoji = lookupOverEmoji(&over)) {
+		selectEmoji(lookupChosen(emoji, &over));
+	} else if (const auto custom = lookupCustomEmoji(&over)) {
+		selectCustom(lookupChosen(custom, &over));
+	} else {
+		return;
+	}
+	_hideRequests.fire({});
+}
+
+void EmojiListWidget::focusInEvent(QFocusEvent *e) {
+	RpWidget::focusInEvent(e);
+	// Land on the emoji last walked to, or the first one there is.
+	const auto selected = std::get_if<OverEmoji>(&_selected);
+	auto over = (selected && accessibleIndex(*selected) >= 0)
+		? std::optional<OverEmoji>(*selected)
+		: accessibleChild(0);
+	if (!over) {
+		return;
+	}
+	keyboardSelect(*over, false);
+	const auto index = accessibleIndex(*over);
+	InvokeQueued(this, [=] {
+		const auto now = std::get_if<OverEmoji>(&_selected);
+		if (hasFocus() && now && accessibleIndex(*now) == index) {
+			accessibilityChildFocused(index);
+		}
+	});
+}
+
+void EmojiListWidget::focusOutEvent(QFocusEvent *e) {
+	RpWidget::focusOutEvent(e);
+	_keyboardSelection = false;
+}
+
+void EmojiListWidget::keyPressEvent(QKeyEvent *e) {
+	const auto key = e->key();
+	const auto rowHeight = std::max(_singleSize.height(), 1);
+	const auto rowsOnPage = std::max(
+		(getVisibleBottom() - getVisibleTop()) / rowHeight,
+		1);
+	if (key == Qt::Key_Left || key == Qt::Key_Right) {
+		const auto forward = (key == Qt::Key_Right) != rtl();
+		keyboardMoveBy(forward ? 1 : -1);
+	} else if (key == Qt::Key_Up || key == Qt::Key_Down) {
+		keyboardMoveRows((key == Qt::Key_Down) ? 1 : -1);
+	} else if (key == Qt::Key_PageUp || key == Qt::Key_PageDown) {
+		keyboardMoveRows((key == Qt::Key_PageDown)
+			? rowsOnPage
+			: -rowsOnPage);
+	} else if (key == Qt::Key_Home) {
+		keyboardMoveBy(-accessibilityChildCount());
+	} else if (key == Qt::Key_End) {
+		keyboardMoveBy(accessibilityChildCount());
+	} else if (!e->isAutoRepeat()
+		&& (key == Qt::Key_Space
+			|| key == Qt::Key_Return
+			|| key == Qt::Key_Enter)) {
+		activateKeyboardSelected();
+	} else if (key == Qt::Key_Escape) {
+		returnFocus();
+		_hideRequests.fire({});
+	} else {
+		RpWidget::keyPressEvent(e);
+		return;
+	}
+	e->accept();
 }
 
 uint64 EmojiListWidget::currentSet(int yOffset) const {

--- a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.h
+++ b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.h
@@ -13,6 +13,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/tooltip.h"
 #include "ui/round_rect.h"
 #include "base/timer.h"
+#include "base/weak_qptr.h"
 
 #include <map>
 
@@ -172,11 +173,34 @@ public:
 	[[nodiscard]] rpl::producer<std::vector<QString>> searchQueries() const;
 	[[nodiscard]] rpl::producer<int> recentShownCount() const;
 
+	// Fired when the keyboard is done with the list - an emoji chosen or
+	// Escape pressed - so the panel it is in can hide.
+	[[nodiscard]] rpl::producer<> hideRequests() const;
+
+	// The emoji as the items of a list for a screen reader, walked with
+	// the keyboard in screen reader mode.
+	QAccessible::Role accessibilityRole() override;
+	Qt::FocusPolicy accessibilityFocusPolicy() override;
+	int accessibilityChildCount() const override;
+	QAccessible::Role accessibilityChildRole() const override;
+	QString accessibilityChildName(int index) const override;
+	QString accessibilityChildDescription(int index) const override;
+	QRect accessibilityChildRect(int index) const override;
+	QAccessible::State accessibilityChildState(int index) const override;
+	bool accessibilityChildSupportsActions(int index) const override;
+	quintptr accessibilityChildIdentity(int index) const override;
+	int accessibilityChildIndexByIdentity(quintptr identity) const override;
+	void accessibilityChildSetFocus(quintptr identity) override;
+	void accessibilityChildActivate(quintptr identity) override;
+
 protected:
 	void visibleTopBottomUpdated(
 		int visibleTop,
 		int visibleBottom) override;
 
+	void focusInEvent(QFocusEvent *e) override;
+	void focusOutEvent(QFocusEvent *e) override;
+	void keyPressEvent(QKeyEvent *e) override;
 	void mousePressEvent(QMouseEvent *e) override;
 	void mouseReleaseEvent(QMouseEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;
@@ -374,6 +398,26 @@ private:
 	void ensureLoaded(int section);
 	void updateSelected();
 	void setSelected(OverState newSelected);
+
+	// The list a screen reader sees: every cell shown, section by
+	// section - the collapsed sections contribute the rows they show,
+	// the last of those cells being the one that expands them.
+	[[nodiscard]] int shownCount(const SectionInfo &info) const;
+	[[nodiscard]] bool isExpandCell(const SectionInfo &info, int index) const;
+	[[nodiscard]] std::optional<OverEmoji> accessibleChild(int index) const;
+	[[nodiscard]] int accessibleIndex(const OverEmoji &over) const;
+	[[nodiscard]] QString accessibleEmojiText(const OverEmoji &over) const;
+	[[nodiscard]] QString sectionTitle(int section) const;
+	void keyboardSelect(const OverEmoji &over, bool announce);
+	void keyboardMoveBy(int delta);
+	void keyboardMoveRows(int rows);
+	[[nodiscard]] std::optional<OverEmoji> neighborRow(
+		const OverEmoji &over,
+		int step) const;
+	void activateKeyboardSelected();
+	void expandSection(int section);
+	void ensureCellVisible(const OverEmoji &over);
+	void returnFocus();
 	void setPressed(OverState newPressed);
 
 	void fillRecentMenu(
@@ -593,6 +637,12 @@ private:
 
 	OverState _selected;
 	OverState _pressed;
+	// The selection was made from the keyboard: the mouse leaving the
+	// list does not clear it, and the widget that had the focus before
+	// the list took it gets it back when the list is done.
+	bool _keyboardSelection = false;
+	base::weak_qptr<QWidget> _focusReturn;
+	rpl::event_stream<> _hideRequests;
 	OverState _pickerSelected;
 	QPoint _lastMousePos;
 

--- a/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
+++ b/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
@@ -754,7 +754,18 @@ auto TabbedSelector::choosingStickerUpdated() const
 }
 
 rpl::producer<> TabbedSelector::cancelled() const {
-	return hasGifsTab() ? gifs()->cancelRequests() : nullptr;
+	// The emoji list asks to hide as well, once the keyboard is done with
+	// it - an emoji chosen or Escape pressed.
+	auto result = rpl::producer<>();
+	if (hasGifsTab()) {
+		result = gifs()->cancelRequests();
+	}
+	if (hasEmojiTab()) {
+		result = result
+			? rpl::merge(std::move(result), emoji()->hideRequests())
+			: emoji()->hideRequests();
+	}
+	return result;
 }
 
 rpl::producer<> TabbedSelector::checkForHide() const {

--- a/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
+++ b/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
@@ -107,6 +107,9 @@ namespace Ui {
 
 	emojiToggle->installEventFilter(emojiPanel);
 	emojiToggle->addClickHandler([=] {
+		// The field the chosen emoji goes to is told apart by the focus,
+		// which a toggle pressed from the keyboard holds itself.
+		field->setFocus();
 		updateEmojiPanelGeometry();
 		emojiPanel->toggleAnimated();
 	});


### PR DESCRIPTION
The emoji panel is a painted grid with no keyboard handling and nothing a screen reader can read: opened from the keyboard, it appeared with no one to talk to, and pressing the "Emoji" button of a field seemed to do nothing.

- `EmojiListWidget` exposes every shown cell as an item of a list (the existing painted-list accessibility API): named by the emoji itself — the screen reader speaks it in its own words and language — described by its section (the category, or the title of a custom set); the "+N" cell of a collapsed set opens it.
- In screen reader mode the list takes the focus once the panel is shown and remembers where it came from. Left/Right, Up/Down (by column, on into the next section), Home/End, PageUp/PageDown walk the cells. Enter or Space chooses, Escape gives up; both return the focus to where it was and ask the panel to hide (`TabbedSelector::cancelled()` passes the request on, like the GIF tab's cancel). SetFocus/Invoke from the screen reader work the same way. A keyboard selection survives the mouse leaving the list.
- The "Emoji" toggle of a field gives the focus to its field before opening the panel: the fields of a box tell the target of a chosen emoji apart by the focus, which a toggle pressed from the keyboard held itself. With the mouse the field has it already.

Nothing changes without a screen reader. Standalone, no library changes needed. Verified with NVDA: emoji names, section names, all keys, insertion and focus return.