### PR TITLE
Fix clipped descenders in the group-call participant name

### DIFF
--- a/Telegram/SourceFiles/info/info.style
+++ b/Telegram/SourceFiles/info/info.style
@@ -1183,7 +1183,7 @@ shortInfoCover: ShortInfoCover {
 	radius: boxRadius;
 	name: FlatLabel(defaultFlatLabel) {
 		textFg: groupCallVideoTextFg;
-		maxHeight: 19px;
+		maxHeight: 24px;
 		style: TextStyle(defaultTextStyle) {
 			font: font(15px semibold);
 		}


### PR DESCRIPTION
## Summary

- The group-call participant card (`CoverItem` / `PeerShortInfoCover`) clips descenders in the name. Letters such as **g** and **y** in a name like "Ignatyev" are cut off along the bottom.
- Cause: `shortInfoCover` (inherited by `groupCallMenuCover`) uses a 15px semibold `FlatLabel` with `maxHeight: 19px`. `FlatLabel` sizes itself to `min(textHeight, maxHeight)`, so 19px is below the font line height and the widget clips the glyphs.
- Fix: raise the name `maxHeight` to 24px, matching the profile cover name cap (`infoProfileCover` already uses 24px for a similar semibold name). This is a ceiling, not a fixed height, so a single line still sizes to the font metrics and does not overlap the status line.

Fixes #31264

## Test plan

- [ ] Join a voice/group call on Windows.
- [ ] Right-click a participant whose name contains descenders (`g`, `y`, `p`, `j`, `q`).
- [ ] Confirm the name in the popup card is fully visible, including the loop of **g**.
- [ ] Confirm a long name still elides on one line instead of wrapping over the status.
- [ ] Confirm the same cover used by the short-info box (peer card outside calls) is also unclipped.

Made with [Cursor](https://cursor.com)