### PR TITLE
Open My Profile from the My Account settings entry

### DIFF
--- a/Telegram/SourceFiles/core/deep_links/deep_links_settings.cpp
+++ b/Telegram/SourceFiles/core/deep_links/deep_links_settings.cpp
@@ -221,7 +221,7 @@ Result ShowMyProfile(const Context &ctx) {
 		return Result::NeedsAuth;
 	}
 	ctx.controller->showSection(
-		Info::Stories::Make(ctx.controller->session().user()));
+		Info::Stories::MakeMyProfile(ctx.controller->session().user()));
 	return Result::Handled;
 }
 

--- a/Telegram/SourceFiles/info/stories/info_stories_inner_widget.cpp
+++ b/Telegram/SourceFiles/info/stories/info_stories_inner_widget.cpp
@@ -203,11 +203,13 @@ InnerWidget::InnerWidget(
 	QWidget *parent,
 	not_null<Controller*> controller,
 	rpl::producer<int> albumId,
-	int addingToAlbumId)
+	int addingToAlbumId,
+	bool myProfile)
 : RpWidget(parent)
 , _controller(controller)
 , _peer(controller->key().storiesPeer())
 , _addingToAlbumId(addingToAlbumId)
+, _myProfile(myProfile)
 , _albumId(std::move(albumId))
 , _albumChanges(Data::StoryAlbumUpdate{
 	.peer = _peer,
@@ -275,7 +277,7 @@ void InnerWidget::setupTop() {
 		return;
 	} else if (albumId == Data::kStoriesAlbumIdArchive) {
 		createAboutArchive();
-	} else if (_isStackBottom) {
+	} else if (_isStackBottom || _myProfile) {
 		if (_peer->isSelf()) {
 			createProfileTop();
 		} else if (_peer->owner().stories().hasArchive(_peer)) {

--- a/Telegram/SourceFiles/info/stories/info_stories_inner_widget.h
+++ b/Telegram/SourceFiles/info/stories/info_stories_inner_widget.h
@@ -54,10 +54,14 @@ public:
 		QWidget *parent,
 		not_null<Controller*> controller,
 		rpl::producer<int> albumId,
-		int addingToAlbumId = 0);
+		int addingToAlbumId = 0,
+		bool myProfile = false);
 	~InnerWidget();
 
 	[[nodiscard]] rpl::producer<> backRequest() const;
+	[[nodiscard]] bool myProfile() const {
+		return _myProfile;
+	}
 
 	bool showInternal(not_null<Memento*> memento);
 	void setIsStackBottom(bool isStackBottom) {
@@ -135,6 +139,7 @@ private:
 	const not_null<Controller*> _controller;
 	const not_null<PeerData*> _peer;
 	const int _addingToAlbumId = 0;
+	const bool _myProfile = false;
 
 	std::vector<Data::StoryAlbum> _albums;
 	rpl::variable<int> _albumId;

--- a/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
+++ b/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
@@ -283,6 +283,10 @@ void Widget::setupBottomButton(int wasBottomHeight) {
 	}
 }
 
+void Widget::enableBackButton() {
+	_inner->enableBackButton();
+}
+
 void Widget::showFinished() {
 	_shown = true;
 	if (const auto bottom = _pinnedToBottom.data()) {

--- a/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
+++ b/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
@@ -53,14 +53,15 @@ object_ptr<ContentWidget> Memento::createWidget(
 		QWidget *parent,
 		not_null<Controller*> controller,
 		const QRect &geometry) {
-	auto result = object_ptr<Widget>(parent, controller);
+	auto result = object_ptr<Widget>(parent, controller, _myProfile);
 	result->setInternalState(geometry, this);
 	return result;
 }
 
 Widget::Widget(
 	QWidget *parent,
-	not_null<Controller*> controller)
+	not_null<Controller*> controller,
+	bool myProfile)
 : ContentWidget(parent, controller)
 , _albumId(controller->key().storiesAlbumId())
 , _inner(UseClassicProfileScroll()
@@ -69,14 +70,16 @@ Widget::Widget(
 			this,
 			controller,
 			_albumId.value(),
-			controller->key().storiesAddToAlbumId()),
+			controller->key().storiesAddToAlbumId(),
+			myProfile),
 		_flexibleScroll)
 	: setInnerWidget(
 		object_ptr<InnerWidget>(
 			this,
 			controller,
 			_albumId.value(),
-			controller->key().storiesAddToAlbumId())))
+			controller->key().storiesAddToAlbumId(),
+			myProfile)))
 , _pinnedToTop(_inner->createPinnedToTop(this)) {
 	const auto classic = UseClassicProfileScroll();
 	const auto flexible = _pinnedToTop
@@ -186,6 +189,7 @@ void Widget::setInternalState(
 
 std::shared_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_shared<Memento>(controller());
+	result->setMyProfile(_inner->myProfile());
 	saveState(result.get());
 	return result;
 }
@@ -321,6 +325,13 @@ std::shared_ptr<Info::Memento> Make(not_null<PeerData*> peer, int albumId) {
 		std::vector<std::shared_ptr<ContentMemento>>(
 			1,
 			std::make_shared<Memento>(peer, albumId, 0)));
+}
+
+std::shared_ptr<Info::Memento> MakeMyProfile(not_null<PeerData*> peer) {
+	const auto memento = std::make_shared<Memento>(peer, 0, 0);
+	memento->setMyProfile(true);
+	return std::make_shared<Info::Memento>(
+		std::vector<std::shared_ptr<ContentMemento>>(1, memento));
 }
 
 } // namespace Info::Stories

