### PR TITLE
Show back button on My Profile when opened in a stack

### DIFF
--- a/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
+++ b/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
@@ -283,6 +283,10 @@ void Widget::setupBottomButton(int wasBottomHeight) {
 	}
 }
 
+void Widget::enableBackButton() {
+	_inner->enableBackButton();
+}
+
 void Widget::showFinished() {
 	_shown = true;
 	if (const auto bottom = _pinnedToBottom.data()) {

--- a/Telegram/SourceFiles/info/stories/info_stories_widget.h
+++ b/Telegram/SourceFiles/info/stories/info_stories_widget.h
@@ -67,6 +67,7 @@ public:
 
 	rpl::producer<bool> desiredBottomShadowVisibility() override;
 
+	void enableBackButton() override;
 	void showFinished() override;
 
 private:


### PR DESCRIPTION
My Profile draws its own top bar, which has a back button of its own. That button is shown through `_backToggles` in `Info::Stories::InnerWidget`, which `InnerWidget::enableBackButton()` sets.

When a page is pushed on top of another section, `WrapWidget::showNewContent()` calls `enableBackButton()` on the content widget. `Info::Profile::Widget` forwards that call to its inner widget, but `Info::Stories::Widget` did not override it, so the empty `ContentWidget` implementation ran and the back button never appeared. A stacked My Profile could only be left by closing the whole layer.

`Info::Stories::Widget` now forwards `enableBackButton()` to its inner widget, the same way `Info::Profile::Widget` does.

**Testing**

Built and tested on macOS (Debug), with My Profile pushed on top of Settings through #31288: the back button is shown and returns to Settings.
