### PR TITLE
Center topic icons in the collapsed chat list

### DIFF
--- a/Telegram/SourceFiles/data/data_forum_topic.cpp
+++ b/Telegram/SourceFiles/data/data_forum_topic.cpp
@@ -646,7 +646,7 @@ void ForumTopic::paintUserpic(
 			const auto size = Data::FrameSizeFromTag(tag) / ratio;
 			position = QPoint(
 				(context.width - size) / 2,
-				(st->height - size) / 2);
+				(st::defaultDialogRow.height - size) / 2);
 		}
 		_icon->paint(p, {
 			.textColor = (context.active
@@ -668,7 +668,7 @@ void ForumTopic::paintUserpic(
 		if (context.narrow) {
 			position = QPoint(
 				(context.width - size) / 2,
-				(st->height - size) / 2);
+				(st::defaultDialogRow.height - size) / 2);
 		} else {
 			const auto esize = st::emojiSize;
 			const auto shift = (esize - size) / 2;


### PR DESCRIPTION
In the collapsed chat list, `ForumTopic::paintUserpic()` centers a topic's icon vertically within the height of its row style, `st::forumTopicRow` (54px). Collapsed topic rows are taller than that: `Row::recountHeight()` interpolates a topic row's height to `st::defaultDialogRow.height` (62px) as the list narrows. So in the collapsed list the icon was drawn 4px above the center of its row.

Both narrow branches of `paintUserpic()`, for custom emoji icons and for default icons, now center within `st::defaultDialogRow.height`, the height collapsed rows actually have. The wide layout positions the icon from the row padding and is unchanged, so the expanded topics list and the topic list in the forward box look the same as before.

**Testing**

Built and tested on macOS (Debug):

- In the collapsed chat list, topic icons are vertically centered in their rows.
- The expanded topics list and the topic list in the forward box are unchanged.

**Screenshots**

<img width="73" height="197" alt="image" src="https://github.com/user-attachments/assets/81dc92b8-39b6-4f6a-8c62-8541e63f11b0" />
<img width="73" height="197" alt="image" src="https://github.com/user-attachments/assets/895a9427-4ac8-47ae-b80a-69ab6d1fb1ff" />