--- a/Telegram/SourceFiles/info/stories/info_stories_widget.h
+++ b/Telegram/SourceFiles/info/stories/info_stories_widget.h
@@ -41,14 +41,25 @@ public:
 		return _media;
 	}
 
+	void setMyProfile(bool myProfile) {
+		_myProfile = myProfile;
+	}
+	[[nodiscard]] bool myProfile() const {
+		return _myProfile;
+	}
+
 private:
 	Media::Memento _media;
+	bool _myProfile = false;
 
 };
 
 class Widget final : public ContentWidget {
 public:
-	Widget(QWidget *parent, not_null<Controller*> controller);
+	Widget(
+		QWidget *parent,
+		not_null<Controller*> controller,
+		bool myProfile);
 
 	void setInnerFocus() override;
 	void setIsStackBottom(bool isStackBottom) override;
@@ -94,5 +105,7 @@ private:
 [[nodiscard]] std::shared_ptr<Info::Memento> Make(
 	not_null<PeerData*> peer,
 	int albumId = 0);
+[[nodiscard]] std::shared_ptr<Info::Memento> MakeMyProfile(
+	not_null<PeerData*> peer);
 
 } // namespace Info::Stories

--- a/Telegram/SourceFiles/info/stories/info_stories_widget.h
+++ b/Telegram/SourceFiles/info/stories/info_stories_widget.h
@@ -67,6 +67,7 @@ public:
 
 	rpl::producer<bool> desiredBottomShadowVisibility() override;
 
+	void enableBackButton() override;
 	void showFinished() override;
 
 private:

--- a/Telegram/SourceFiles/settings/sections/settings_main.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_main.cpp
@@ -29,10 +29,12 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "data/data_cloud_themes.h"
 #include "data/data_session.h"
 #include "data/data_user.h"
+#include "info/info_memento.h"
 #include "info/profile/info_profile_badge.h"
 #include "info/profile/info_profile_emoji_status_panel.h"
 #include "info/profile/info_profile_phone_menu.h"
 #include "info/profile/info_profile_values.h"
+#include "info/stories/info_stories_widget.h"
 #include "lang/lang_cloud_manager.h"
 #include "lang/lang_instance.h"
 #include "lang/lang_keys.h"
@@ -366,10 +368,13 @@ void BuildSectionButtons(SectionBuilder &builder) {
 	const auto showOther = builder.showOther();
 
 	if (!session->supportMode()) {
-		builder.addSectionButton({
+		builder.addButton({
 			.title = tr::lng_settings_my_account(),
-			.targetSection = InformationId(),
 			.icon = { &st::menuIconProfile },
+			.onClick = [=] {
+				controller->showSection(
+					Info::Stories::MakeMyProfile(session->user()));
+			},
 			.keywords = { u"profile"_q, u"edit"_q, u"information"_q },
 		});
 	}

--- a/Telegram/SourceFiles/window/window_main_menu.cpp
+++ b/Telegram/SourceFiles/window/window_main_menu.cpp
@@ -671,7 +671,7 @@ void MainMenu::setupMenu() {
 				{ &st::menuIconProfile })
 		)->setClickedCallback([=] {
 			controller->showSection(
-				Info::Stories::Make(controller->session().user()));
+				Info::Stories::MakeMyProfile(controller->session().user()));
 		});
 
 		SetupMenuBots(_menu, controller);


### PR DESCRIPTION
Settings → My Account opened Edit Profile, the same page as the Edit profile item in the Settings menu. It now opens My Profile, the page with the profile color, level, bio, usernames, gifts and stories, as My Profile in the side menu does.

**Why this needed more than a different target**

My Profile is not a Settings section, so the entry becomes an `addButton()` that calls `showSection()` with the stories memento, instead of an `addSectionButton()`. The button looks the same, and settings search is unaffected, since the entry still has no id.

From Settings, the page is pushed onto the Settings layer instead of being opened as a root, as it is from the side menu. `Info::Stories::InnerWidget::setupTop()` builds the full profile only when the page is at the bottom of its stack. That check is intentional: it keeps the posts list opened from inside a profile from repeating the profile header. On top of Settings, though, it turned My Profile into a bare posts list.

**Changes**

- `Info::Stories::MakeMyProfile()` creates the memento with an explicit My Profile flag, and `setupTop()` builds the full profile when the page is at the bottom of its stack or is My Profile.
- The flag is passed to the widget when it is created and saved again in `doCreateMemento()`, so it survives opening a deeper page and coming back. Switching albums updates the page in place, so that keeps it too.
- The side menu, the `settings/my-profile` deep link and the My Account entry all use `MakeMyProfile()`. The deep link makes the same call, so it would push the same bare page whenever Settings was already open.

The back button on a stacked My Profile comes from #31287. Its commit is included here and will drop out of this diff once that is merged.

**Testing**

Built and tested on macOS (Debug):

- Settings → My Account opens the full My Profile page, with a back button that returns to Settings.
- Side menu → My Profile is unchanged.
- Switching album tabs on My Profile keeps the profile header.
- Opening a deeper page from My Profile and going back keeps the profile header.
