### PR TITLE
Show community section icons in the collapsed chat list

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs.style
+++ b/Telegram/SourceFiles/dialogs/dialogs.style
@@ -205,6 +205,9 @@ dialogsTTLBadgeInnerMargins: margins(2px, 2px, 2px, 2px);
 dialogsTTLBadgeSkip: point(1px, 1px);
 dialogsCommunityHiddenBadgeIcon: icon{{ "community/requests_hidden", premiumButtonFg }};
 dialogsCommunityHiddenBadgePadding: 4px;
+dialogsCommunityJoinedIcon: icon{{ "folders/folder_existing_chats", windowActiveTextFg }};
+dialogsCommunityViewableIcon: icon{{ "poll/filled/filled_poll_view-22x22", windowActiveTextFg }};
+dialogsCommunityRequestableIcon: icon{{ "community/requests_hidden-22x22", windowActiveTextFg }};
 
 dialogsSpeakingStrokeNumerator: 16px;
 dialogsSpeakingDenominator: 8.;

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -1314,13 +1314,21 @@ void InnerWidget::paintEvent(QPaintEvent *e) {
 		}
 		if (communityModeShown()) {
 			p.restore();
-			const auto paintBar = [&](const QString &text) {
+			const auto paintBar = [&](
+					const QString &text,
+					const style::icon &icon) {
 				p.fillRect(
 					0,
 					0,
 					fullWidth,
 					st::searchedBarHeight,
 					currentBg());
+				if (context.narrow) {
+					icon.paintInCenter(
+						p,
+						QRect(0, 0, fullWidth, st::searchedBarHeight));
+					return;
+				}
 				p.setFont(st::defaultSubsectionTitle.style.font);
 				p.setPen(st::windowActiveTextFg);
 				p.drawTextLeft(
@@ -1333,13 +1341,14 @@ void InnerWidget::paintEvent(QPaintEvent *e) {
 					int sectionTop,
 					const CommunityRowsView &view,
 					const QString &text,
+					const style::icon &icon,
 					int flatBase) {
 				if (view.empty()) {
 					return;
 				}
 				p.save();
 				p.translate(0, sectionTop);
-				paintBar(text);
+				paintBar(text, icon);
 				const auto rowsTop = st::searchedBarHeight;
 				p.translate(0, rowsTop);
 				const auto localClip = r.translated(
@@ -1361,19 +1370,24 @@ void InnerWidget::paintEvent(QPaintEvent *e) {
 			if (!_shownList->empty()) {
 				p.save();
 				p.translate(0, dialogsOffset() - st::searchedBarHeight);
-				paintBar(tr::lng_community_chats_joined(tr::now));
+				paintBar(
+					tr::lng_community_chats_joined(tr::now),
+					st::dialogsCommunityJoinedIcon);
 				p.restore();
 			}
 			paintSection(
 				communityViewableTop(),
 				_communityViewable,
 				tr::lng_community_chats_viewable(tr::now),
+				st::dialogsCommunityViewableIcon,
 				0);
 			if (_communityRequestableList
 				&& (_communityRequestableCount > 0)) {
 				p.save();
 				p.translate(0, communityRequestableTop());
-				paintBar(tr::lng_community_chats_requestable(tr::now));
+				paintBar(
+					tr::lng_community_chats_requestable(tr::now),
+					st::dialogsCommunityRequestableIcon);
 				p.restore();
 			}
 			p.translate(0, communitySectionsBottom());


### PR DESCRIPTION
When a community is opened, the chat list groups its chats under the section headers "Chats you are in", "Chats you can view" and "Hidden chats". `InnerWidget::paintEvent()` always drew these headers as text, so in the collapsed chat list, which is narrowed down to userpics, the titles were cut off.

In the collapsed list, each header bar now shows a centered icon instead of its title. The icons are existing resources, drawn in the header text color:

- Chats you are in: `folders/folder_existing_chats`, the Existing chats icon from folder settings.
- Chats you can view: `poll/filled/filled_poll_view`, an eye.
- Hidden chats: `community/requests_hidden`, the crossed-out eye already used as the badge on the userpics of hidden chats.

The expanded list still shows the titles.

**Testing**

Built and tested on macOS (Debug), with a community opened:

- The collapsed chat list shows the section icons in place of the cut titles.
- The expanded chat list shows the titles as before.

**Screenshot**

<img width="78" height="421" alt="image" src="https://github.com/user-attachments/assets/cdd2ed75-0e7a-4f8b-bbbf-e36e4148111d" />
<img width="78" height="421" alt="image" src="https://github.com/user-attachments/assets/e66e7ba0-4afe-45c1-a42d-52c1613a9ad7" />

