### PR TITLE
Animate mouse wheel scrolling instead of jumping

### DIFF
--- a/Telegram/SourceFiles/core/sandbox.cpp
+++ b/Telegram/SourceFiles/core/sandbox.cpp
@@ -30,6 +30,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/qthelp_regex.h"
 #include "ui/ui_utility.h"
 #include "ui/effects/animations.h"
+#include "ui/smooth_scroll.h"
 
 #ifdef Q_OS_MAC
 #include "platform/mac/global_menu_mac.h"
@@ -665,6 +666,8 @@ bool Sandbox::notify(QObject *receiver, QEvent *e) {
 		if (!weak) {
 			return true;
 		}
+	} else if (e->type() == QEvent::Wheel && receiver) {
+		Ui::EnsureSmoothScroll(receiver);
 	}
 	return QApplication::notify(receiver, e);
 }

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
@@ -65,6 +65,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/dynamic_thumbnails.h"
 #include "ui/painter.h"
 #include "ui/search_field_controller.h"
+#include "ui/smooth_scroll.h"
 #include "ui/unread_badge_paint.h"
 #include "ui/ui_utility.h"
 #include "window/window_separate_id.h"
@@ -1410,6 +1411,7 @@ Suggestions::Suggestions(
 Suggestions::~Suggestions() = default;
 
 void Suggestions::setupTabs() {
+	Ui::DisableSmoothScroll(_tabsScroll.get());
 	_tabsScroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto pixelDelta = e->pixelDelta();
 		const auto angleDelta = e->angleDelta();

--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
@@ -31,6 +31,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/dynamic_thumbnails.h"
 #include "ui/effects/ripple_animation.h"
 #include "ui/text/text_utilities.h"
+#include "ui/smooth_scroll.h"
 #include "ui/ui_utility.h"
 #include "ui/widgets/buttons.h"
 #include "ui/widgets/discrete_sliders.h"
@@ -148,6 +149,7 @@ void SubsectionTabs::setupHorizontal(
 		widget->width(),
 		std::max(toggle->height(), slider->height()));
 
+	Ui::DisableSmoothScroll(scroll);
 	scroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto pixelDelta = e->pixelDelta();
 		const auto angleDelta = e->angleDelta();

--- a/Telegram/SourceFiles/info/info_flexible_scroll.cpp
+++ b/Telegram/SourceFiles/info/info_flexible_scroll.cpp
@@ -9,6 +9,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 #include "ui/effects/animation_value.h"
 #include "ui/widgets/scroll_area.h"
+#include "ui/smooth_scroll.h"
 #include "base/event_filter.h"
 #include "base/options.h"
 #include "styles/style_info.h"
@@ -119,6 +120,7 @@ void SetupFlexibleRegularScroll(
 			state->lastApplied = -1;
 		}
 	});
