### PR TITLE
Expand stories from under the top bar in the collapsed chat list

### DIFF
--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -4589,9 +4589,12 @@ void Widget::updateControlsGeometry() {
 	if (_stories) {
 		const auto inFolderTitle = _openedFolder && _subsectionTopBar;
 		const auto storiesLeft = inFolderTitle
-			? (_subsectionTopBar->titleLeft()
-				- st::dialogsStories.left
-				- st::dialogsStories.photoLeft)
+			? anim::interpolate(
+				(_subsectionTopBar->titleLeft()
+					- st::dialogsStories.left
+					- st::dialogsStories.photoLeft),
+				_narrowWidth,
+				narrowRatio)
 			: (filterLeft + filterWidth);
 		_stories->setLayoutConstraints(
 			{ storiesLeft, filterTop + added },

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
@@ -359,7 +359,7 @@ List::Layout List::computeLayout(float64 expanded) const {
 		.expandedRatio = expandedRatio,
 		.expandRatio = expandRatio,
 		.ratio = ratio,
-		.titleOpacity = (1. - expanded),
+		.titleOpacity = _changingFromTop ? 0. : (1. - expanded),
 		.segmentsSpinProgress = segmentsSpinProgress,
 		.thumbnailLeft = thumbnailLeft,
 		.photoLeft = photoLeft,
@@ -398,6 +398,13 @@ void List::paintEvent(QPaintEvent *e) {
 	const auto layered = (layout.single < (photo + 4 * line))
 		|| (hidden > 0.);
 	auto p = QPainter(this);
+	if (_changingFromTop) {
+		p.setClipRect(
+			0,
+			_geometryFull.y() - y(),
+			width(),
+			_lastExpandedHeight);
+	}
 	if (layered) {
 		ensureLayer();
 		auto q = QPainter(&_layer);
@@ -1173,10 +1180,25 @@ rpl::producer<> List::collapsedGeometryChanged() const {
 }
 
 void List::updateGeometry() {
+	_changingFromTop = false;
 	switch (_state) {
 	case State::Small: setGeometry(countSmallGeometry()); break;
 	case State::Changing: {
-		_changingGeometryFrom = countSmallGeometry();
+		const auto small = countSmallGeometry();
+		_changingFromTop = !parentWidget()->rect().intersects(small);
+		if (_changingFromTop) {
+			const auto title = _title.isEmpty()
+				? 0
+				: (_titleWidth + _st.small.left);
+			const auto thumbs = small.width() - title;
+			_changingGeometryFrom = QRect(
+				_geometryFull.x() + (_geometryFull.width() - thumbs) / 2,
+				_geometryFull.y() - small.height(),
+				thumbs,
+				small.height());
+		} else {
+			_changingGeometryFrom = small;
+		}
 		setGeometry(_geometryFull.united(_changingGeometryFrom));
 	} break;
 	case State::Full: setGeometry(_geometryFull);

--- a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.h
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.h
@@ -211,6 +211,7 @@ private:
 	bool _hiddenInstant : 1 = false;
 	bool _expandIgnored : 1 = false;
 	bool _expanded : 1 = false;
+	bool _changingFromTop : 1 = false;
 
 	mutable CollapsedGeometry _lastCollapsedGeometry;
 	mutable float64 _lastCollapsedRatio = 0.;


### PR DESCRIPTION
Pulling down the chat list expands the stories list. `Dialogs::Stories::List` animates the stories from their collapsed thumbnails, shown in the top bar, to the expanded list below it.

In the collapsed chat list the collapsed thumbnails are out of view: `Dialogs::Widget::updateControlsGeometry()` places them after the search field, which moves out of the narrow column. The expansion still started from that position, so the stories flew in from the right, from outside the column.

**Changes**

- When the collapsed thumbnails are out of view, `List::updateGeometry()` starts the expansion from just above the expanded list, horizontally centered, under the top bar. Painting is clipped to the pulled height, so the stories slide down from under the top bar as the chat list moves down, and slide back under it when the list returns. The stories count title doesn't fit the column and is not shown during this expansion.
- In an opened folder, the collapsed thumbnails are placed after the folder title instead, and in the collapsed chat list they were still partly inside the column. They now move out of the column as the chat list narrows, as the ones after the search field do, so the stories of archived chats expand the same way.

With the chat list expanded the collapsed thumbnails are visible, and the animation is unchanged.

The collapsed archived chats also get two fixes around it:

- Opened in a separate window, archived chats have no back button in the top bar, so in the collapsed chat list the top of the column was empty. The menu button now stays visible there: `HistoryView::TopBarWidget` moves it from the right edge to the center of the column as the chat list narrows, and opens its menu to the right while the bar is narrow.
- Searching widens the collapsed chat list and narrows it back with an animation. In a folder, `Widget::updateStoriesVisibility()` treated that animation like the search suggestions one, though a folder has no suggestions, so the stories faded instead of hiding right away and their count slid into view as the column resized. With the stories hidden, `Widget::updateStoriesTitleShown()` also showed the folder title while the top bar was only partly collapsed. The stories of an opened folder now hide right away during this animation, and its title stays hidden until the animation ends.

**Testing**

Built and tested on macOS (Debug):

- In the collapsed chat list, pulling down expands the stories from under the top bar, and releasing collapses them back under it.
- The same in the collapsed archived chats.
- With the chat list expanded, the stories expand as before.
- With archived chats opened in a separate window and the chat list collapsed, the menu button is centered in the column and opens the archive menu to the right. Expanding the chat list moves it back to the right edge.
- Opening and closing search in the collapsed archived chats no longer shows the archived chats title or the stories count while the chat list widens and narrows.

**Screen capture**

https://github.com/user-attachments/assets/46fee15f-252c-4bad-9d78-1e9fb7a46793

