### PR TITLE
Open the topics column when the chat list is expanded

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -2354,6 +2354,7 @@ void Widget::changeOpenedForum(Data::Forum *forum, anim::type animated) {
 	if (_openedForum == forum) {
 		return;
 	}
+	_childListPostponed = false;
 	changeOpenedSubsection([&] {
 		cancelSearch({ .forceFullCancel = true });
 		closeChildList(anim::type::instant);
@@ -3955,10 +3956,13 @@ void Widget::showForum(
 	}
 	const auto nochat = !controller()->mainSectionShown();
 	if (!params.childColumn
-		|| (Core::App().settings().dialogsWidthRatio(nochat) == 0.)
 		|| (_layout != Layout::Main)
 		|| OptionForumHideChatsList.value()) {
 		changeOpenedForum(forum, params.animated);
+		return;
+	} else if (Core::App().settings().dialogsWidthRatio(nochat) == 0.) {
+		changeOpenedForum(forum, params.animated);
+		_childListPostponed = true;
 		return;
 	}
 	cancelSearch({ .forceFullCancel = true });
@@ -4432,6 +4436,16 @@ void Widget::completeHashtag(QString tag) {
 
 void Widget::resizeEvent(QResizeEvent *e) {
 	updateControlsGeometry();
+	if (_childListPostponed) {
+		const auto nochat = !controller()->mainSectionShown();
+		if (Core::App().settings().dialogsWidthRatio(nochat) > 0.) {
+			const auto forum = not_null(_openedForum);
+			changeOpenedForum(nullptr, anim::type::instant);
+			showForum(
+				forum,
+				Window::SectionShow(anim::type::instant).withChildColumn());
+		}
+	}
 }
 
 void Widget::updateLockUnlockVisibility(anim::type animated) {

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.h
@@ -455,6 +455,7 @@ private:
 	std::unique_ptr<Ui::RpWidget> _childListShadow;
 	rpl::variable<float64> _childListShown;
 	rpl::variable<PeerId> _childListPeerId;
+	bool _childListPostponed = false;
 	std::unique_ptr<Ui::RpWidget> _hideChildListCanvas;
 	std::unique_ptr<Ui::RpWidget> _chatsFilterSlideCanvas;
 


### PR DESCRIPTION
Opening a forum from the chat list shows its topics in a separate column, with the chat list narrowed to userpics on its left. `Dialogs::Widget::showForum()` does that through `openChildList()`, but only when the chat list is not collapsed. When it is collapsed, the forum is opened through `changeOpenedForum()`, which shows the topics in place of the chats.

That choice was not revisited when the chat list was expanded afterwards. For example, collapsing the chat list, opening a forum and then expanding the list kept the topics in place of the chats, without the chat list column that opening the same forum from the expanded list shows.

Now `showForum()` remembers when it was asked for a child column and fell back to `changeOpenedForum()` only because the chat list was collapsed. When the chat list is expanded, `resizeEvent()` opens the forum again in the child column. Forums opened without a child column, for example from a profile, keep their layout, and so do forums with the Hide chat list in forums option enabled.

**Testing**

Built and tested on macOS (Debug):

- Collapsing the chat list, opening a forum from it and expanding the list shows the chat list column next to the topics, as opening the forum from the expanded list does.
- Opening a forum from the expanded chat list is unchanged.