+	Ui::DisableSmoothScroll(scroll);
 	scroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto delta = e->angleDelta().y();
 		if (std::abs(delta) != 120 || e->phase() != Qt::NoScrollPhase) {
@@ -214,6 +216,8 @@ void FlexibleScrollHelper::setupScrollAnimation() {
 }
 
 void FlexibleScrollHelper::setupScrollHandling() {
+	Ui::DisableSmoothScroll(_scroll);
+
 	rpl::combine(
 		_pinnedToTop->heightValue(),
 		_inner->heightValue()

--- a/Telegram/SourceFiles/info/media/info_media_widget.cpp
+++ b/Telegram/SourceFiles/info/media/info_media_widget.cpp
@@ -15,6 +15,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/menu/menu_add_action_callback.h"
 #include "ui/widgets/scroll_area.h"
 #include "ui/search_field_controller.h"
+#include "ui/smooth_scroll.h"
 #include "ui/ui_utility.h"
 #include "data/data_peer.h"
 #include "data/data_user.h"
@@ -150,7 +151,7 @@ Widget::Widget(QWidget *parent, not_null<Controller*> controller)
 		scrollTo(request);
 	}, _inner->lifetime());
 
-	scroll()->setCustomWheelProcess([this](not_null<QWheelEvent*> e) {
+	Ui::InstallSmoothScroll(scroll(), [this](not_null<QWheelEvent*> e) {
 		return (e->modifiers() & Qt::ControlModifier)
 			&& _inner->processZoomWheel(e);
 	});

--- a/Telegram/SourceFiles/ui/controls/labeled_emoji_tabs.cpp
+++ b/Telegram/SourceFiles/ui/controls/labeled_emoji_tabs.cpp
@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/abstract_button.h"
 #include "ui/effects/ripple_animation.h"
 #include "ui/painter.h"
+#include "ui/smooth_scroll.h"
 #include "ui/widgets/buttons.h"
 #include "ui/widgets/scroll_area.h"
 #include "styles/style_basic.h"
@@ -487,6 +488,7 @@ LabeledEmojiScrollTabs::LabeledEmojiScrollTabs(
 	for (const auto &button : _inner->_buttons) {
 		_dragScroll->add(button);
 	}
+	DisableSmoothScroll(_scroll);
 	_scroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto pixelDelta = e->pixelDelta();
 		const auto angleDelta = e->angleDelta();

--- a/Telegram/SourceFiles/ui/smooth_scroll.cpp
+++ b/Telegram/SourceFiles/ui/smooth_scroll.cpp
@@ -1,0 +1,210 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "ui/smooth_scroll.h"
+
+#include "ui/effects/animation_value.h"
+#include "ui/effects/animations.h"
+#include "ui/widgets/elastic_scroll.h"
+#include "ui/widgets/scroll_area.h"
+#include "ui/ui_utility.h"
+
+#include <QtGui/QWheelEvent>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QScrollBar>
+
+namespace Ui {
+namespace {
+
+constexpr auto kDuration = crl::time(260);
+
+struct State {
+	Animations::Basic animation;
+	crl::time started = 0;
+	int from = 0;
+	int target = 0;
+	int applied = 0;
+	bool tracking = false;
+};
+
+[[nodiscard]] base::flat_set<QObject*> &Attached() {
+	static auto result = base::flat_set<QObject*>();
+	return result;
+}
+
+[[nodiscard]] base::flat_set<QObject*> &Skipped() {
+	static auto result = base::flat_set<QObject*>();
+	return result;
+}
+
+[[nodiscard]] bool Register(not_null<QWidget*> scroll) {
+	const auto object = static_cast<QObject*>(scroll.get());
+	if (Skipped().contains(object) || !Attached().emplace(object).second) {
+		return false;
+	}
+	QObject::connect(object, &QObject::destroyed, [](QObject *dead) {
+		Attached().remove(dead);
+	});
+	return true;
+}
+
+[[nodiscard]] bool DiscreteWheel(not_null<QWheelEvent*> e) {
+	// A trackpad, a touch screen and a momentum tail all arrive as a
+	// phased stream of small deltas that is already smooth, and would
+	// only be made worse by animating on top of it. A classic wheel
+	// notch is the one input that arrives without a phase. Modifiers
+	// are left alone as well: the scrolls multiply a notch to a page.
+	if (e->phase() != Qt::NoScrollPhase) {
+		return false;
+	} else if (e->modifiers() & (Qt::ControlModifier | Qt::ShiftModifier)) {
+		return false;
+	}
+	const auto delta = e->angleDelta();
+	return std::abs(delta.y()) >= 120
+		&& std::abs(delta.y()) > std::abs(delta.x());
+}
+
+template <typename Scroll>
+void InitAnimation(not_null<State*> state, not_null<Scroll*> scroll) {
+	state->animation.init([=](crl::time now) {
+		// Anything that moved the scroll while we were animating it -
+		// a jump to a message, the keyboard, a geometry update after
+		// more history was loaded - owns the position now, and wins.
+		if (state->tracking && scroll->scrollTop() != state->applied) {
+			state->animation.stop();
+			state->tracking = false;
+			return;
+		}
+		const auto progress = std::clamp(
+			(now - state->started) / float64(kDuration),
+			0.,
+			1.);
+		scroll->scrollToY(anim::interpolate(
+			state->from,
+			state->target,
+			anim::easeOutQuint(1., progress)));
+		state->applied = scroll->scrollTop();
+		state->tracking = true;
+		if (progress >= 1.) {
+			state->animation.stop();
+			state->tracking = false;
+		}
+	});
+}
+
+template <typename Scroll>
+[[nodiscard]] bool ProcessWheel(
+		not_null<State*> state,
+		not_null<Scroll*> scroll,
+		not_null<QWheelEvent*> e,
+		// Already points where the user wants to go: a natural-scrolling
+		// setting is applied to the angle delta before it reaches us, and
+		// inverted() only reports that setting. Every other scroll in the
+		// app takes the delta as it comes, so this one does too.
+		int delta) {
+	const auto giveUp = [&] {
+		state->animation.stop();
+		state->tracking = false;
+		return false;
+	};
+	if (anim::Disabled() || !DiscreteWheel(e)) {
+		return giveUp();
+	}
+	const auto max = scroll->scrollTopMax();
+	if (max <= 0 || !delta) {
+		return giveUp();
+	}
+	const auto animating = state->animation.animating();
+	const auto base = animating ? state->target : scroll->scrollTop();
+	const auto target = base + delta;
+	if (target < 0 || target > max) {
+		// The edges belong to the scroll itself: that is where the
+		// elastic overscroll is stretched and where a chat is asked
+		// for more content to append below the last message.
+		if (animating) {
+			// A flight in progress leaves the scroll on an
+			// intermediate frame, so give it the position that
+			// flight was travelling to. The notch is handed back
+			// to the scroll below and would otherwise start from
+			// that frame and stop short of the edge.
+			scroll->scrollToY(base);
+		}
+		return giveUp();
+	}
+	state->from = scroll->scrollTop();
+	state->target = target;
+	state->started = crl::now();
+	state->tracking = false;
+	if (!animating) {
+		state->animation.start();
+	}
+	return true;
+}
+
+} // namespace
+
+void InstallSmoothScroll(
+		not_null<ScrollArea*> scroll,
+		Fn<bool(not_null<QWheelEvent*>)> before) {
+	if (!Register(scroll)) {
+		return;
+	}
+	const auto state = scroll->lifetime().make_state<State>();
+	InitAnimation(state, scroll);
+	scroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
+		if (before && before(e)) {
+			return true;
+		}
+		const auto single = scroll->verticalScrollBar()->singleStep()
+			* QApplication::wheelScrollLines();
+		const auto delta = -e->angleDelta().y() * single / 120;
+		return ProcessWheel(state, scroll, e, delta);
+	});
+}
+
+void InstallSmoothScroll(
+		not_null<ElasticScroll*> scroll,
+		Fn<bool(not_null<QWheelEvent*>)> before) {
+	if (!Register(scroll)) {
+		return;
+	}
+	const auto state = scroll->lifetime().make_state<State>();
+	InitAnimation(state, scroll);
+	scroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
+		if (before && before(e)) {
+			return true;
+		}
+		return ProcessWheel(state, scroll, e, -ScrollDelta(e).y());
+	});
+}
+
+void DisableSmoothScroll(not_null<QWidget*> scroll) {
+	const auto object = static_cast<QObject*>(scroll.get());
+	Skipped().emplace(object);
+	QObject::connect(object, &QObject::destroyed, [](QObject *dead) {
+		Skipped().remove(dead);
+	});
+}
+
+void EnsureSmoothScroll(not_null<QObject*> wheelTarget) {
+	if (!wheelTarget->isWidgetType()) {
+		return;
+	}
+	auto widget = static_cast<QWidget*>(wheelTarget.get());
+	while (widget) {
+		if (const auto area = dynamic_cast<ScrollArea*>(widget)) {
+			InstallSmoothScroll(area);
+			return;
+		} else if (const auto elastic = dynamic_cast<ElasticScroll*>(widget)) {
+			InstallSmoothScroll(elastic);
+			return;
+		}
+		widget = widget->parentWidget();
+	}
+}
+
+} // namespace Ui

