### PR TITLE
Shorten large unread counters instead of cutting them

### DIFF
--- a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
@@ -66,6 +66,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/painter.h"
 #include "ui/search_field_controller.h"
 #include "ui/unread_badge_paint.h"
+#include "ui/unread_counter_format.h"
 #include "ui/ui_utility.h"
 #include "window/window_separate_id.h"
 #include "window/window_session_controller.h"
@@ -298,9 +299,7 @@ bool RecentRow::refreshBadge() {
 
 		_badgeString = !_counter
 			? (_unread ? u" "_q : QString())
-			: (_counter < 1000)
-			? QString::number(_counter)
-			: (QString::number(_counter / 1000) + 'K');
+			: FormatUnreadCounterShort(_counter);
 		if (_badgeString.isEmpty()) {
 			_badgeSize = QSize();
 		} else {
@@ -376,9 +375,7 @@ void RecentRow::rightActionPaint(
 	} else if (_badgeString.isEmpty()) {
 		_badgeString = !_counter
 			? u" "_q
-			: (_counter < 1000)
-			? QString::number(_counter)
-			: (QString::number(_counter / 1000) + 'K');
+			: FormatUnreadCounterShort(_counter);
 	}
 	auto st = Ui::UnreadBadgeStyle();
 	st.selected = selected;

--- a/Telegram/SourceFiles/dialogs/ui/top_peers_strip.cpp
+++ b/Telegram/SourceFiles/dialogs/ui/top_peers_strip.cpp
@@ -19,6 +19,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/dynamic_image.h"
 #include "ui/painter.h"
 #include "ui/unread_badge_paint.h"
+#include "ui/unread_counter_format.h"
 #include "styles/style_dialogs.h"
 #include "styles/style_widgets.h"
 
@@ -850,9 +851,7 @@ void TopPeersStrip::paintUserpic(
 		if (entry.badgeString.isEmpty()) {
 			entry.badgeString = !entry.badge
 				? u" "_q
-				: (entry.badge < 1000)
-				? QString::number(entry.badge)
-				: (QString::number(entry.badge / 1000) + 'K');
+				: FormatUnreadCounterShort(entry.badge);
 		}
 		auto st = Ui::UnreadBadgeStyle();
 		st.selected = selected;

--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
@@ -37,6 +37,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/text/text_options.h"
 #include "ui/painter.h"
 #include "ui/unread_badge.h"
+#include "ui/unread_counter_format.h"
 #include "ui/controls/button_context_menu.h"
 #include "ui/ui_utility.h"
 #include "window/window_adaptive.h"
@@ -1806,14 +1807,9 @@ void TopBarWidget::updateUnreadBadge() {
 	const auto key = _activeChat.key;
 	const auto muted = session().data().unreadBadgeMutedIgnoreOne(key);
 	const auto counter = session().data().unreadBadgeIgnoreOne(key);
-	const auto text = [&] {
-		if (!counter) {
-			return QString();
-		}
-		return (counter > 999)
-			? u"..%1"_q.arg(counter % 100, 2, 10, QChar('0'))
-			: QString::number(counter);
-	}();
+	const auto text = counter
+		? FormatUnreadCounterShort(counter)
+		: QString();
 	_unreadBadge->setText(text, !muted);
 }
 

--- a/Telegram/SourceFiles/platform/mac/main_window_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/main_window_mac.mm
@@ -19,6 +19,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "media/audio/media_audio.h"
 #include "storage/localstorage.h"
 #include "ui/text/text_utilities.h"
+#include "ui/unread_counter_format.h"
 #include "window/window_controller.h"
 #include "window/window_session_controller.h"
 #include "platform/mac/global_menu_mac.h"
@@ -303,9 +304,7 @@ void MainWindow::updateDockCounter() {
 
 	const auto string = !counter
 		? QString()
-		: (counter < 1000)
-		? QString("%1").arg(counter)
-		: QString("..%1").arg(counter % 100, 2, 10, QChar('0'));
+		: FormatUnreadCounterShort(counter);
 	_private->setWindowBadge(string);
 }
 

--- a/Telegram/SourceFiles/ui/unread_counter_format.cpp
+++ b/Telegram/SourceFiles/ui/unread_counter_format.cpp
@@ -25,3 +25,11 @@ QString FormatUnreadCounter(
 	}
 	return QString::number(unreadCounter);
 }
+
+QString FormatUnreadCounterShort(int unreadCounter) {
+	return (unreadCounter < 1'000)
+		? QString::number(unreadCounter)
+		: (unreadCounter < 1'000'000)
+		? (QString::number(unreadCounter / 1'000) + 'K')
+		: (QString::number(unreadCounter / 1'000'000) + 'M');
+}

--- a/Telegram/SourceFiles/ui/unread_counter_format.h
+++ b/Telegram/SourceFiles/ui/unread_counter_format.h
@@ -11,3 +11,5 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 	int unreadCounter,
 	bool hasMentionOrReaction,
 	bool narrow = false);
+
+[[nodiscard]] QString FormatUnreadCounterShort(int unreadCounter);

--- a/Telegram/SourceFiles/window/main_window.cpp
+++ b/Telegram/SourceFiles/window/main_window.cpp
@@ -43,6 +43,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/painter.h"
 #include "ui/screen_reader_mode.h"
 #include "ui/ui_utility.h"
+#include "ui/unread_counter_format.h"
 #include "apiwrap.h"
 #include "mainwidget.h" // session->content()->windowShown().
 #include "tray.h"
@@ -269,10 +270,7 @@ QIcon CreateIcon(Main::Session *session, bool returnNullIfDefault) {
 }
 
 QImage GenerateCounterLayer(CounterLayerArgs &&args) {
-	const auto count = args.count.value();
-	const auto text = (count < 1000)
-		? QString::number(count)
-		: u"..%1"_q.arg(count % 100, 2, 10, QChar('0'));
+	const auto text = FormatUnreadCounterShort(args.count.value());
 	const auto textSize = text.size();
 
 	struct Dimensions {


### PR DESCRIPTION
Some unread counters cut large counts down to their last digits. The unread badge on the top bar back button, the macOS Dock badge and the window icon counter showed a count of 1,483 as "..83", which doesn't tell how many unread there are.

Other unread badges already shorten counts to thousands instead: the top peers strip and the recent chats in search suggestions, each with its own copy of `(count < 1000) ? number : (count / 1000) + 'K'`.

**Changes**

- `FormatUnreadCounterShort()` is added to `ui/unread_counter_format`, next to `FormatUnreadCounter()`. It keeps that format and adds millions, so counts are shown as 999, 1K, 145K or 1M.
- The back button badge, the Dock badge, the window icon counter from `Window::GenerateCounterLayer()`, the top peers strip and the search suggestions all use it.

The tray icon counters, `Window::WithSmallCounter()` and `PlaceCounter()` on macOS, have room for about two digits and keep cutting counts from 100 on. The Linux tray also caches its icons based on that format.

**Testing**

Built and tested on macOS (Debug):

- With 1,483 unread in the account, the back button badge in the collapsed chat list shows 1K instead of ..83.
- With 145,037 unread in all accounts, the Dock badge shows 145K instead of ..37.

The window icon counter is drawn only on Windows and was not tested.
