### PR TITLE
Fix vertex buffer under-allocation in the media viewer

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
@@ -169,7 +169,7 @@ OverlayWidget::RendererGL::RendererGL(not_null<OverlayWidget*> owner)
 }
 
 void OverlayWidget::RendererGL::init(QOpenGLFunctions &f) {
-	constexpr auto kQuads = 9;
+	constexpr auto kQuads = 11;
 	constexpr auto kQuadVertices = kQuads * 4;
 	constexpr auto kQuadValues = kQuadVertices * 4;
 	constexpr auto kControlsValues = kControlsCount * kControlValues;


### PR DESCRIPTION
The media viewer's OpenGL renderer sizes its vertex buffer from `kQuads`, which is 9. The quad region actually holds 11 quads — offsets 0 through `kGroupThumbsOffset` at 40, with `kControlsOffset` starting at 44 vec4 units — so the buffer is 32 floats short.

The shortfall lands at the very end of the buffer, on the stories sibling parts. `paintStoriesSiblingPart` writes at `kControlsOffset + kControlsCount * kControlValues / 4 + 12 + index * 4`. Parts 0 and 1 fit; parts 2 and 3 do not. The call site computes `base = (index - 1) * 2` and `kRightSiblingTextureIndex` is 2, so the right sibling writes parts 2 and 3 — exactly the overflowing pair. The left sibling uses 0 and 1 and is unaffected.

`QOpenGLBuffer::write()` passes straight to `glBufferSubData`, which rejects an out-of-range write with `GL_INVALID_VALUE` and writes nothing, so those quads are drawn from vertex data that was never set.

**Symptom:** in stories on the OpenGL renderer, the right sibling's userpic and name are missing.

**Reproduced** by logging the write bounds and `glGetError()` at the call site:

```
VBUFCHECK: part=2 writeEnd=2112 allocated=2048 past=1 glError=1281
VBUFCHECK: part=3 writeEnd=2176 allocated=2048 past=1 glError=1281
```

`2048` bytes is the 512 floats `kQuads = 9` yields, and `1281` is `GL_INVALID_VALUE`. With `kQuads = 11` the writes land, `glGetError()` returns 0, and the right sibling's avatar and name render correctly.

Only the OpenGL renderer is affected. The RHI renderer (the default on macOS and Linux with Qt 6.7+) and the software renderer do not use this buffer, so reproducing requires turning off the "Use Qt RHI renderer" experimental option.

Tested on macOS with a Debug build.
