### PR TITLE
Update tlottie to ea9a681: bounded rendering for hostile dash animations

### DIFF
--- a/Telegram/build/docker/centos_env/Dockerfile
+++ b/Telegram/build/docker/centos_env/Dockerfile
@@ -1015,7 +1015,7 @@ export DESTDIR=/usr/src/tlottie-cache
 git init tlottie
 cd tlottie
 git remote add origin https://github.com/dkaraush/tlottie.git
-git fetch --depth=1 origin 4b940c7942fbde8ee56f10f39a5224a4153bd91e
+git fetch --depth=1 origin ea9a681507922a5e0541c228803b35b958a8dd5e
 git reset --hard FETCH_HEAD
 cargo rustc --lib --release --locked \
 	--features c-api --crate-type staticlib \

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -1928,7 +1928,7 @@ release:
 stage('tlottie', """
     git clone https://github.com/dkaraush/tlottie.git
     cd tlottie
-    git checkout 4b940c7942
+    git checkout ea9a681507922a5e0541c228803b35b958a8dd5e
 win:
     SET "RUSTUP_HOME=%THIRDPARTY_DIR%\\rust\\rustup"
     SET "CARGO_HOME=%THIRDPARTY_DIR%\\rust\\cargo"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -476,7 +476,7 @@ parts:
   tlottie:
     source: https://github.com/dkaraush/tlottie.git
     source-depth: 1
-    source-commit: 4b940c7942fbde8ee56f10f39a5224a4153bd91e
+    source-commit: ea9a681507922a5e0541c228803b35b958a8dd5e
     plugin: nil
     build-packages:
       - wget


### PR DESCRIPTION
**Fixes #31280.**
The sticker in this issue is a single path with tangent magnitudes of `±140000` and an animated dash pattern (`d`/`g` shrinking to `0.005`), which makes the dash splitter materialize millions of segments and spiral into OOM at 15-20% CPU. This is the same class as the polystar/polygon fix in rlottie (CVE-2026-47319).
tlottie ea9a6815 carries the full set of hard resource limits (`src/composition/limits.rs`): `max_path_coordinate_abs = 140000`, `max_dashed_path_segment_span`, `max_dash_elements`, `max_dashed_piece_estimate_per_group`, covered by a dedicated DoS regression suite (`src/tests/dos.rs`, 111 tests) that includes this exact pattern (`animated_dash_period_shrink_stays_bounded`, `renderer_recovers_after_mid_frame_dash_limit`).
**Verified locally:**
- cargo rustc --lib --release --locked --features c-api --crate-type staticlib, builds clean
- Full test suite: 242 passed, 0 failed
- On limit exceedance the renderer returns Err(LimitExceeded) and the next frame renders normally, no crash, the sticker is simply rejected at parse or render time, which lib_lottie's `Instance::Create` already maps to a clean `nullptr` → `load() == false`

The pin is updated in Telegram/build/prepare/prepare.py and Telegram/build/docker/centos_env/Dockerfile. 
No changes to Telegram/lib_lottie itself are needed.
cc @john-preston @23rd