### PR TITLE
Bound waiting while restoring separate windows

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -691,6 +691,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_restore_windows_enabled_toast" = "Windows will now restore on launch. You can disable this in Settings > Advanced.";
 "lng_restore_windows_disabled_toast" = "Windows will not be restored. You can enable this in Settings > Advanced.";
 "lng_restore_windows_unavailable" = "This chat is no longer available.";
+"lng_restore_windows_timeout" = "This window could not be restored. Please reopen the chat from the main window.";
 "lng_settings_open_system_settings" = "Open Settings";
 "lng_settings_add_sendto" = "Place Telegram in \"Send to\" menu";
 "lng_settings_mac_warn_before_quit" = "Show warning before quitting with {text}";

--- a/Telegram/SourceFiles/window/window_restore_shell.cpp
+++ b/Telegram/SourceFiles/window/window_restore_shell.cpp
@@ -68,7 +68,7 @@ void RestoreShell::setupBody() {
 	_loading->start();
 }
 
-void RestoreShell::showUnavailable() {
+void RestoreShell::showUnavailable(bool timedOut) {
 	if (_unavailable) {
 		return;
 	}
@@ -76,7 +76,9 @@ void RestoreShell::showUnavailable() {
 	_loading = nullptr;
 	const auto label = Ui::CreateChild<Ui::FlatLabel>(
 		_content,
-		tr::lng_restore_windows_unavailable(tr::now),
+		(timedOut
+			? tr::lng_restore_windows_timeout(tr::now)
+			: tr::lng_restore_windows_unavailable(tr::now)),
 		st::windowShellUnavailableLabel);
 	_content->sizeValue() | rpl::on_next([=](QSize size) {
 		const auto padding = st::windowShellUnavailablePadding;

--- a/Telegram/SourceFiles/window/window_restore_shell.h
+++ b/Telegram/SourceFiles/window/window_restore_shell.h
@@ -23,7 +23,7 @@ public:
 	RestoreShell(const QString &title, Core::WindowPosition position);
 	~RestoreShell();
 
-	void showUnavailable();
+	void showUnavailable(bool timedOut);
 	void close();
 	void activate();
 	[[nodiscard]] bool isActiveWindow() const;

--- a/Telegram/SourceFiles/window/window_saved_windows.cpp
+++ b/Telegram/SourceFiles/window/window_saved_windows.cpp
@@ -50,6 +50,7 @@ namespace {
 
 constexpr auto kSaveDelay = crl::time(1000);
 constexpr auto kBatchResolveFallback = 10 * crl::time(1000);
+constexpr auto kRestoreStepTimeout = 60 * crl::time(1000);
 constexpr auto kMaxSavedWindows = 64;
 constexpr auto kMaxSavedChats = 64;
 constexpr auto kMaxClosedWindows = 16;
@@ -316,12 +317,14 @@ struct SavedWindows::Step {
 	std::vector<Data::Thread*> slots;
 	std::unique_ptr<RestoreShell> shell;
 	SeparateId createdId = SeparateId(nullptr);
+	base::Timer timeout;
 	int id = 0;
 	int pending = 0;
 	bool created = false;
 	bool dispatching = false;
 	bool dead = false;
 	bool shellClosed = false;
+	bool timedOut = false;
 	rpl::lifetime lifetime;
 };
 
@@ -866,6 +869,13 @@ void SavedWindows::startStep(SavedWindow &&data) {
 		queueFinishStep(stepId);
 		return;
 	}
+	step->timeout.setCallback(crl::guard(this, [=] {
+		if (const auto step = stepById(stepId)) {
+			step->timedOut = true;
+			queueFinishStep(stepId);
+		}
+	}));
+	step->timeout.callOnce(kRestoreStepTimeout);
 	if (step->data.thread.valid()) {
 		resolveSlot(step, 0);
 	}
@@ -1010,7 +1020,7 @@ void SavedWindows::markUnavailable(std::unique_ptr<Step> step) {
 			step->data.position);
 	pushClosed(std::move(step->data), shell.get());
 	const auto raw = shell.get();
-	raw->showUnavailable();
+	raw->showUnavailable(step->timedOut);
 	raw->closeRequests(
 	) | rpl::on_next([=] {
 		crl::on_main(this, [=] {
@@ -1179,10 +1189,10 @@ not_null<SavedWindows::BatchResolve*> SavedWindows::ensureBatchResolve(
 			sendBatchResolve(session);
 		}
 	});
-	// raw->fallback.setCallback(crl::guard(this, [=] {
-	// 	sendBatchResolve(session);
-	// }));
-	// raw->fallback.callOnce(kBatchResolveFallback);
+	raw->fallback.setCallback(crl::guard(this, [=] {
+		sendBatchResolve(session);
+	}));
+	raw->fallback.callOnce(kBatchResolveFallback);
 	session->account().sessionChanges(
 	) | rpl::take(1) | rpl::on_next([=](Main::Session *) {
 		_batches.remove(session);


### PR DESCRIPTION
Restoring separate windows can leave an indefinite loading placeholder when chat/contact loading or a topic request never completes. This bounds the restore attempt so an unresolved window eventually stops spinning.

- Re-enable the existing 10-second fallback for batch peer resolution.
- Give each restore step a 60-second deadline. Finish through the existing path, replaying resolved slots if the window's main thread is available.
- If the main thread is still unresolved, show a localized instruction to reopen the chat from the main window instead of claiming that the chat no longer exists. Preserve the existing recently-closed-window recovery path.

Related to #31254. This is a bounded-recovery mitigation; the exact stalled request/event in that report has not been identified.

### Validation
- Passed `git diff --check`, localization-key uniqueness, and UTF-8/LF checks.
- Reviewed timer ownership and late callbacks: the timer belongs to the restore step; queued completion and topic callbacks look up the step by ID and ignore an already removed step.
- **Not compiled or run.** This checkout has no configured build tree, Xcode, or Telegram's Qt/dependency bundle. Submitted as a draft pending a Debug build and runtime validation.

### Runtime checks still required
- Normal restore completes before either deadline without a later duplicate window.
- Hold contact/chat-list readiness: peer lookup is attempted after 10 seconds.
- Hold a peer/topic response beyond 60 seconds: the spinner is replaced by the recovery message.
- Resolve the main thread but stall a saved navigation entry: the window opens with the resolved entries after the deadline.
- Close a placeholder, disable restoration, or switch/logout the account before timeout: no window reappears and no late callback uses removed state.
- Deliver the pending response after timeout and reopen the chat: no crash or duplicate completion.

The deadline also applies on slow/offline connections, so some windows may need to be reopened manually. Unresolved navigation entries are skipped when restoring an otherwise available window. No installed application or local account data is modified by this PR.
