### PR TITLE
Hide the top bar menu button when its menu is empty

### DIFF
--- a/Telegram/SourceFiles/info/info_wrap_widget.cpp
+++ b/Telegram/SourceFiles/info/info_wrap_widget.cpp
@@ -531,12 +531,8 @@ void WrapWidget::addTopBarMenuButton() {
 	Expects(_topBar != nullptr);
 	Expects(_content != nullptr);
 
-	{
-		const auto guard = gsl::finally([&] { _topBarMenu = nullptr; });
-		showTopBarMenu(true);
-		if (!_topBarMenu) {
-			return;
-		}
+	if (!topBarMenuHasActions()) {
+		return;
 	}
 
 	_topBarMenuToggle.reset(_topBar->addButton(
@@ -547,7 +543,7 @@ void WrapWidget::addTopBarMenuButton() {
 				: st::infoTopBarMenu))));
 	_topBarMenuToggle->setAccessibleName(tr::lng_sr_profile_menu(tr::now));
 	_topBarMenuToggle->addClickHandler([this] {
-		showTopBarMenu(false);
+		showTopBarMenu();
 	});
 
 	Shortcuts::Requests(
@@ -558,7 +554,7 @@ void WrapWidget::addTopBarMenuButton() {
 
 		request->check(Command::ShowChatMenu, 1) && request->handle([=] {
 			Window::ActivateWindow(_controller->parentController());
-			showTopBarMenu(false);
+			showTopBarMenu();
 			return true;
 		});
 	}, _topBarMenuToggle->lifetime());
@@ -601,7 +597,15 @@ void WrapWidget::addProfileCallsButton() {
 	}
 }
 
-void WrapWidget::showTopBarMenu(bool check) {
+bool WrapWidget::topBarMenuHasActions() const {
+	const auto menu = base::make_unique_q<Ui::PopupMenu>(
+		QWidget::window(),
+		st::popupMenuExpandedSeparator);
+	_content->fillTopBarMenu(Ui::Menu::CreateAddActionCallback(menu));
+	return !menu->empty();
+}
+
+void WrapWidget::showTopBarMenu() {
 	if (_topBarMenu) {
 		_topBarMenu->hideMenu(true);
 		return;
@@ -620,8 +624,6 @@ void WrapWidget::showTopBarMenu(bool check) {
 	_content->fillTopBarMenu(Ui::Menu::CreateAddActionCallback(_topBarMenu));
 	if (_topBarMenu->empty()) {
 		_topBarMenu = nullptr;
-		return;
-	} else if (check) {
 		return;
 	}
 	_topBarMenu->setForcedOrigin(Ui::PanelAnimation::Origin::TopRight);
@@ -847,7 +849,7 @@ void WrapWidget::showFinishedHook() {
 		}();
 		if (!highlightId.isEmpty()
 			&& controller->takeHighlightControlId(highlightId)) {
-			showTopBarMenu(false);
+			showTopBarMenu();
 			if (_topBarMenu) {
 				const auto menu = _topBarMenu->menu();
 				for (const auto &action : menu->actions()) {

--- a/Telegram/SourceFiles/info/info_wrap_widget.h
+++ b/Telegram/SourceFiles/info/info_wrap_widget.h
@@ -219,8 +219,9 @@ private:
 	bool requireTopBarSearch() const;
 
 	void addTopBarMenuButton();
+	[[nodiscard]] bool topBarMenuHasActions() const;
 	void addProfileCallsButton();
-	void showTopBarMenu(bool check);
+	void showTopBarMenu();
 
 	const bool _isSeparatedWindow = false;
 


### PR DESCRIPTION
`WrapWidget::addTopBarMenuButton()` adds the three-dots button only if the section's top bar menu has at least one action. It finds that out by building the menu in advance through `showTopBarMenu(true)`.

That check reused `_topBarMenu`, and `showTopBarMenu()` starts by hiding the current menu and returning early whenever `_topBarMenu` is set. When a section is opened from an item of the top bar menu, that menu can still be `_topBarMenu` while the new section is being set up. The early return then skipped building the new section's menu, `_topBarMenu` stayed set, and the button was added even for a section with no menu actions. Clicking it did nothing.

For example, choosing Edit profile from the Settings menu opened Edit Profile with a three-dots button that did nothing, while opening the same page any other way showed no button.

The check now builds its own temporary menu, so a menu that is still open cannot affect it. With the check no longer going through `showTopBarMenu()`, its `check` parameter is removed.

**Testing**

Built and tested on macOS (Debug):

- Edit profile opened from the Settings menu no longer shows the three-dots button.
- The Settings menu still has its three-dots button, and it works.
- A chat profile still has its three-dots button, and it works.