--- a/Telegram/SourceFiles/ui/smooth_scroll.h
+++ b/Telegram/SourceFiles/ui/smooth_scroll.h
@@ -1,0 +1,39 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+class QWheelEvent;
+
+namespace Ui {
+
+class ElasticScroll;
+class ScrollArea;
+
+// `before` lets a scroll keep a wheel handler of its own - one that
+// claims some events and leaves the plain ones alone, like a modifier
+// shortcut - and still scroll smoothly for everything it declines.
+void InstallSmoothScroll(
+	not_null<ScrollArea*> scroll,
+	Fn<bool(not_null<QWheelEvent*>)> before = nullptr);
+void InstallSmoothScroll(
+	not_null<ElasticScroll*> scroll,
+	Fn<bool(not_null<QWheelEvent*>)> before = nullptr);
+
+// Called for every wheel event target, so that the scroll it belongs to
+// gets its handler on first use instead of at every creation site. The
+// call sits before the event is dispatched, so even the first notch a
+// scroll ever receives is already animated.
+void EnsureSmoothScroll(not_null<QObject*> wheelTarget);
+
+// A scroll that drives the wheel itself through setCustomWheelProcess
+// must call this while it is being set up: the attach above happens on
+// the first wheel event, which is always later, and would replace the
+// handler that was set there.
+void DisableSmoothScroll(not_null<QWidget*> scroll);
+
+} // namespace Ui

