### PR TITLE
Repaint video userpic in profile top bar only on new frames

### DIFF
--- a/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_top_bar.cpp
@@ -2782,7 +2782,6 @@ void TopBar::paintUserpic(QPainter &p, const QRect &geometry) {
 		if (!frame.isNull()) {
 			auto hq = PainterHighQualityEnabler(p);
 			p.drawImage(geometry, frame);
-			update();
 			return;
 		}
 	}
@@ -3188,7 +3187,9 @@ void TopBar::updateVideoUserpic() {
 		return;
 	}
 	if (!_videoUserpicPlayer) {
-		_videoUserpicPlayer = std::make_unique<Ui::VideoUserpicPlayer>();
+		_videoUserpicPlayer = std::make_unique<Ui::VideoUserpicPlayer>([=] {
+			update();
+		});
 	}
 	_videoUserpicPlayer->setup(_peer, photo);
 }

--- a/Telegram/SourceFiles/ui/peer/video_userpic_player.cpp
+++ b/Telegram/SourceFiles/ui/peer/video_userpic_player.cpp
@@ -21,7 +21,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace Ui {
 
-VideoUserpicPlayer::VideoUserpicPlayer() = default;
+VideoUserpicPlayer::VideoUserpicPlayer(Fn<void()> repaint)
+: _repaint(std::move(repaint)) {
+}
 
 VideoUserpicPlayer::~VideoUserpicPlayer() = default;
 
@@ -149,7 +151,10 @@ void VideoUserpicPlayer::handleUpdate(
 	v::match(update.data, [&](Information &update) {
 		streamingReady(std::move(update));
 	}, [](PreloadedVideo) {
-	}, [](UpdateVideo) {
+	}, [&](UpdateVideo) {
+		if (_repaint) {
+			_repaint();
+		}
 	}, [](PreloadedAudio) {
 	}, [](UpdateAudio) {
 	}, [](WaitingForData) {

--- a/Telegram/SourceFiles/ui/peer/video_userpic_player.h
+++ b/Telegram/SourceFiles/ui/peer/video_userpic_player.h
@@ -21,7 +21,7 @@ namespace Ui {
 
 class VideoUserpicPlayer final {
 public:
-	VideoUserpicPlayer();
+	explicit VideoUserpicPlayer(Fn<void()> repaint);
 	~VideoUserpicPlayer();
 
 	void setup(not_null<PeerData*> peer, not_null<PhotoData*> photo);
@@ -39,6 +39,7 @@ private:
 	void handleError(::Media::Streaming::Error &&error);
 	void streamingReady(::Media::Streaming::Information &&info);
 
+	Fn<void()> _repaint;
 	std::unique_ptr<::Media::Streaming::Instance> _streamed;
 	PhotoData *_streamedPhoto = nullptr;
 	QImage _ellipseMask;


### PR DESCRIPTION
With the profile column open on a chat that has a video userpic, `TopBar::paintUserpic()` re-queues itself via `update()` on every paint. Since the default surface format uses swap interval 0 on Linux, the loop is unthrottled.

Measured on Linux/Wayland (KWin, AMD Raphael iGPU, 3840x1100 window), Flatpak 7.1.3:
- before: ~420 backing-store flushes/s, each re-uploading the 584x473 top bar and redrawing the whole window; the process held 112-132% of the iGPU 3D engine busy time
- after: ~30 flushes/s (the video frame rate), 4-14%

Built with the CentOS build image and verified on the same setup.
