### PR TITLE
Fix 1v1 screenshare audio stopping on mic mute

### DIFF
--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++ b/Telegram/SourceFiles/calls/calls_call.cpp
@@ -520,7 +520,12 @@ rpl::producer<Webrtc::DeviceResolvedId> Call::captureMuteDeviceId() {
 
 void Call::setMuted(bool mute) {
 	_muted = mute;
-	if (_instance) {
+	if (_screenWithAudio && _screenAudioControl) {
+		_screenAudioControl->setMicrophoneMuted(mute);
+		if (_instance) {
+			_instance->setMuteMicrophone(false);
+		}
+	} else if (_instance) {
 		_instance->setMuteMicrophone(mute);
 	}
 }
@@ -1187,9 +1192,13 @@ void Call::createAndStartController(const MTPDphoneCall &call) {
 				sendSignalingData(bytes);
 			});
 		},
-		.createAudioDeviceModule = Webrtc::AudioDeviceModuleCreator(
-			saveSetDeviceIdCallback),
 	};
+
+	_screenAudioControl = std::make_shared<Webrtc::MixingAudioControl>();
+	descriptor.createAudioDeviceModule
+		= Webrtc::MixingAudioDeviceModuleCreator(
+			Webrtc::AudioDeviceModuleCreator(saveSetDeviceIdCallback),
+			_screenAudioControl);
 	if (Logs::DebugEnabled()) {
 		const auto callLogFolder = cWorkingDir() + u"DebugLogs"_q;
 		const auto callLogPath = callLogFolder + u"/last_call_log.txt"_q;
@@ -1493,6 +1502,13 @@ void Call::toggleScreenSharing(
 		}
 		_videoCaptureDeviceId = QString();
 		_videoCaptureIsScreencast = false;
+		if (_screenWithAudio && _screenAudioControl) {
+			_screenAudioControl->setMicrophoneMuted(false);
+			_screenAudioControl->setLoopbackEnabled(false);
+			if (_muted.current() && _instance) {
+				_instance->setMuteMicrophone(true);
+			}
+		}
 		_screenWithAudio = false;
 		if (_systemAudioCapture) {
 			_systemAudioCapture->stop();
@@ -1507,6 +1523,15 @@ void Call::toggleScreenSharing(
 	_videoCaptureIsScreencast = true;
 	_videoCaptureDeviceId = *uniqueId;
 	_screenWithAudio = withAudio;
+	if (_screenAudioControl) {
+		_screenAudioControl->setLoopbackEnabled(withAudio);
+		if (withAudio && _muted.current()) {
+			_screenAudioControl->setMicrophoneMuted(true);
+			if (_instance) {
+				_instance->setMuteMicrophone(false);
+			}
+		}
+	}
 	if (_videoCapture) {
 		_videoCapture->switchToDevice(uniqueId->toStdString(), true);
 		if (_instance) {
@@ -1695,6 +1720,7 @@ void Call::handleControllerError(const QString &error) {
 }
 
 void Call::destroyController() {
+	_screenAudioControl = nullptr;
 	_instanceLifetime.destroy();
 	Core::App().mediaDevices().setCaptureMuteTracker(this, false);
 	if (_systemAudioCapture) {

--- a/Telegram/SourceFiles/calls/calls_call.h
+++ b/Telegram/SourceFiles/calls/calls_call.h
@@ -37,6 +37,7 @@ namespace Webrtc {
 enum class VideoState;
 class VideoTrack;
 struct DeviceResolvedId;
+class MixingAudioControl;
 } // namespace Webrtc
 
 namespace Calls {
@@ -387,6 +388,7 @@ private:
 	std::vector<not_null<PeerData*>> _conferenceParticipants;
 
 	std::unique_ptr<tgcalls::Instance> _instance;
+	std::shared_ptr<Webrtc::MixingAudioControl> _screenAudioControl;
 	std::shared_ptr<tgcalls::VideoCaptureInterface> _videoCapture;
 	QString _videoCaptureDeviceId;
 	bool _videoCaptureIsScreencast = false;


### PR DESCRIPTION
Mute mic at ADM level while keeping the channel open when screen audio is active. Depends on desktop-app/lib_webrtc#29.