--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
+++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
@@ -27,6 +27,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/widgets/menu/menu_action.h"
 #include "ui/filter_icons.h"
 #include "ui/power_saving.h"
+#include "ui/smooth_scroll.h"
 #include "ui/ui_utility.h"
 #include "ui/widgets/chat_filters_tabs_slider_reorder.h"
 #include "ui/widgets/menu/menu_add_action_callback_factory.h"
@@ -336,6 +337,7 @@ not_null<Ui::RpWidget*> AddChatFiltersTabsStrip(
 			});
 	}
 	wrap->toggle(false, anim::type::instant);
+	DisableSmoothScroll(scroll);
 	scroll->setCustomWheelProcess([=](not_null<QWheelEvent*> e) {
 		const auto pixelDelta = e->pixelDelta();
 		const auto angleDelta = e->angleDelta();

--- a/Telegram/cmake/td_ui.cmake
+++ b/Telegram/cmake/td_ui.cmake
@@ -675,6 +675,8 @@ PRIVATE
     ui/peer/color_sample.h
     ui/power_saving.cpp
     ui/power_saving.h
+    ui/smooth_scroll.cpp
+    ui/smooth_scroll.h
     ui/vertical_list.cpp
     ui/vertical_list.h
     ui/unread_badge_paint.cpp


### PR DESCRIPTION
A wheel notch moved the scroll straight to its new position, so reading a long chat with the wheel was a series of jumps with nothing to follow between them. Each notch now eases to that same position over 260ms, so the place you were reading stays visible while it travels.

Only a classic wheel notch is animated:

- a trackpad, a touch screen and the momentum tail after them arrive as a phased stream of small deltas that is already smooth, and are left as they are;
- the `Ctrl` and `Shift` wheels, which page the scroll, are left as they are;
- a delta below a full notch is left to native scrolling, and a complete one is scaled by its magnitude;
- reduced-motion setups are left as they are, through `anim::Disabled()`;
- the top and bottom edges stay with the scroll, where the elastic overscroll is stretched and where a chat asks for more history;
- the scrolls that drive the wheel themselves — the flexible info scroll, the chat folders strip, the subsection tabs, the emoji tabs and the suggestions tabs — opt out through `DisableSmoothScroll()`.

Both `ScrollArea` and `ElasticScroll` are covered without touching `lib_ui`. Handlers are attached lazily from `Sandbox::notify`, so a scroll gets one on its first wheel event instead of at every creation site, and the first notch it ever receives is already animated.

Tested on Linux with Qt 6.11.2 and the packaged dependencies: a full build and link, then a run through the chat list, a long history, settings, the shared media zoom on `Ctrl`+wheel, the horizontal tab strips, both scroll edges and trackpad input.

